### PR TITLE
Add implementation of thread_sync syscall.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -424,7 +424,7 @@ version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 dependencies = [
- "spin 0.5.2",
+ "spin",
 ]
 
 [[package]]
@@ -661,15 +661,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
-name = "spin"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "511254be0c5bcf062b019a6c89c01a664aa359ded62f78aa72c6fc137c0590e5"
-dependencies = [
- "lock_api",
-]
-
-[[package]]
 name = "spinning_top"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -785,7 +776,6 @@ dependencies = [
  "nonoverlapping_interval_tree",
  "object",
  "slabmalloc",
- "spin 0.9.2",
  "stivale-boot",
  "tar-no-std",
  "twizzler-abi",

--- a/src/bin/init/Cargo.toml
+++ b/src/bin/init/Cargo.toml
@@ -2,9 +2,7 @@
 name = "init"
 version = "0.1.0"
 edition = "2021"
-
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+authors = ["Daniel Bittman <danielbittman1@gmail.com>"]
 
 [dependencies]
-#twizzler = {path = "../../lib/twizzler"}
 twizzler-abi = {path = "../../lib/twizzler-abi" }

--- a/src/bin/init/src/main.rs
+++ b/src/bin/init/src/main.rs
@@ -73,10 +73,12 @@ fn test_thread_sync_timeout() {
             ThreadSyncFlags::empty(),
         ));
 
+        let mut c = 0u64;
         loop {
-            println!("{:?} going to sleep", std::thread::current().id());
-            let res = sys_thread_sync(&mut [wait], Some(Duration::SECOND));
+            println!("{:?} going to sleep {}", std::thread::current().id(), c);
+            let res = sys_thread_sync(&mut [wait], Some(Duration::MILLISECOND * 1000));
             println!("woke up: {:?} {:?}", res, wait.get_result());
+            c += 1;
         }
     });
 

--- a/src/bin/init/src/main.rs
+++ b/src/bin/init/src/main.rs
@@ -131,10 +131,20 @@ fn test_mutex() {
     }
 }
 
+fn get_user_input() {
+    println!("enter some text:");
+    let mut s = String::new();
+    std::io::stdin()
+        .read_line(&mut s)
+        .expect("Did not enter a correct string");
+    println!("you typed: {}", s);
+}
+
 fn main() {
     let _foo = unsafe { FOO + BAR };
     println!("Hello, World {}", unsafe { FOO + BAR });
 
+    get_user_input();
     test_thread_sync_timeout();
     test_mutex();
     test_thread_sync();

--- a/src/bin/init/src/main.rs
+++ b/src/bin/init/src/main.rs
@@ -28,10 +28,41 @@ static mut FOO: u32 = 42;
 #[thread_local]
 static mut BAR: u32 = 0;
 #[allow(named_asm_labels)]
+
+static BAZ: AtomicU64 = AtomicU64::new(0);
+
+fn test_thread_sync() {
+    let j = std::thread::spawn(|| {
+        let reference = ThreadSyncReference::Virtual(&BAZ as *const AtomicU64);
+        let value = 0;
+        let wait = ThreadSync::new_sleep(ThreadSyncSleep::new(
+            reference,
+            value,
+            twizzler_abi::syscall::ThreadSyncOp::Equal,
+            ThreadSyncFlags::empty(),
+        ));
+
+        loop {
+            println!("{:?} going to sleep", std::thread::current().id());
+            let res = sys_thread_sync(&mut [wait], None);
+            println!("woke up: {:?} {:?}", res, wait.get_result());
+        }
+    });
+
+    let reference = ThreadSyncReference::Virtual(&BAZ as *const AtomicU64);
+    let wake = ThreadSync::new_wake(ThreadSyncWake::new(reference, 1));
+    loop {
+        println!("{:?} waking up", std::thread::current().id());
+        let res = sys_thread_sync(&mut [wake], None);
+        println!("done {:?}", res);
+    }
+}
+
 fn main() {
     let _foo = unsafe { FOO + BAR };
     println!("Hello, World {}", unsafe { FOO + BAR });
 
+    test_thread_sync();
     let j = std::thread::spawn(|| {
         for i in 0..1 {
             println!("hello from thread");
@@ -53,3 +84,10 @@ extern "C" fn _start() -> ! {
     unsafe { asm!("call std_runtime_start", options(noreturn)) }
 }
 */
+
+use std::sync::atomic::AtomicU64;
+
+use twizzler_abi::syscall::{
+    sys_thread_sync, ThreadSync, ThreadSyncFlags, ThreadSyncReference, ThreadSyncSleep,
+    ThreadSyncWake,
+};

--- a/src/kernel/Cargo.toml
+++ b/src/kernel/Cargo.toml
@@ -7,7 +7,6 @@ edition = "2021"
 [dependencies]
 bitflags = "*"
 uart_16550 = "0.2.0"
-spin = "*"
 x86 = "*"
 x86_64 = "*"
 linked_list_allocator = "*"

--- a/src/kernel/src/arch/amd64/acpi.rs
+++ b/src/kernel/src/arch/amd64/acpi.rs
@@ -3,6 +3,8 @@ use core::ptr::NonNull;
 use acpi::AcpiTables;
 use x86_64::PhysAddr;
 
+use crate::once::Once;
+
 use super::memory::phys_to_virt;
 
 #[derive(Clone, Copy, Debug)]
@@ -27,7 +29,7 @@ impl acpi::AcpiHandler for AcpiHandlerImpl {
     fn unmap_physical_region<T>(_region: &acpi::PhysicalMapping<Self, T>) {}
 }
 
-static ACPI: spin::Once<acpi::AcpiTables<AcpiHandlerImpl>> = spin::Once::new();
+static ACPI: Once<acpi::AcpiTables<AcpiHandlerImpl>> = Once::new();
 static HANDLER: AcpiHandlerImpl = AcpiHandlerImpl {};
 
 pub fn init(rsdp: u64) {
@@ -35,6 +37,6 @@ pub fn init(rsdp: u64) {
 }
 
 pub fn get_acpi_root() -> &'static AcpiTables<AcpiHandlerImpl> {
-    ACPI.get()
+    ACPI.poll()
         .expect("need to call acpi::init before get_acpi_root")
 }

--- a/src/kernel/src/arch/amd64/memory.rs
+++ b/src/kernel/src/arch/amd64/memory.rs
@@ -191,6 +191,10 @@ impl MapFlags {
     }
 }
 
+pub struct ArchMemoryContextSwitchInfo {
+    target: u64,
+}
+
 const PAGE_SIZE_HUGE: usize = 1024 * 1024 * 1024;
 const PAGE_SIZE_LARGE: usize = 2 * 1024 * 1024;
 const PAGE_SIZE: usize = 0x1000;
@@ -216,8 +220,10 @@ impl ArchMemoryContext {
         self.table_root.frame
     }
 
-    pub unsafe fn switch(&self) {
-        x86::controlregs::cr3_write(self.root().as_u64())
+    pub fn get_switch_info(&self) -> ArchMemoryContextSwitchInfo {
+        ArchMemoryContextSwitchInfo {
+            target: self.root().as_u64(),
+        }
     }
 
     pub fn clone_empty_user(&self) -> Self {
@@ -417,5 +423,11 @@ impl ArchMemoryContext {
             };
         }
         Ok(())
+    }
+}
+
+impl ArchMemoryContextSwitchInfo {
+    pub unsafe fn switch(&self) {
+        x86::controlregs::cr3_write(self.target)
     }
 }

--- a/src/kernel/src/condvar.rs
+++ b/src/kernel/src/condvar.rs
@@ -1,0 +1,38 @@
+use alloc::vec::Vec;
+
+use crate::{
+    sched::schedule_thread,
+    spinlock::{SpinLockGuard, Spinlock},
+    thread::{current_thread_ref, ThreadRef},
+};
+
+struct InnerCondVar {
+    queue: Vec<ThreadRef>,
+}
+
+struct CondVar {
+    inner: Spinlock<InnerCondVar>,
+}
+
+impl CondVar {
+    pub fn wait<'a, T>(&self, guard: SpinLockGuard<'a, T>) -> SpinLockGuard<'a, T> {
+        crate::interrupt::with_disabled(|| {
+            let current_thread = current_thread_ref().unwrap();
+            let mut inner = self.inner.lock();
+            inner.queue.push(current_thread);
+            drop(inner);
+            unsafe {
+                guard.force_unlock();
+                crate::sched::schedule(false);
+                guard.force_relock()
+            }
+        })
+    }
+
+    pub fn signal(&self) {
+        let mut inner = self.inner.lock();
+        while let Some(t) = inner.queue.pop() {
+            schedule_thread(t);
+        }
+    }
+}

--- a/src/kernel/src/idcounter.rs
+++ b/src/kernel/src/idcounter.rs
@@ -3,13 +3,14 @@ use core::{
     sync::atomic::{AtomicU64, Ordering},
 };
 
+use crate::once::Once;
 use alloc::vec::Vec;
 
 use crate::mutex::Mutex;
 
 pub struct IdCounter {
     counter: AtomicU64,
-    reuse: spin::Once<Mutex<Vec<u64>>>,
+    reuse: Once<Mutex<Vec<u64>>>,
 }
 
 pub struct Id<'a> {
@@ -21,7 +22,7 @@ impl IdCounter {
     pub const fn new() -> Self {
         Self {
             counter: AtomicU64::new(1),
-            reuse: spin::Once::new(),
+            reuse: Once::new(),
         }
     }
 

--- a/src/kernel/src/image.rs
+++ b/src/kernel/src/image.rs
@@ -1,7 +1,8 @@
 use x86_64::VirtAddr;
 use xmas_elf::program::{self};
 
-static KERNEL_IMAGE: spin::Once<&'static [u8]> = spin::Once::new();
+use crate::once::Once;
+static KERNEL_IMAGE: Once<&'static [u8]> = Once::new();
 
 pub fn init(kernel_image: &'static [u8]) {
     KERNEL_IMAGE.call_once(|| kernel_image);

--- a/src/kernel/src/initrd.rs
+++ b/src/kernel/src/initrd.rs
@@ -1,5 +1,5 @@
+use crate::once::Once;
 use alloc::sync::Arc;
-use spin::Once;
 use x86_64::VirtAddr;
 
 use crate::obj::ObjectRef;

--- a/src/kernel/src/machine/mod.rs
+++ b/src/kernel/src/machine/mod.rs
@@ -7,36 +7,61 @@ use core::sync::atomic::Ordering;
 
 #[allow(unused_imports)]
 pub use pc::*;
+use twizzler_abi::syscall::KernelConsoleReadError;
+use twizzler_abi::syscall::KernelConsoleReadFlags;
 
 use crate::log::KernelConsoleHardware;
+use crate::once::Once;
 
 pub struct MachineConsoleHardware {
-    serial: UnsafeCell<uart_16550::SerialPort>,
-    init_state: AtomicU32,
+    serial: Once<UnsafeCell<uart_16550::SerialPort>>,
 }
 
+impl MachineConsoleHardware {
+    fn init(&self) {
+        self.serial.call_once(|| {
+            let mut s = unsafe { uart_16550::SerialPort::new(0x3f8) };
+            s.init();
+            UnsafeCell::new(s)
+        });
+    }
+}
+
+// TODO: have a separate receive thread running to collect data into a buffer.
 impl KernelConsoleHardware for MachineConsoleHardware {
-    fn write(&self, data: &[u8], _flags: crate::log::KernelConsoleWriteFlags) {
-        loop {
-            let state = self.init_state.load(Ordering::SeqCst);
-            if state == 2 {
-                break;
-            }
-            if state == 0
-                && self
-                    .init_state
-                    .compare_exchange(0, 1, Ordering::SeqCst, Ordering::SeqCst)
-                    .is_ok()
-            {
-                unsafe {
-                    self.serial.get().as_mut().unwrap().init();
+    fn read(
+        &self,
+        data: &mut [u8],
+        _flags: KernelConsoleReadFlags,
+    ) -> Result<usize, KernelConsoleReadError> {
+        self.init();
+        let mut c = 0;
+        for i in 0..data.len() {
+            let v = unsafe { self.serial.wait().get().as_mut().unwrap().receive() };
+            match v {
+                13 => {
+                    log!("\n");
+                    data[i] = 10;
+                    c += 1;
+                    break;
                 }
-                self.init_state.store(2, Ordering::SeqCst);
+                4 => break,
+                _ => {
+                    log!("{}", v as char);
+                    data[i] = v
+                }
             }
+            c += 1;
         }
+        Ok(c)
+    }
+
+    fn write(&self, data: &[u8], _flags: crate::log::KernelConsoleWriteFlags) {
+        self.init();
         unsafe {
-            let _ = self
+            let _res = self
                 .serial
+                .wait()
                 .get()
                 .as_mut()
                 .unwrap()
@@ -48,8 +73,7 @@ impl KernelConsoleHardware for MachineConsoleHardware {
 impl MachineConsoleHardware {
     pub const fn new() -> Self {
         Self {
-            serial: unsafe { UnsafeCell::new(uart_16550::SerialPort::new(0x3f8)) },
-            init_state: AtomicU32::new(0),
+            serial: Once::new(),
         }
     }
 }

--- a/src/kernel/src/machine/pc/serial.rs
+++ b/src/kernel/src/machine/pc/serial.rs
@@ -1,13 +1,14 @@
 use uart_16550::SerialPort;
 
 use lazy_static::lazy_static;
-use spin::Mutex;
+
+use crate::spinlock::Spinlock;
 
 lazy_static! {
-    pub static ref SERIAL1: Mutex<SerialPort> = {
+    pub static ref SERIAL1: Spinlock<SerialPort> = {
         let mut serial_port = unsafe { SerialPort::new(0x3f8) };
         serial_port.init();
-        Mutex::new(serial_port)
+        Spinlock::new(serial_port)
     };
 }
 

--- a/src/kernel/src/main.rs
+++ b/src/kernel/src/main.rs
@@ -29,6 +29,7 @@ pub mod machine;
 pub mod memory;
 mod mutex;
 mod obj;
+mod once;
 mod operations;
 mod panic;
 mod processor;
@@ -40,10 +41,10 @@ pub mod utils;
 extern crate alloc;
 
 extern crate bitflags;
+use crate::once::Once;
 use arch::BootInfoSystemTable;
 use initrd::BootModule;
 use memory::MemoryRegion;
-use spin::Once;
 use thread::current_thread_ref;
 use x86_64::VirtAddr;
 

--- a/src/kernel/src/main.rs
+++ b/src/kernel/src/main.rs
@@ -21,6 +21,7 @@
 pub mod log;
 pub mod arch;
 mod clock;
+mod condvar;
 mod idcounter;
 mod image;
 mod initrd;

--- a/src/kernel/src/main.rs
+++ b/src/kernel/src/main.rs
@@ -15,6 +15,7 @@
 #![feature(optimize_attribute)]
 #![feature(asm_sym)]
 #![feature(asm_const)]
+#![feature(btree_drain_filter)]
 
 #[macro_use]
 pub mod log;

--- a/src/kernel/src/memory/allocator.rs
+++ b/src/kernel/src/memory/allocator.rs
@@ -20,6 +20,8 @@ pub const HEAP_MAX_LEN: usize = 0x0000001000000000 / 16; //4GB
 
 use x86_64::VirtAddr;
 
+use crate::spinlock::Spinlock;
+
 use super::KernelMemoryManager;
 
 struct HeapPager {
@@ -145,14 +147,15 @@ impl HeapPager {
     }
 }
 
+// TODO (urgent): Is it safe to use a spinlock here? Or a mutex here?
 static mut PAGER: HeapPager = HeapPager::new();
-static mut LL_BACKUP_ALLOCATOR: spin::Mutex<linked_list_allocator::Heap> =
-    spin::Mutex::new(linked_list_allocator::Heap::empty());
+static mut LL_BACKUP_ALLOCATOR: Spinlock<linked_list_allocator::Heap> =
+    Spinlock::new(linked_list_allocator::Heap::empty());
 
 const EARLY_ALLOCATION_SIZE: usize = 1024 * 1024 * 2;
 static mut EARLY_ALLOCATION_AREA: [u8; EARLY_ALLOCATION_SIZE] = [0; EARLY_ALLOCATION_SIZE];
 static EARLY_ALLOCATION_PTR: AtomicUsize = AtomicUsize::new(0);
-pub struct SafeZoneAllocator(spin::mutex::Mutex<ZoneAllocator<'static>>);
+pub struct SafeZoneAllocator(Spinlock<ZoneAllocator<'static>>);
 
 pub fn init(kmm: &'static KernelMemoryManager) {
     unsafe {
@@ -260,5 +263,4 @@ unsafe impl GlobalAlloc for SafeZoneAllocator {
 }
 
 #[global_allocator]
-static SLAB_ALLOCATOR: SafeZoneAllocator =
-    SafeZoneAllocator(spin::Mutex::new(ZoneAllocator::new()));
+static SLAB_ALLOCATOR: SafeZoneAllocator = SafeZoneAllocator(Spinlock::new(ZoneAllocator::new()));

--- a/src/kernel/src/memory/fault.rs
+++ b/src/kernel/src/memory/fault.rs
@@ -42,7 +42,7 @@ pub fn page_fault(addr: VirtAddr, cause: PageFaultCause, flags: PageFaultFlags, 
         panic!("page fault in thread with no memory context");
     }
     let vmc = vmc.unwrap();
-    let mapping = { vmc.lock().lookup_object(addr) };
+    let mapping = { vmc.inner().lookup_object(addr) };
 
     if let Some(mapping) = mapping {
         let objid = mapping.obj.id();
@@ -51,7 +51,7 @@ pub fn page_fault(addr: VirtAddr, cause: PageFaultCause, flags: PageFaultFlags, 
         let is_write = cause == PageFaultCause::Write;
 
         if let Some((page, cow)) = obj_page_tree.get_page(page_number, is_write) {
-            let mut vmc = vmc.lock();
+            let mut vmc = vmc.inner();
             /* check if mappings changed */
             if vmc.lookup_object(addr).map_or(0.into(), |o| o.obj.id()) != objid {
                 drop(vmc);

--- a/src/kernel/src/memory/frame.rs
+++ b/src/kernel/src/memory/frame.rs
@@ -15,8 +15,8 @@
 
 use core::ops::Add;
 
+use crate::once::Once;
 use alloc::vec::Vec;
-use spin::Once;
 use x86_64::structures::paging::{FrameAllocator, PhysFrame, Size4KiB};
 use x86_64::PhysAddr;
 

--- a/src/kernel/src/memory/mod.rs
+++ b/src/kernel/src/memory/mod.rs
@@ -24,13 +24,13 @@ pub enum MapFailed {
 }
 
 pub struct MappingIter<'a> {
-    ctx: &'a MemoryContext,
+    ctx: &'a MemoryContextInner,
     next: VirtAddr,
     done: bool,
 }
 
 impl<'a> MappingIter<'a> {
-    fn new(ctx: &'a MemoryContext, start: VirtAddr) -> Self {
+    fn new(ctx: &'a MemoryContextInner, start: VirtAddr) -> Self {
         Self {
             ctx,
             next: start,
@@ -40,7 +40,7 @@ impl<'a> MappingIter<'a> {
 }
 
 use self::{
-    context::{MapFlags, MemoryContext},
+    context::{MapFlags, MemoryContext, MemoryContextInner},
     frame::{alloc_frame, PhysicalFrameFlags},
 };
 #[derive(Clone, Copy, Debug)]
@@ -81,9 +81,9 @@ impl<'a> Iterator for MappingIter<'a> {
     }
 }
 
-fn init_kernel_context(clone_regions: &[VirtAddr]) -> MemoryContext {
-    let ctx = MemoryContext::current();
-    let mut new_context = MemoryContext::new_blank();
+fn init_kernel_context(clone_regions: &[VirtAddr]) -> MemoryContextInner {
+    let ctx = MemoryContextInner::current();
+    let mut new_context = MemoryContextInner::new_blank();
 
     let phys_mem_offset = arch::memory::phys_to_virt(PhysAddr::new(0));
     /* TODO: map ALL of the physical address space */
@@ -115,13 +115,13 @@ fn init_kernel_context(clone_regions: &[VirtAddr]) -> MemoryContext {
         new_context.clone_region(&ctx, *va);
     }
     unsafe {
-        new_context.arch.switch();
+        new_context.switch();
     }
     new_context
 }
 
 struct KernelMemoryManagerInner {
-    kernel_context: MemoryContext,
+    kernel_context: MemoryContextInner,
 }
 pub struct KernelMemoryManager {
     inner: spin::Mutex<KernelMemoryManagerInner>,

--- a/src/kernel/src/memory/mod.rs
+++ b/src/kernel/src/memory/mod.rs
@@ -1,7 +1,7 @@
 use alloc::boxed::Box;
 use x86_64::{PhysAddr, VirtAddr};
 
-use crate::{arch, BootInfo};
+use crate::{arch, spinlock::Spinlock, BootInfo};
 
 pub mod allocator;
 pub mod context;
@@ -124,7 +124,8 @@ struct KernelMemoryManagerInner {
     kernel_context: MemoryContextInner,
 }
 pub struct KernelMemoryManager {
-    inner: spin::Mutex<KernelMemoryManagerInner>,
+    // TODO: spinlock or mutex?
+    inner: Spinlock<KernelMemoryManagerInner>,
 }
 
 impl KernelMemoryManager {
@@ -193,7 +194,7 @@ pub fn init<B: BootInfo>(boot_info: &B, clone_regions: &[VirtAddr]) {
 
     unsafe {
         KERNEL_MEMORY_MANAGER = Box::into_raw(Box::new(KernelMemoryManager {
-            inner: spin::Mutex::new(KernelMemoryManagerInner {
+            inner: Spinlock::new(KernelMemoryManagerInner {
                 kernel_context: kernel_context,
             }),
         }))

--- a/src/kernel/src/obj/mod.rs
+++ b/src/kernel/src/obj/mod.rs
@@ -14,6 +14,8 @@ use crate::{
     mutex::{LockGuard, Mutex},
 };
 
+use self::thread_sync::SleepInfo;
+
 pub mod copy;
 pub mod pages;
 pub mod pagevec;
@@ -26,6 +28,7 @@ pub struct Object {
     flags: AtomicU32,
     range_tree: Mutex<range::PageRangeTree>,
     maplist: Mutex<BTreeSet<MappingRef>>,
+    sleep_info: Mutex<SleepInfo>,
 }
 
 #[derive(Clone, Copy, Debug, PartialOrd, Ord, PartialEq, Eq)]
@@ -115,6 +118,7 @@ impl Object {
             flags: AtomicU32::new(0),
             range_tree: Mutex::new(range::PageRangeTree::new()),
             maplist: Mutex::new(BTreeSet::new()),
+            sleep_info: Mutex::new(SleepInfo::new()),
         }
     }
 

--- a/src/kernel/src/obj/thread_sync.rs
+++ b/src/kernel/src/obj/thread_sync.rs
@@ -1,5 +1,110 @@
+use alloc::{
+    collections::BTreeMap,
+    vec::{self, Vec},
+};
+use twizzler_abi::syscall::ThreadSyncOp;
+
+use crate::thread::{current_thread_ref, ThreadRef};
+
 use super::Object;
 
+struct SleepEntry {
+    threads: BTreeMap<u64, ThreadRef>,
+}
+
+pub struct SleepInfo {
+    words: BTreeMap<usize, SleepEntry>,
+}
+
+impl SleepEntry {
+    pub fn new(thread: ThreadRef) -> Self {
+        let mut map = BTreeMap::new();
+        map.insert(thread.id(), thread);
+        Self { threads: map }
+    }
+}
+
+impl SleepInfo {
+    pub fn new() -> Self {
+        SleepInfo {
+            words: BTreeMap::new(),
+        }
+    }
+
+    pub fn insert(&mut self, offset: usize, thread: ThreadRef) {
+        if let Some(se) = self.words.get_mut(&offset) {
+            se.threads.insert(thread.id(), thread);
+        } else {
+            self.words.insert(offset, SleepEntry::new(thread));
+        }
+    }
+
+    pub fn remove(&mut self, offset: usize, thread_id: u64) {
+        if let Some(se) = self.words.get_mut(&offset) {
+            se.threads.remove(&thread_id);
+        }
+    }
+
+    pub fn wake_n(&mut self, offset: usize, max_count: usize) -> usize {
+        let mut count = 0;
+        if let Some(se) = self.words.get_mut(&offset) {
+            if max_count == 1 {
+                /* This is fairly common, so we can have a fast path */
+                let mut remove = None;
+                for (id, t) in &se.threads {
+                    if t.reset_sync_sleep() {
+                        remove = Some(*id);
+                        break;
+                    }
+                }
+                if let Some(ref id) = remove {
+                    crate::syscall::sync::add_to_requeue(se.threads.remove(id).unwrap())
+                }
+                return 1;
+            }
+            for (_, t) in se.threads.drain_filter(|_, v| {
+                let p = count < max_count && v.reset_sync_sleep();
+                count += 1;
+                p
+            }) {
+                /* TODO (opt): if sync_sleep_done is also set, maybe we can just immeditately reschedule this thread. */
+                crate::syscall::sync::add_to_requeue(t);
+            }
+        }
+        count
+    }
+}
+
 impl Object {
-    pub fn wakeup_word(&self, offset: usize, count: u64) {}
+    pub fn wakeup_word(&self, offset: usize, count: usize) -> usize {
+        let mut sleep_info = self.sleep_info.lock();
+        sleep_info.wake_n(offset, count)
+    }
+
+    pub fn setup_sleep_word(
+        &self,
+        offset: usize,
+        op: ThreadSyncOp,
+        val: u64,
+        first_sleep: bool,
+    ) -> bool {
+        let thread = current_thread_ref().unwrap();
+        let mut sleep_info = self.sleep_info.lock();
+
+        let cur = unsafe { self.read_atomic_u64(offset) };
+        let res = op.check(cur, val);
+        if res {
+            if first_sleep {
+                thread.set_sync_sleep();
+            }
+            sleep_info.insert(offset, thread);
+        }
+        res
+    }
+
+    pub fn remove_from_sleep_word(&self, offset: usize) {
+        let thread = current_thread_ref().unwrap();
+        let mut sleep_info = self.sleep_info.lock();
+        sleep_info.remove(offset, thread.id());
+    }
 }

--- a/src/kernel/src/obj/thread_sync.rs
+++ b/src/kernel/src/obj/thread_sync.rs
@@ -34,8 +34,10 @@ impl SleepInfo {
     pub fn insert(&mut self, offset: usize, thread: ThreadRef) {
         if let Some(se) = self.words.get_mut(&offset) {
             se.threads.insert(thread.id(), thread);
+            //   logln!("inserted {}", se.threads.len());
         } else {
             self.words.insert(offset, SleepEntry::new(thread));
+            // logln!("inserted 1");
         }
     }
 
@@ -48,6 +50,7 @@ impl SleepInfo {
     pub fn wake_n(&mut self, offset: usize, max_count: usize) -> usize {
         let mut count = 0;
         if let Some(se) = self.words.get_mut(&offset) {
+            //  logln!("wake up {}/{} threads", max_count, se.threads.len());
             if max_count == 1 {
                 /* This is fairly common, so we can have a fast path */
                 let mut remove = None;
@@ -58,9 +61,10 @@ impl SleepInfo {
                     }
                 }
                 if let Some(ref id) = remove {
-                    crate::syscall::sync::add_to_requeue(se.threads.remove(id).unwrap())
+                    crate::syscall::sync::add_to_requeue(se.threads.remove(id).unwrap());
+                    return 1;
                 }
-                return 1;
+                return 0;
             }
             for (_, t) in se.threads.drain_filter(|_, v| {
                 let p = count < max_count && v.reset_sync_sleep();

--- a/src/kernel/src/once.rs
+++ b/src/kernel/src/once.rs
@@ -1,0 +1,105 @@
+use core::{
+    cell::UnsafeCell,
+    mem::MaybeUninit,
+    sync::atomic::{AtomicU32, Ordering},
+};
+
+pub struct Once<T> {
+    status: AtomicU32,
+    data: UnsafeCell<MaybeUninit<T>>,
+}
+
+// SAFETY: Once call_once has been issued, the underlying data structure is made available,
+// and we internally manage consistency of the unsafecell and the status.
+unsafe impl<T: Send + Sync> Sync for Once<T> {}
+unsafe impl<T: Send> Send for Once<T> {}
+
+const INCOMPLETE: u32 = 0;
+const RUNNING: u32 = 1;
+const COMPLETE: u32 = 2;
+
+impl<T> Once<T> {
+    /// Constructs a new Once with uninitialized data, must be initialized with call_once before it
+    /// will return any data.
+    pub const fn new() -> Self {
+        Self {
+            status: AtomicU32::new(INCOMPLETE),
+            data: UnsafeCell::new(MaybeUninit::uninit()),
+        }
+    }
+    /// Initialize the data once and only once, returning the data once it is initialized. The given
+    /// closure will only execute the first time this function is called, and otherwise will not be run.
+    ///
+    /// If multiple calls to call_once race, only one of them will run and initialize the data, the
+    /// others will block.
+    pub fn call_once<F: FnOnce() -> T>(&self, f: F) -> &T {
+        let status = self.status.load(Ordering::SeqCst);
+        if status == INCOMPLETE {
+            match self.status.compare_exchange(
+                INCOMPLETE,
+                RUNNING,
+                Ordering::SeqCst,
+                Ordering::SeqCst,
+            ) {
+                Ok(_) => {
+                    // We will initialize this Once.
+                    // SAFETY: We are the only ones who can access the UnsafeCell, here, since we
+                    // succeeded the cmpxchg above.
+                    unsafe {
+                        (*self.data.get()).as_mut_ptr().write(f());
+                    }
+                    self.status.store(COMPLETE, Ordering::SeqCst);
+                }
+                Err(_) => {
+                    return self.wait();
+                }
+            }
+        } else if status == RUNNING {
+            return self.wait();
+        }
+        // SAFETY: Data will never change, since the status is COMPLETE, and the data is
+        // initialized, for the same reason.
+        return unsafe { self.force_get() };
+    }
+
+    unsafe fn force_get(&self) -> &T {
+        return &*(*self.data.get()).as_ptr();
+    }
+
+    /// If the data is not ready, then return None, or return Some if the data is ready. If this
+    /// races with a call to call_once, the function will either return None or wait until the data
+    /// is ready and return Some.
+    pub fn poll(&self) -> Option<&T> {
+        loop {
+            let status = self.status.load(Ordering::SeqCst);
+            if status == COMPLETE {
+                // SAFETY: If status is complete, the data is ready.
+                return Some(unsafe { self.force_get() });
+            } else if status == INCOMPLETE {
+                return None;
+            }
+            core::hint::spin_loop();
+        }
+    }
+
+    /// Wait until the data is ready (someone calls call_once).
+    pub fn wait(&self) -> &T {
+        loop {
+            match self.poll() {
+                Some(x) => break x,
+                None => core::hint::spin_loop(),
+            }
+        }
+    }
+}
+
+impl<T> Drop for Once<T> {
+    fn drop(&mut self) {
+        // We don't have to check for running here, since we have &mut access to self.
+        if self.status.load(Ordering::SeqCst) == COMPLETE {
+            unsafe {
+                core::ptr::drop_in_place((*self.data.get()).as_mut_ptr());
+            }
+        }
+    }
+}

--- a/src/kernel/src/operations.rs
+++ b/src/kernel/src/operations.rs
@@ -12,7 +12,7 @@ pub fn map_object_into_context(
     perms: MappingPerms,
 ) -> Result<(), ()> {
     let mapping = Arc::new(Mapping::new(obj.clone(), vmc.clone(), slot, perms));
-    let mut vmc = vmc.lock();
+    let mut vmc = vmc.inner();
     obj.insert_mapping(mapping.clone());
     vmc.insert_mapping(mapping);
 

--- a/src/kernel/src/processor.rs
+++ b/src/kernel/src/processor.rs
@@ -4,8 +4,8 @@ use core::{
     sync::atomic::{AtomicBool, AtomicU64, Ordering},
 };
 
+use crate::{once::Once, spinlock::Spinlock};
 use alloc::{boxed::Box, collections::VecDeque, vec::Vec};
-use spin::{Mutex, Once};
 use x86_64::VirtAddr;
 
 use crate::{
@@ -42,7 +42,7 @@ pub struct ProcessorStats {
 
 pub struct Processor {
     pub arch: ArchProcessor,
-    pub sched: Mutex<SchedulingQueues>,
+    pub sched: Spinlock<SchedulingQueues>,
     running: AtomicBool,
     topology_path: Once<Vec<(usize, bool)>>,
     pub id: u32,
@@ -154,7 +154,7 @@ impl Processor {
     pub fn new(id: u32) -> Self {
         Self {
             arch: ArchProcessor::default(),
-            sched: Mutex::new(Default::default()),
+            sched: Spinlock::new(Default::default()),
             running: AtomicBool::new(false),
             topology_path: Once::new(),
             id,

--- a/src/kernel/src/sched.rs
+++ b/src/kernel/src/sched.rs
@@ -492,7 +492,7 @@ pub fn schedule_resched() {
 
 #[thread_local]
 static STAT_COUNTER: AtomicU64 = AtomicU64::new(0);
-const PRINT_STATS: bool = false;
+const PRINT_STATS: bool = true;
 pub fn schedule_stattick(dt: Nanoseconds) {
     schedule_maybe_rebalance(dt);
 
@@ -540,5 +540,6 @@ pub fn schedule_stattick(dt: Nanoseconds) {
                 logln!("thread {}: {:?}", t.id(), t.stats);
             }
         }
+        //crate::clock::print_info();
     }
 }

--- a/src/kernel/src/sched.rs
+++ b/src/kernel/src/sched.rs
@@ -280,7 +280,7 @@ pub fn remove_thread(id: u64) {
     ALL_THREADS.lock().remove(&id);
 }
 
-pub fn schedule_new_thread(thread: Thread) {
+pub fn schedule_new_thread(thread: Thread) -> ThreadRef {
     thread.set_state(ThreadState::Running);
     let thread = Arc::new(thread);
     {
@@ -288,7 +288,8 @@ pub fn schedule_new_thread(thread: Thread) {
     }
     let cpuid = select_cpu(&thread);
     let processor = get_processor(cpuid);
-    schedule_thread_on_cpu(thread, processor);
+    schedule_thread_on_cpu(thread.clone(), processor);
+    thread
 }
 
 pub fn schedule_thread(thread: ThreadRef) {
@@ -491,7 +492,7 @@ pub fn schedule_resched() {
 
 #[thread_local]
 static STAT_COUNTER: AtomicU64 = AtomicU64::new(0);
-const PRINT_STATS: bool = true;
+const PRINT_STATS: bool = false;
 pub fn schedule_stattick(dt: Nanoseconds) {
     schedule_maybe_rebalance(dt);
 

--- a/src/kernel/src/spinlock.rs
+++ b/src/kernel/src/spinlock.rs
@@ -106,7 +106,7 @@ impl<T, Relax: RelaxStrategy> LockGuard<'_, T, Relax> {
         self.lock
     }
 
-    pub unsafe fn force_unlock(&self) {
+    pub unsafe fn force_unlock(&mut self) {
         self.dont_unlock_on_drop = true;
         self.lock.release();
         crate::interrupt::set(self.interrupt_state);

--- a/src/kernel/src/syscall/sync.rs
+++ b/src/kernel/src/syscall/sync.rs
@@ -1,10 +1,155 @@
 use core::time::Duration;
 
-use twizzler_abi::syscall::{ThreadSync, ThreadSyncError};
+use alloc::{collections::BTreeMap, vec::Vec};
+use twizzler_abi::syscall::{
+    ThreadSync, ThreadSyncError, ThreadSyncReference, ThreadSyncSleep, ThreadSyncWake,
+};
+use x86_64::VirtAddr;
+
+use crate::{
+    mutex::Mutex,
+    obj::{LookupFlags, ObjectRef},
+    spinlock::Spinlock,
+    thread::{current_memory_context, current_thread_ref, ThreadRef, ThreadState},
+};
+
+struct Requeue {
+    list: Spinlock<BTreeMap<u64, ThreadRef>>,
+}
+
+/* TODO: make this thread-local */
+static mut REQUEUE: spin::Once<Requeue> = spin::Once::new();
+
+fn get_requeue_list() -> &'static Requeue {
+    unsafe {
+        REQUEUE.call_once(|| Requeue {
+            list: Spinlock::new(BTreeMap::new()),
+        })
+    }
+}
+
+pub fn requeue_all() {
+    let requeue = get_requeue_list();
+    let mut list = requeue.list.lock();
+    for (_, thread) in list.drain_filter(|_, v| v.reset_sync_sleep_done()) {
+        crate::sched::schedule_thread(thread);
+    }
+}
+
+pub fn add_to_requeue(thread: ThreadRef) {
+    let requeue = get_requeue_list();
+    requeue.list.lock().insert(thread.id(), thread);
+}
+
+fn finish_blocking() {
+    let thread = current_thread_ref().unwrap();
+    thread.set_state(ThreadState::Blocked);
+    crate::sched::schedule(false);
+    thread.set_state(ThreadState::Running);
+}
+
+fn get_obj_and_offset(addr: VirtAddr) -> Result<(ObjectRef, usize), ThreadSyncError> {
+    let t = current_thread_ref().unwrap();
+    logln!("w{}", t.id());
+    let vmc = current_memory_context().ok_or(ThreadSyncError::Unknown)?;
+    logln!("x{}", t.id());
+    let mapping = { vmc.inner().lookup_object(addr) }.ok_or(ThreadSyncError::InvalidReference)?;
+    logln!("y");
+    let offset = (addr.as_u64() as usize) % (1024 * 1024 * 1024); //TODO: arch-dep, centralize these calculations somewhere, see PageNumber
+    Ok((mapping.obj.clone(), offset))
+}
+
+fn get_obj(reference: ThreadSyncReference) -> Result<(ObjectRef, usize), ThreadSyncError> {
+    Ok(match reference {
+        ThreadSyncReference::ObjectRef(id, offset) => {
+            let obj = match crate::obj::lookup_object(id, LookupFlags::empty()) {
+                crate::obj::LookupResult::Found(o) => o,
+                _ => Err(ThreadSyncError::InvalidReference)?,
+            };
+            (obj, offset)
+        }
+        ThreadSyncReference::Virtual(addr) => get_obj_and_offset(VirtAddr::new(addr as u64))?,
+    })
+}
+
+struct SleepEvent {
+    obj: ObjectRef,
+    offset: usize,
+    did_sleep: bool,
+}
+
+fn prep_sleep(sleep: &ThreadSyncSleep, first_sleep: bool) -> Result<SleepEvent, ThreadSyncError> {
+    let (obj, offset) = get_obj(sleep.reference)?;
+    let did_sleep = obj.setup_sleep_word(offset, sleep.op, sleep.value, first_sleep);
+    Ok(SleepEvent {
+        obj,
+        offset,
+        did_sleep,
+    })
+}
+
+fn undo_sleep(sleep: SleepEvent) {
+    sleep.obj.remove_from_sleep_word(sleep.offset);
+}
+
+fn wakeup(wake: &ThreadSyncWake) -> Result<usize, ThreadSyncError> {
+    let (obj, offset) = get_obj(wake.reference)?;
+    logln!("got ref");
+    Ok(obj.wakeup_word(offset, wake.count))
+}
 
 pub fn sys_thread_sync(
-    _ops: &[ThreadSync],
+    ops: &mut [ThreadSync],
     _timeout: Option<&mut Duration>,
-) -> Result<u64, ThreadSyncError> {
-    Ok(0)
+) -> Result<usize, ThreadSyncError> {
+    let mut ready_count = 0;
+    let mut unsleeps = Vec::new();
+    let ttt = current_thread_ref().unwrap();
+    logln!("{} thread_sync {:?}", ttt.id(), ops);
+    for op in ops {
+        match op {
+            ThreadSync::Sleep(sleep, result) => match prep_sleep(sleep, unsleeps.len() == 0) {
+                Ok(se) => {
+                    *result = Ok(0);
+                    if se.did_sleep {
+                        unsleeps.push(se)
+                    } else {
+                        ready_count += 1;
+                    }
+                }
+                Err(x) => *result = Err(x),
+            },
+            ThreadSync::Wake(wake, result) => match wakeup(wake) {
+                Ok(count) => {
+                    *result = Ok(count);
+                    if count > 0 {
+                        ready_count += 1;
+                    }
+                }
+                Err(x) => {
+                    *result = Err(x);
+                }
+            },
+        }
+    }
+    let thread = current_thread_ref().unwrap();
+    logln!("{} GOT HERE", thread.id());
+    {
+        let guard = thread.enter_critical();
+        if unsleeps.len() > 0 {
+            thread.set_sync_sleep_done();
+        }
+        requeue_all();
+        if unsleeps.len() > 0 {
+            logln!("actually sleeping");
+            finish_blocking();
+            logln!("back from sleeping")
+        }
+        drop(guard);
+    }
+    for op in unsleeps {
+        undo_sleep(op);
+    }
+    logln!("  => ret {}", ready_count);
+    Ok(ready_count)
 }

--- a/src/kernel/src/syscall/thread.rs
+++ b/src/kernel/src/syscall/thread.rs
@@ -3,7 +3,7 @@ use twizzler_abi::{
     syscall::{ThreadControl, ThreadSpawnArgs, ThreadSpawnError},
 };
 
-use crate::{thread::current_thread_ref};
+use crate::thread::current_thread_ref;
 
 pub fn sys_spawn(args: &ThreadSpawnArgs) -> Result<ObjID, ThreadSpawnError> {
     let id = crate::thread::start_new_user(*args);
@@ -20,7 +20,7 @@ pub fn thread_ctrl(cmd: ThreadControl, arg: u64) -> (u64, u64) {
                 let th = current_thread_ref().unwrap();
                 unsafe {
                     th.repr.as_ref().unwrap().write_val_and_signal(0x1000 /* TODO: object null page size */ + 8 /* TODO: thread repr status word */,
-                    1u64, u64::MAX);
+                    1u64, usize::MAX);
                 }
             }
             crate::thread::exit();

--- a/src/kernel/src/thread.rs
+++ b/src/kernel/src/thread.rs
@@ -378,6 +378,10 @@ impl<'a> Drop for CriticalGuard<'a> {
 }
 
 impl Priority {
+    pub const REALTIME: Self = Self {
+        class: PriorityClass::RealTime,
+        adjust: AtomicI32::new(0),
+    };
     pub fn queue_number<const NR_QUEUES: usize>(&self) -> usize {
         assert_eq!(NR_QUEUES % PriorityClass::ClassCount as usize, 0);
         let queues_per_class = NR_QUEUES / PriorityClass::ClassCount as usize;
@@ -667,4 +671,11 @@ pub fn start_new_init() {
     }
     thread.repr = Some(create_blank_object());
     schedule_new_thread(thread);
+}
+
+pub fn start_new_kernel(pri: Priority, start: extern "C" fn()) -> ThreadRef {
+    let mut thread = Thread::new();
+    thread.priority = pri;
+    unsafe { thread.init(start) }
+    schedule_new_thread(thread)
 }

--- a/src/lib/twizzler-abi/src/alloc.rs
+++ b/src/lib/twizzler-abi/src/alloc.rs
@@ -113,7 +113,9 @@ impl TwzGlobalAlloc {
             self.initial_slot = AllocSlot::new();
             if self.initial_slot.is_none() {
                 crate::print_err("failed to allocate initial allocation object");
-                crate::abort();
+                unsafe {
+                    crate::internal_abort();
+                }
             }
         }
         let ptr = crate::internal_unwrap(
@@ -130,7 +132,9 @@ impl TwzGlobalAlloc {
                 self.other_slots[self.slot_counter] = AllocSlot::new();
                 if self.other_slots[self.slot_counter].is_none() {
                     crate::print_err("failed to create allocation object");
-                    crate::abort();
+                    unsafe {
+                        crate::internal_abort();
+                    }
                 }
             }
             let ptr = crate::internal_unwrap(

--- a/src/lib/twizzler-abi/src/lib.rs
+++ b/src/lib/twizzler-abi/src/lib.rs
@@ -37,6 +37,7 @@ pub mod time;
 pub fn ready() {}
 
 /// We need to provide a no-mangled abort() call for things like libunwind.
+#[cfg(feature = "rt")]
 #[no_mangle]
 pub extern "C" fn abort() -> ! {
     unsafe { internal_abort() }
@@ -55,6 +56,7 @@ fn print_err(err: &str) {
 /// that assumes stack protections works (libunwind).
 /// # Safety
 /// This function cannot be called safely, as it will abort unconditionally.
+#[cfg(feature = "rt")]
 #[no_mangle]
 pub unsafe extern "C" fn __stack_chk_fail() {
     print_err("stack overflow -- aborting");
@@ -69,6 +71,8 @@ fn internal_unwrap<T>(t: Option<T>, msg: &str) -> T {
         t
     } else {
         print_err(msg);
-        abort();
+        unsafe {
+            internal_abort();
+        }
     }
 }

--- a/src/lib/twizzler-abi/src/syscall.rs
+++ b/src/lib/twizzler-abi/src/syscall.rs
@@ -446,7 +446,7 @@ fn justval<T: From<u64>>(_: u64, v: u64) -> T {
 pub fn sys_thread_sync(
     operations: &mut [ThreadSync],
     timeout: Option<Duration>,
-) -> Result<bool, ThreadSyncError> {
+) -> Result<usize, ThreadSyncError> {
     let ptr = operations.as_mut_ptr();
     let count = operations.len();
     let timeout = timeout
@@ -463,7 +463,7 @@ pub fn sys_thread_sync(
         code,
         val,
         |c, _| c != 0,
-        |_, v| v > 0,
+        |_, v| v as usize,
         |_, v| ThreadSyncError::from(v),
     )
 }


### PR DESCRIPTION
This branch adds the thread sync system call implementation, which has some changes throughout:

1. Changes to rust port to support new thread_sync semantics in the sync primitives (and fixing some bugs)
2. Full implementation of the thread_sync system call, requiring some cross-kernel changes to support waiting on object words and such.
3. Removal of the spin crate, as this crate does not have interrupt safe spinlocks (our are, so now we use those everywhere, and spin was really just there at the start to get some things going more easily).
4. Addition of a kernel API for Once (thread-safe single initialization of value)
5. Addition of a kernel thread to handle soft timeout processing (invoked from hardtick if needed to run a timeout callback).
6. Addition of a kernel condvar primitive.
7. Implementation of kernel_console_read system call.
8. Various minor tweaks to twizzler_abi to support new functionality.