### PR TITLE
Fix CPU feature enabling on older CPUs.

### DIFF
--- a/src/kernel/src/arch/amd64/interrupt.rs
+++ b/src/kernel/src/arch/amd64/interrupt.rs
@@ -2,7 +2,7 @@ use core::sync::atomic::Ordering;
 
 use twizzler_abi::upcall::{ExceptionInfo, UpcallFrame, UpcallInfo};
 use x86::current::rflags::RFlags;
-use x86_64::{instructions::segmentation::Segment64, VirtAddr};
+use x86_64::VirtAddr;
 
 use crate::{
     arch::lapic,
@@ -116,7 +116,6 @@ unsafe extern "C" fn common_handler_entry(
 ) {
     let user = user != 0;
     if user {
-        x86_64::registers::segmentation::FS::write_base(VirtAddr::new(kernel_fs));
         x86::msr::wrmsr(x86::msr::IA32_FS_BASE, kernel_fs);
         let t = current_thread_ref().unwrap();
         t.set_entry_registers(Registers::Interrupt(ctx, *ctx));
@@ -127,7 +126,6 @@ unsafe extern "C" fn common_handler_entry(
         let t = current_thread_ref().unwrap();
         t.set_entry_registers(Registers::None);
         let user_fs = t.arch.user_fs.load(Ordering::SeqCst);
-        x86_64::registers::segmentation::FS::write_base(VirtAddr::new(user_fs));
         x86::msr::wrmsr(x86::msr::IA32_FS_BASE, user_fs);
         drop(t);
     }

--- a/src/kernel/src/arch/amd64/lapic.rs
+++ b/src/kernel/src/arch/amd64/lapic.rs
@@ -143,7 +143,9 @@ pub fn schedule_oneshot_tick(time: Nanoseconds) {
 }
 
 pub fn read_monotonic_nanoseconds() -> Nanoseconds {
-    let tsc = unsafe { x86::time::rdtscp() };
+    // TODO: should we use rdtsc or rdtscp here? (the latter will require a cpuid check once (only
+    // once, cache the result))
+    let tsc = unsafe { x86::time::rdtsc() };
     let f = unsafe { FREQ_MHZ };
     if unlikely(f == 0) {
         panic!("cannot read nanoseconds before TSC calibration");

--- a/src/kernel/src/arch/amd64/mod.rs
+++ b/src/kernel/src/arch/amd64/mod.rs
@@ -57,14 +57,13 @@ pub unsafe fn jump_to_user(target: VirtAddr, stack: VirtAddr, arg: u64) {
             .arch
             .user_fs
             .load(Ordering::SeqCst);
-        x86_64::registers::segmentation::FS::write_base(VirtAddr::new(user_fs));
         x86::msr::wrmsr(x86::msr::IA32_FS_BASE, user_fs);
     }
     syscall::return_to_user(&ctx as *const syscall::X86SyscallContext);
 }
 
 pub use lapic::schedule_oneshot_tick;
-use x86_64::{registers::segmentation::Segment64, VirtAddr};
+use x86_64::VirtAddr;
 
 pub fn set_interrupt(
     num: u32,

--- a/src/kernel/src/arch/amd64/start.rs
+++ b/src/kernel/src/arch/amd64/start.rs
@@ -126,10 +126,7 @@ extern "C" fn __stivale_start(info: &'static StivaleStruct) -> ! {
         let efer = x86::msr::rdmsr(x86::msr::IA32_EFER);
         x86::msr::wrmsr(x86::msr::IA32_EFER, efer | (1 << 11));
         let cr4 = x86::controlregs::cr4();
-        x86::controlregs::cr4_write(
-            cr4 | x86::controlregs::Cr4::CR4_ENABLE_GLOBAL_PAGES
-                | x86::controlregs::Cr4::CR4_ENABLE_FSGSBASE,
-        );
+        x86::controlregs::cr4_write(cr4 | x86::controlregs::Cr4::CR4_ENABLE_GLOBAL_PAGES);
     }
     let mut boot_info = StivaleBootInfo {
         arch: info,


### PR DESCRIPTION
This commit fixes the kernel's reliance on rd/wrfs/gsbase instructions
and falls back to fxsave/etc instructions when xsave is not present.

This addresses #75 