### PR TITLE
Kernel object page pinning and DmaObject + DmaRegion implementation.

### DIFF
--- a/src/bin/init/src/main.rs
+++ b/src/bin/init/src/main.rs
@@ -151,6 +151,7 @@ fn list_subobjs(level: usize, id: ObjID) {
             )),
             Some(id),
             0,
+            0,
             KactionFlags::empty(),
         );
         if res.is_err() {
@@ -170,6 +171,7 @@ fn list_subobjs(level: usize, id: ObjID) {
             )),
             Some(id),
             0,
+            0,
             KactionFlags::empty(),
         );
         if res.is_err() {
@@ -188,6 +190,7 @@ fn enumerate_children(level: usize, id: ObjID) {
             KactionCmd::Generic(KactionGenericCmd::GetChild(n)),
             Some(id),
             0,
+            0,
             KactionFlags::empty(),
         );
         if res.is_err() {
@@ -205,6 +208,7 @@ fn test_kaction() {
     let res = sys_kaction(
         KactionCmd::Generic(KactionGenericCmd::GetKsoRoot),
         None,
+        0,
         0,
         KactionFlags::empty(),
     );

--- a/src/kernel/src/device.rs
+++ b/src/kernel/src/device.rs
@@ -65,10 +65,15 @@ fn get_kso_manager() -> &'static KsoManager {
     })
 }
 
-pub fn kaction(cmd: KactionCmd, id: Option<ObjID>, arg: u64) -> Result<KactionValue, KactionError> {
+pub fn kaction(
+    cmd: KactionCmd,
+    id: Option<ObjID>,
+    arg: u64,
+    _arg2: u64,
+) -> Result<KactionValue, KactionError> {
     match cmd {
         KactionCmd::Generic(cmd) => match cmd {
-            KactionGenericCmd::AllocateDMA(_np) => {
+            KactionGenericCmd::PinPages(_np) => {
                 todo!()
             }
             KactionGenericCmd::GetKsoRoot => {

--- a/src/kernel/src/device.rs
+++ b/src/kernel/src/device.rs
@@ -76,8 +76,10 @@ pub fn kaction(
     match cmd {
         KactionCmd::Generic(cmd) => match cmd {
             KactionGenericCmd::ReleasePin => {
-                // TODO
-                logln!("unimplemented: release pin");
+                let id = id.ok_or(KactionError::InvalidArgument)?;
+                let obj = lookup_object(id, LookupFlags::empty()).ok_or(KactionError::NotFound)?;
+                let pin = arg as u32;
+                obj.release_pin(pin);
                 Ok(KactionValue::U64(0))
             }
             KactionGenericCmd::PinPages(_np) => {

--- a/src/kernel/src/device.rs
+++ b/src/kernel/src/device.rs
@@ -75,6 +75,11 @@ pub fn kaction(
 ) -> Result<KactionValue, KactionError> {
     match cmd {
         KactionCmd::Generic(cmd) => match cmd {
+            KactionGenericCmd::ReleasePin => {
+                // TODO
+                logln!("unimplemented: release pin");
+                Ok(KactionValue::U64(0))
+            }
             KactionGenericCmd::PinPages(_np) => {
                 let id = id.ok_or(KactionError::InvalidArgument)?;
                 let obj = lookup_object(id, LookupFlags::empty()).ok_or(KactionError::NotFound)?;

--- a/src/kernel/src/obj/mod.rs
+++ b/src/kernel/src/obj/mod.rs
@@ -122,6 +122,10 @@ impl Object {
         self.maplist.lock().insert(mapping);
     }
 
+    pub fn release_pin(&self, _pin: u32) {
+        // TODO: Currently we don't track pins. This will be changed in-future when we fully implement eviction.
+    }
+
     pub fn pin(&self, start: PageNumber, len: usize) -> Option<(Vec<PhysAddr>, u32)> {
         let mut tree = self.lock_page_tree();
 

--- a/src/kernel/src/syscall/mod.rs
+++ b/src/kernel/src/syscall/mod.rs
@@ -89,6 +89,7 @@ fn type_sys_kaction(
     lo: u64,
     arg: u64,
     _flags: u64,
+    arg2: u64,
 ) -> Result<KactionValue, KactionError> {
     let cmd = KactionCmd::try_from(cmd)?;
     let objid = if hi == 0 {
@@ -96,7 +97,7 @@ fn type_sys_kaction(
     } else {
         Some(ObjID::new_from_parts(hi, lo))
     };
-    crate::device::kaction(cmd, objid, arg)
+    crate::device::kaction(cmd, objid, arg, arg2)
 }
 
 fn type_read_clock_info(src: u64, info: u64, _flags: u64) -> Result<u64, ReadClockInfoError> {
@@ -212,7 +213,8 @@ pub fn syscall_entry<T: SyscallContext>(context: &mut T) {
             let lo = context.arg2();
             let arg = context.arg3();
             let flags = context.arg4();
-            let result = type_sys_kaction(cmd, hi, lo, arg, flags);
+            let arg2 = context.arg5();
+            let result = type_sys_kaction(cmd, hi, lo, arg, flags, arg2);
             let (code, val) = convert_result_to_codes(result, |v| v.into(), zero_err);
             context.set_return_values(code, val);
         }

--- a/src/kernel/src/syscall/mod.rs
+++ b/src/kernel/src/syscall/mod.rs
@@ -36,7 +36,7 @@ pub trait SyscallContext {
         u64: From<R2>;
 }
 
-unsafe fn create_user_slice<'a, T>(ptr: u64, len: u64) -> Option<&'a mut [T]> {
+pub unsafe fn create_user_slice<'a, T>(ptr: u64, len: u64) -> Option<&'a mut [T]> {
     /* TODO: verify pointers */
     Some(core::slice::from_raw_parts_mut(ptr as *mut T, len as usize))
 }

--- a/src/lib/twizzler-abi/src/kso.rs
+++ b/src/lib/twizzler-abi/src/kso.rs
@@ -153,8 +153,8 @@ pub enum KactionGenericCmd {
     GetChild(u16),
     /// Get a sub-object.
     GetSubObject(u8, u8),
-    /// Allocate DMA memory.
-    AllocateDMA(u16),
+    /// Pin pages of object memory.
+    PinPages(u16),
 }
 
 impl From<KactionGenericCmd> for u32 {
@@ -163,7 +163,7 @@ impl From<KactionGenericCmd> for u32 {
             KactionGenericCmd::GetKsoRoot => (0, 0),
             KactionGenericCmd::GetChild(v) => (1, v),
             KactionGenericCmd::GetSubObject(t, v) => (2, ((t as u16) << 8) | (v as u16)),
-            KactionGenericCmd::AllocateDMA(v) => (3, v),
+            KactionGenericCmd::PinPages(v) => (3, v),
         };
         ((h as u32) << 16) | l as u32
     }
@@ -177,7 +177,7 @@ impl TryFrom<u32> for KactionGenericCmd {
             0 => KactionGenericCmd::GetKsoRoot,
             1 => KactionGenericCmd::GetChild(l),
             2 => KactionGenericCmd::GetSubObject((l >> 8) as u8, l as u8),
-            3 => KactionGenericCmd::AllocateDMA(l),
+            3 => KactionGenericCmd::PinPages(l),
             _ => return Err(KactionError::InvalidArgument),
         };
         Ok(v)

--- a/src/lib/twizzler-abi/src/kso.rs
+++ b/src/lib/twizzler-abi/src/kso.rs
@@ -155,6 +155,8 @@ pub enum KactionGenericCmd {
     GetSubObject(u8, u8),
     /// Pin pages of object memory.
     PinPages(u16),
+    /// Release Pin
+    ReleasePin,
 }
 
 impl From<KactionGenericCmd> for u32 {
@@ -164,6 +166,7 @@ impl From<KactionGenericCmd> for u32 {
             KactionGenericCmd::GetChild(v) => (1, v),
             KactionGenericCmd::GetSubObject(t, v) => (2, ((t as u16) << 8) | (v as u16)),
             KactionGenericCmd::PinPages(v) => (3, v),
+            KactionGenericCmd::ReleasePin => (4, 0),
         };
         ((h as u32) << 16) | l as u32
     }
@@ -178,6 +181,7 @@ impl TryFrom<u32> for KactionGenericCmd {
             1 => KactionGenericCmd::GetChild(l),
             2 => KactionGenericCmd::GetSubObject((l >> 8) as u8, l as u8),
             3 => KactionGenericCmd::PinPages(l),
+            4 => KactionGenericCmd::ReleasePin,
             _ => return Err(KactionError::InvalidArgument),
         };
         Ok(v)

--- a/src/lib/twizzler-abi/src/syscall/kaction.rs
+++ b/src/lib/twizzler-abi/src/syscall/kaction.rs
@@ -34,3 +34,9 @@ pub fn sys_kaction(
 pub struct PinnedPage {
     phys: u64,
 }
+
+impl PinnedPage {
+    pub fn new(phys: u64) -> Self {
+        Self { phys }
+    }
+}

--- a/src/lib/twizzler-abi/src/syscall/kaction.rs
+++ b/src/lib/twizzler-abi/src/syscall/kaction.rs
@@ -30,6 +30,7 @@ pub fn sys_kaction(
     )
 }
 
+#[derive(Clone, Copy, Debug, Hash, PartialEq, PartialOrd, Ord, Eq)]
 #[repr(C)]
 pub struct PinnedPage {
     phys: u64,
@@ -38,5 +39,9 @@ pub struct PinnedPage {
 impl PinnedPage {
     pub fn new(phys: u64) -> Self {
         Self { phys }
+    }
+
+    pub fn physical_address(&self) -> u64 {
+        self.phys
     }
 }

--- a/src/lib/twizzler-abi/src/syscall/kaction.rs
+++ b/src/lib/twizzler-abi/src/syscall/kaction.rs
@@ -11,11 +11,16 @@ pub fn sys_kaction(
     cmd: KactionCmd,
     id: Option<ObjID>,
     arg: u64,
+    arg2: u64,
     flags: KactionFlags,
 ) -> Result<KactionValue, KactionError> {
     let (hi, lo) = id.map_or((0, 0), |id| id.split());
-    let (code, val) =
-        unsafe { raw_syscall(Syscall::Kaction, &[cmd.into(), hi, lo, arg, flags.bits()]) };
+    let (code, val) = unsafe {
+        raw_syscall(
+            Syscall::Kaction,
+            &[cmd.into(), hi, lo, arg, flags.bits(), arg2],
+        )
+    };
     convert_codes_to_result(
         code,
         val,
@@ -23,4 +28,9 @@ pub fn sys_kaction(
         |c, v| KactionValue::from((c, v)),
         |_, v| KactionError::from(v),
     )
+}
+
+#[repr(C)]
+pub struct PinnedPage {
+    phys: u64,
 }

--- a/src/lib/twizzler-driver/src/arch/mod.rs
+++ b/src/lib/twizzler-driver/src/arch/mod.rs
@@ -2,4 +2,4 @@
 pub(crate) mod x86;
 
 #[cfg(target_arch = "x86_64")]
-pub(crate) use x86::sync;
+pub(crate) use x86::*;

--- a/src/lib/twizzler-driver/src/arch/mod.rs
+++ b/src/lib/twizzler-driver/src/arch/mod.rs
@@ -1,0 +1,5 @@
+#[cfg(target_arch = "x86_64")]
+pub(crate) mod x86;
+
+#[cfg(target_arch = "x86_64")]
+pub(crate) use x86::sync;

--- a/src/lib/twizzler-driver/src/arch/mod.rs
+++ b/src/lib/twizzler-driver/src/arch/mod.rs
@@ -2,4 +2,4 @@
 pub(crate) mod x86;
 
 #[cfg(target_arch = "x86_64")]
-pub(crate) use x86::*;
+pub use x86::*;

--- a/src/lib/twizzler-driver/src/arch/x86.rs
+++ b/src/lib/twizzler-driver/src/arch/x86.rs
@@ -9,4 +9,4 @@ pub(crate) fn sync<'a, T: DeviceSync>(
     // x86 is already coherent
 }
 
-pub(crate) const DMA_PAGE_SIZE: usize = 0x1000;
+pub const DMA_PAGE_SIZE: usize = 0x1000;

--- a/src/lib/twizzler-driver/src/arch/x86.rs
+++ b/src/lib/twizzler-driver/src/arch/x86.rs
@@ -1,0 +1,5 @@
+use crate::dma::{DeviceSync, DmaRegion};
+
+pub(crate) fn sync<'a, T: DeviceSync>(_region: &DmaRegion<'a, T>) {
+    // x86 is already coherent
+}

--- a/src/lib/twizzler-driver/src/arch/x86.rs
+++ b/src/lib/twizzler-driver/src/arch/x86.rs
@@ -1,5 +1,12 @@
-use crate::dma::{DeviceSync, DmaRegion};
+use crate::dma::{DeviceSync, DmaRegion, SyncMode};
 
-pub(crate) fn sync<'a, T: DeviceSync>(_region: &DmaRegion<'a, T>) {
+pub(crate) fn sync<'a, T: DeviceSync>(
+    _region: &DmaRegion<'a, T>,
+    _mode: SyncMode,
+    _offset: usize,
+    _len: usize,
+) {
     // x86 is already coherent
 }
+
+pub(crate) const DMA_PAGE_SIZE: usize = 0x1000;

--- a/src/lib/twizzler-driver/src/device/children.rs
+++ b/src/lib/twizzler-driver/src/device/children.rs
@@ -13,7 +13,7 @@ impl Iterator for DeviceChildrenIterator {
     fn next(&mut self) -> Option<Self::Item> {
         let cmd = KactionCmd::Generic(KactionGenericCmd::GetChild(self.pos));
         let result =
-            twizzler_abi::syscall::sys_kaction(cmd, Some(self.id), 0, KactionFlags::empty())
+            twizzler_abi::syscall::sys_kaction(cmd, Some(self.id), 0, 0, KactionFlags::empty())
                 .ok()?;
         self.pos += 1;
         result.objid().map(|id| Device::new(id).ok()).flatten()

--- a/src/lib/twizzler-driver/src/device/mod.rs
+++ b/src/lib/twizzler-driver/src/device/mod.rs
@@ -38,9 +38,14 @@ impl Device {
 
     fn get_subobj(&self, ty: u8, idx: u8) -> Option<ObjID> {
         let cmd = KactionCmd::Generic(KactionGenericCmd::GetSubObject(ty, idx));
-        let result =
-            twizzler_abi::syscall::sys_kaction(cmd, Some(self.obj.id()), 0, KactionFlags::empty())
-                .ok()?;
+        let result = twizzler_abi::syscall::sys_kaction(
+            cmd,
+            Some(self.obj.id()),
+            0,
+            0,
+            KactionFlags::empty(),
+        )
+        .ok()?;
         result.objid()
     }
 
@@ -67,6 +72,6 @@ impl Device {
         value: u64,
         flags: KactionFlags,
     ) -> Result<KactionValue, KactionError> {
-        twizzler_abi::syscall::sys_kaction(action, Some(self.obj.id()), value, flags)
+        twizzler_abi::syscall::sys_kaction(action, Some(self.obj.id()), value, 0, flags)
     }
 }

--- a/src/lib/twizzler-driver/src/dma/mod.rs
+++ b/src/lib/twizzler-driver/src/dma/mod.rs
@@ -21,6 +21,7 @@ pub enum SyncMode {
     PostCpuToDevice,
     PreDeviceToCpu,
     PostDeviceToCpu,
+    FullCoherence,
 }
 
 bitflags::bitflags! {

--- a/src/lib/twizzler-driver/src/dma/object.rs
+++ b/src/lib/twizzler-driver/src/dma/object.rs
@@ -1,3 +1,4 @@
+use twizzler_abi::object::NULLPAGE_SIZE;
 use twizzler_object::Object;
 
 use super::{Access, DeviceSync, DmaArrayRegion, DmaOptions, DmaRegion};
@@ -13,7 +14,14 @@ impl DmaObject {
         access: Access,
         options: DmaOptions,
     ) -> DmaArrayRegion<'a, T> {
-        todo!()
+        DmaArrayRegion::new(
+            self,
+            core::mem::size_of::<T>() * len,
+            access,
+            options,
+            NULLPAGE_SIZE,
+            len,
+        )
     }
 
     pub fn region<'a, T: DeviceSync>(
@@ -21,15 +29,23 @@ impl DmaObject {
         access: Access,
         options: DmaOptions,
     ) -> DmaRegion<'a, T> {
-        todo!()
+        DmaRegion::new(
+            self,
+            core::mem::size_of::<T>(),
+            access,
+            options,
+            NULLPAGE_SIZE,
+        )
     }
 
     pub fn object(&self) -> &Object<()> {
         todo!()
     }
 
-    pub fn new<T>(&self, obj: Object<T>) -> Self {
-        todo!()
+    pub fn new<T>(obj: Object<T>) -> Self {
+        Self {
+            obj: unsafe { obj.transmute() },
+        }
     }
 }
 
@@ -41,6 +57,6 @@ impl Drop for DmaObject {
 
 impl<T> From<Object<T>> for DmaObject {
     fn from(obj: Object<T>) -> Self {
-        todo!()
+        Self::new(obj)
     }
 }

--- a/src/lib/twizzler-driver/src/dma/object.rs
+++ b/src/lib/twizzler-driver/src/dma/object.rs
@@ -2,26 +2,34 @@ use std::sync::Mutex;
 
 use twizzler_abi::{
     kso::{KactionCmd, KactionFlags, KactionGenericCmd},
-    object::NULLPAGE_SIZE,
+    object::{MAX_SIZE, NULLPAGE_SIZE},
     syscall::sys_kaction,
 };
 use twizzler_object::{ObjID, Object};
 
-use super::{Access, DeviceSync, DmaArrayRegion, DmaOptions, DmaRegion};
+use super::{Access, DeviceSync, DmaOptions, DmaRegion, DmaSliceRegion};
 
+/// A handle for an object that can be used to perform DMA, and is most useful directly as a way to
+/// perform DMA operations on a specific object. For an allocator-like DMA interface, see [crate::pool::DmaPool].
 pub struct DmaObject {
     obj: Object<()>,
     pub(crate) releasable_pins: Mutex<Vec<u32>>,
 }
 
 impl DmaObject {
+    /// Create a [DmaSliceRegion] from the base of this object, where the region represents memory
+    /// of type `[T; len]`.
     pub fn slice_region<'a, T: DeviceSync>(
         &'a self,
         len: usize,
         access: Access,
         options: DmaOptions,
-    ) -> DmaArrayRegion<'a, T> {
-        DmaArrayRegion::new(
+    ) -> DmaSliceRegion<'a, T> {
+        let nr_bytes = core::mem::size_of::<T>()
+            .checked_mul(len)
+            .expect("Value of len too large");
+        assert!(nr_bytes < MAX_SIZE - NULLPAGE_SIZE * 2);
+        DmaSliceRegion::new(
             self,
             core::mem::size_of::<T>() * len,
             access,
@@ -31,6 +39,8 @@ impl DmaObject {
         )
     }
 
+    /// Create a [DmaRegion] from the base of this object, where the region represents memory
+    /// of type `T`.
     pub fn region<'a, T: DeviceSync>(
         &'a self,
         access: Access,
@@ -45,10 +55,12 @@ impl DmaObject {
         )
     }
 
+    /// Get a reference to the object handle.
     pub fn object(&self) -> &Object<()> {
         &self.obj
     }
 
+    /// Create a new [DmaObject] from an existing object handle.
     pub fn new<T>(obj: Object<T>) -> Self {
         Self {
             obj: unsafe { obj.transmute() },

--- a/src/lib/twizzler-driver/src/dma/pin.rs
+++ b/src/lib/twizzler-driver/src/dma/pin.rs
@@ -3,18 +3,22 @@ use std::ops::Index;
 use crate::arch::DMA_PAGE_SIZE;
 
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Ord, Eq, Hash)]
+/// A physical address. Must be aligned on [DMA_PAGE_SIZE].
 pub struct PhysAddr(u64);
 
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Ord, Eq, Hash)]
+/// Information about a page of DMA memory, including it's physical address.
 pub struct PhysInfo {
     addr: PhysAddr,
 }
 
+/// An iterator over DMA memory pages, returning [PhysInfo].
 pub struct DmaPinIter<'a> {
     pin: &'a [PhysInfo],
     idx: usize,
 }
 
+/// A representation of some pinned memory for a region.
 pub struct DmaPin<'a> {
     backing: &'a [PhysInfo],
 }
@@ -26,10 +30,11 @@ impl<'a> DmaPin<'a> {
 }
 
 impl PhysInfo {
-    pub fn new(addr: PhysAddr) -> Self {
+    pub(crate) fn new(addr: PhysAddr) -> Self {
         Self { addr }
     }
 
+    /// Get the address of this DMA memory page.
     pub fn addr(&self) -> PhysAddr {
         self.addr
     }
@@ -88,8 +93,11 @@ impl<'a> Index<usize> for DmaPin<'a> {
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Ord, Eq, Hash)]
+/// Possible failure modes for pinning memory.
 pub enum PinError {
+    /// An internal error occurred.
     InternalError,
+    /// Kernel resources are exhausted.
     Exhausted,
 }
 

--- a/src/lib/twizzler-driver/src/dma/pin.rs
+++ b/src/lib/twizzler-driver/src/dma/pin.rs
@@ -89,6 +89,7 @@ pub enum PinError {
     Exhausted,
 }
 
+#[cfg(test)]
 mod tests {
     use twizzler_abi::syscall::{BackingType, LifetimeType};
     use twizzler_object::{CreateSpec, Object};

--- a/src/lib/twizzler-driver/src/dma/pin.rs
+++ b/src/lib/twizzler-driver/src/dma/pin.rs
@@ -1,5 +1,7 @@
 use std::ops::Index;
 
+use crate::arch::DMA_PAGE_SIZE;
+
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Ord, Eq, Hash)]
 pub struct PhysAddr(u64);
 
@@ -43,7 +45,9 @@ impl TryFrom<u64> for PhysAddr {
     type Error = ();
 
     fn try_from(value: u64) -> Result<Self, Self::Error> {
-        // TODO: verify address
+        if value & (DMA_PAGE_SIZE as u64 - 1) != 0 {
+            return Err(());
+        }
         Ok(Self(value))
     }
 }

--- a/src/lib/twizzler-driver/src/dma/pool.rs
+++ b/src/lib/twizzler-driver/src/dma/pool.rs
@@ -15,6 +15,7 @@ impl DmaPool {
         todo!()
     }
 
+    // TODO: update so these are failable
     pub fn allocate<'a, T: DeviceSync>(&'a self, init: T) -> DmaRegion<'a, T> {
         todo!()
     }

--- a/src/lib/twizzler-driver/src/dma/pool.rs
+++ b/src/lib/twizzler-driver/src/dma/pool.rs
@@ -1,6 +1,6 @@
 use twizzler_object::CreateSpec;
 
-use super::{Access, DeviceSync, DmaArrayRegion, DmaOptions, DmaRegion};
+use super::{Access, DeviceSync, DmaOptions, DmaRegion, DmaSliceRegion};
 
 pub struct DmaPool {
     opts: DmaOptions,
@@ -24,14 +24,14 @@ impl DmaPool {
         todo!()
     }
 
-    pub fn allocate_array<'a, T: DeviceSync>(&'a self, init: T) -> DmaArrayRegion<'a, T> {
+    pub fn allocate_array<'a, T: DeviceSync>(&'a self, init: T) -> DmaSliceRegion<'a, T> {
         todo!()
     }
 
     pub fn allocate_array_with<'a, T: DeviceSync>(
         &'a self,
         init: impl Fn() -> T,
-    ) -> DmaArrayRegion<'a, T> {
+    ) -> DmaSliceRegion<'a, T> {
         todo!()
     }
 }

--- a/src/lib/twizzler-driver/src/dma/pool.rs
+++ b/src/lib/twizzler-driver/src/dma/pool.rs
@@ -3,11 +3,11 @@ use twizzler_object::CreateSpec;
 use super::{Access, DeviceSync, DmaOptions, DmaRegion, DmaSliceRegion};
 
 pub struct DmaPool {
-    opts: DmaOptions,
+    _opts: DmaOptions,
 }
 
 impl DmaPool {
-    pub fn new(spec: CreateSpec, access: Access, opts: DmaOptions) -> Self {
+    pub fn new(_spec: CreateSpec, _access: Access, _opts: DmaOptions) -> Self {
         todo!()
     }
 
@@ -16,21 +16,21 @@ impl DmaPool {
     }
 
     // TODO: update so these are failable
-    pub fn allocate<'a, T: DeviceSync>(&'a self, init: T) -> DmaRegion<'a, T> {
+    pub fn allocate<'a, T: DeviceSync>(&'a self, _init: T) -> DmaRegion<'a, T> {
         todo!()
     }
 
-    pub fn allocate_with<'a, T: DeviceSync>(&'a self, init: impl Fn() -> T) -> DmaRegion<'a, T> {
+    pub fn allocate_with<'a, T: DeviceSync>(&'a self, _init: impl Fn() -> T) -> DmaRegion<'a, T> {
         todo!()
     }
 
-    pub fn allocate_array<'a, T: DeviceSync>(&'a self, init: T) -> DmaSliceRegion<'a, T> {
+    pub fn allocate_array<'a, T: DeviceSync>(&'a self, _init: T) -> DmaSliceRegion<'a, T> {
         todo!()
     }
 
     pub fn allocate_array_with<'a, T: DeviceSync>(
         &'a self,
-        init: impl Fn() -> T,
+        _init: impl Fn() -> T,
     ) -> DmaSliceRegion<'a, T> {
         todo!()
     }

--- a/src/lib/twizzler-driver/src/dma/region.rs
+++ b/src/lib/twizzler-driver/src/dma/region.rs
@@ -96,11 +96,11 @@ impl<'a, T: DeviceSync> DmaRegion<'a, T> {
     }
 
     pub fn num_bytes(&self) -> usize {
-        todo!()
+        self.len
     }
 
     pub fn access(&self) -> Access {
-        todo!()
+        self.access
     }
 
     // Determines the backing information for region. This includes acquiring physical addresses for
@@ -111,7 +111,7 @@ impl<'a, T: DeviceSync> DmaRegion<'a, T> {
     }
 
     // Synchronize the region for cache coherence.
-    pub fn sync(&mut self, sync: SyncMode) {
+    pub fn sync(&self, _sync: SyncMode) {
         todo!()
     }
 
@@ -120,7 +120,12 @@ impl<'a, T: DeviceSync> DmaRegion<'a, T> {
     where
         F: FnOnce(&T) -> R,
     {
-        todo!()
+        if !self.options.contains(DmaOptions::UNSAFE_MANUAL_COHERENCE) {
+            self.sync(SyncMode::PostDeviceToCpu);
+        }
+        let data = unsafe { self.get() };
+        let ret = f(data);
+        ret
     }
 
     // Run a closure that takes a mutable reference to the DMA data, ensuring coherence.
@@ -128,31 +133,46 @@ impl<'a, T: DeviceSync> DmaRegion<'a, T> {
     where
         F: FnOnce(&mut T) -> R,
     {
-        todo!()
+        if !self.options.contains(DmaOptions::UNSAFE_MANUAL_COHERENCE) {
+            // TODO: combine these (update RFC)
+            self.sync(SyncMode::PostDeviceToCpu);
+            self.sync(SyncMode::PreCpuToDevice);
+        }
+        let data = unsafe { self.get_mut() };
+        let ret = f(data);
+        if !self.options.contains(DmaOptions::UNSAFE_MANUAL_COHERENCE) {
+            self.sync(SyncMode::PostCpuToDevice);
+        }
+        ret
     }
 
     /// Release any pin created for this region.
     ///
     /// # Safety
     /// Caller must ensure that no device is using the information from any active pins for this region.
-    pub unsafe fn release_pin(&self) {
-        todo!()
+    pub unsafe fn release_pin(&mut self) {
+        if let Some((_, token)) = self.backing {
+            super::object::release_pin(self.dma.object().id(), token);
+            self.backing = None;
+        }
     }
 
     /// Get a reference to the DMA memory.
     ///
     /// # Safety
     /// The caller must ensure coherence is applied.
+    #[inline]
     pub unsafe fn get(&self) -> &T {
-        todo!()
+        (self.virt as *const T).as_ref().unwrap()
     }
 
     /// Get a mutable reference to the DMA memory.
     ///
     /// # Safety
     /// The caller must ensure coherence is applied.
-    pub unsafe fn get_mut(&self) -> &mut T {
-        todo!()
+    #[inline]
+    pub unsafe fn get_mut(&mut self) -> &mut T {
+        (self.virt as *mut T).as_mut().unwrap()
     }
 }
 
@@ -172,25 +192,30 @@ impl<'a, T: DeviceSync> DmaArrayRegion<'a, T> {
     }
 
     pub fn num_bytes(&self) -> usize {
-        todo!()
+        self.region.len
     }
 
+    #[inline]
     pub fn access(&self) -> Access {
-        todo!()
+        self.region.access()
     }
 
     pub fn len(&self) -> usize {
-        todo!()
+        self.len
     }
+
+    // TODO: update RFC
     // Determines the backing information for region. This includes acquiring physical addresses for
     // the region and holding a pin for the pages.
+    #[inline]
     pub fn pin(&mut self) -> Result<DmaPin<'_>, PinError> {
         self.region.pin()
     }
 
     // Synchronize the region for cache coherence.
-    pub fn sync(&mut self, sync: SyncMode) {
-        todo!()
+    pub fn sync(&self, _range: Range<usize>, sync: SyncMode) {
+        // TODO: sync subset
+        self.region.sync(sync)
     }
 
     // Run a closure that takes a reference to the DMA data, ensuring coherence.
@@ -198,7 +223,16 @@ impl<'a, T: DeviceSync> DmaArrayRegion<'a, T> {
     where
         F: FnOnce(&[T]) -> R,
     {
-        todo!()
+        if !self
+            .region
+            .options
+            .contains(DmaOptions::UNSAFE_MANUAL_COHERENCE)
+        {
+            self.sync(range.clone(), SyncMode::PostDeviceToCpu);
+        }
+        let data = &unsafe { self.get() }[range];
+        let ret = f(data);
+        ret
     }
 
     // Run a closure that takes a mutable reference to the DMA data, ensuring coherence.
@@ -206,31 +240,52 @@ impl<'a, T: DeviceSync> DmaArrayRegion<'a, T> {
     where
         F: FnOnce(&mut [T]) -> R,
     {
-        todo!()
+        // TODO: combine these (update RFC)
+        if !self
+            .region
+            .options
+            .contains(DmaOptions::UNSAFE_MANUAL_COHERENCE)
+        {
+            self.sync(range.clone(), SyncMode::PostDeviceToCpu);
+            self.sync(range.clone(), SyncMode::PreCpuToDevice);
+        }
+        let data = &mut unsafe { self.get_mut() }[range.clone()];
+        let ret = f(data);
+        if !self
+            .region
+            .options
+            .contains(DmaOptions::UNSAFE_MANUAL_COHERENCE)
+        {
+            self.sync(range, SyncMode::PostCpuToDevice);
+        }
+        ret
     }
 
     /// Release any pin created for this region.
     ///
     /// # Safety
     /// Caller must ensure that no device is using the information from any active pins for this region.
-    pub unsafe fn release_pin(&self) {
-        todo!()
+    #[inline]
+    pub unsafe fn release_pin(&mut self) {
+        self.region.release_pin()
     }
 
     /// Get a reference to the DMA memory.
     ///
     /// # Safety
     /// The caller must ensure coherence is applied.
+    #[inline]
     pub unsafe fn get(&self) -> &[T] {
-        todo!()
+        core::slice::from_raw_parts(self.region.virt as *const T, self.len)
     }
 
     /// Get a mutable reference to the DMA memory.
     ///
     /// # Safety
     /// The caller must ensure coherence is applied.
-    pub unsafe fn get_mut(&self) -> &mut [T] {
-        todo!()
+    #[inline]
+    pub unsafe fn get_mut(&mut self) -> &mut [T] {
+        core::slice::from_raw_parts_mut(self.region.virt as *mut T, self.len)
     }
 }
 

--- a/src/lib/twizzler-driver/src/dma/region.rs
+++ b/src/lib/twizzler-driver/src/dma/region.rs
@@ -236,12 +236,8 @@ impl<'a, T: DeviceSync> DmaArrayRegion<'a, T> {
 
 impl<'a, T: DeviceSync> Drop for DmaRegion<'a, T> {
     fn drop(&mut self) {
-        todo!()
-    }
-}
-
-impl<'a, T: DeviceSync> Drop for DmaArrayRegion<'a, T> {
-    fn drop(&mut self) {
-        todo!()
+        if let Some((_, token)) = self.backing.as_ref() {
+            self.dma.releasable_pins.lock().unwrap().push(*token);
+        }
     }
 }

--- a/src/lib/twizzler-driver/src/dma/region.rs
+++ b/src/lib/twizzler-driver/src/dma/region.rs
@@ -66,10 +66,10 @@ impl<'a, T: DeviceSync> DmaRegion<'a, T> {
         let len = self.nr_pages();
         pins.resize(len, PinnedPage::new(0));
 
+        // The kaction call here compresses start and len into a u64, and returns the token and len
+        // in the return u64. This is all because of the limited registers in a syscall.
         let start = (self.offset / DMA_PAGE_SIZE) as u64;
-
         let ptr = (&pins).as_ptr() as u64;
-
         let res = sys_kaction(
             KactionCmd::Generic(KactionGenericCmd::PinPages(0)),
             Some(self.dma.object().id()),

--- a/src/lib/twizzler-driver/src/dma/region.rs
+++ b/src/lib/twizzler-driver/src/dma/region.rs
@@ -112,6 +112,7 @@ impl<'a, T: DeviceSync> DmaRegion<'a, T> {
 
     // Synchronize the region for cache coherence.
     pub fn sync(&self, _sync: SyncMode) {
+        crate::arch::sync(self);
         todo!()
     }
 

--- a/src/lib/twizzler-driver/src/lib.rs
+++ b/src/lib/twizzler-driver/src/lib.rs
@@ -26,7 +26,7 @@ impl BusTreeRoot {
 
 pub fn get_bustree_root() -> BusTreeRoot {
     let cmd = KactionCmd::Generic(KactionGenericCmd::GetKsoRoot);
-    let id = twizzler_abi::syscall::sys_kaction(cmd, None, 0, KactionFlags::empty())
+    let id = twizzler_abi::syscall::sys_kaction(cmd, None, 0, 0, KactionFlags::empty())
         .expect("failed to get device root")
         .unwrap_objid();
     BusTreeRoot { root_id: id }

--- a/src/lib/twizzler-driver/src/lib.rs
+++ b/src/lib/twizzler-driver/src/lib.rs
@@ -5,6 +5,7 @@ use device::children::DeviceChildrenIterator;
 use twizzler_abi::kso::{KactionCmd, KactionFlags, KactionGenericCmd};
 use twizzler_object::ObjID;
 
+mod arch;
 pub mod bus;
 pub mod controller;
 pub mod device;

--- a/src/lib/twizzler-object/src/object.rs
+++ b/src/lib/twizzler-object/src/object.rs
@@ -29,6 +29,10 @@ impl<T> Object<T> {
     pub fn slot(&self) -> &Arc<Slot> {
         &self.slot
     }
+
+    pub unsafe fn transmute<N>(self) -> Object<N> {
+        core::mem::transmute(self)
+    }
 }
 
 impl<Base> From<Arc<Slot>> for Object<Base> {


### PR DESCRIPTION
This PR implements support for pinning pages of object memory for use in DMA, and implements functions in the twizzler-driver::dma module for managing DMA objects and DMA memory regions, including managing syncing and pins. It does not include implementation of the DMA pool functions, which will be done in a future PR.

This in an incremental PR for RFC#0006 ( #84 ).