### PR TITLE
Add additional API documentation to the twizzler-driver crate.

### DIFF
--- a/src/lib/twizzler-driver/src/bus/mod.rs
+++ b/src/lib/twizzler-driver/src/bus/mod.rs
@@ -1,1 +1,3 @@
+//! A mod for managing bus-specific functionality.
+
 pub mod pcie;

--- a/src/lib/twizzler-driver/src/bus/pcie.rs
+++ b/src/lib/twizzler-driver/src/bus/pcie.rs
@@ -1,3 +1,5 @@
+//! PCIe-specific functionality.
+
 use std::ptr::NonNull;
 
 pub use twizzler_abi::device::bus::pcie::*;
@@ -7,7 +9,7 @@ use twizzler_abi::{
     vcell::Volatile,
 };
 
-use crate::device::{events::InterruptAllocationError, mmio::MmioObject, Device};
+use crate::device::{events::InterruptAllocationError, Device, MmioObject};
 
 pub struct PcieCapabilityIterator {
     cfg: MmioObject,

--- a/src/lib/twizzler-driver/src/controller.rs
+++ b/src/lib/twizzler-driver/src/controller.rs
@@ -2,20 +2,24 @@ use std::sync::Arc;
 
 use crate::device::{events::DeviceEventStream, Device};
 
+/// A single manager for both a device and an associated [DeviceEventStream].
 pub struct DeviceController {
     device: Arc<Device>,
     events: DeviceEventStream,
 }
 
 impl DeviceController {
+    /// Get a reference to the event stream.
     pub fn events(&self) -> &DeviceEventStream {
         &self.events
     }
 
+    /// Get a reference to the device.
     pub fn device(&self) -> &Device {
         &self.device
     }
 
+    /// Create a new device controller from a device.
     pub fn new_from_device(device: Device) -> Self {
         let device = Arc::new(device);
         Self {

--- a/src/lib/twizzler-driver/src/device/children.rs
+++ b/src/lib/twizzler-driver/src/device/children.rs
@@ -3,6 +3,7 @@ use twizzler_object::ObjID;
 
 use super::Device;
 
+/// An iterator over the children of a device.
 pub struct DeviceChildrenIterator {
     pub(crate) id: ObjID,
     pub(crate) pos: u16,
@@ -21,6 +22,7 @@ impl Iterator for DeviceChildrenIterator {
 }
 
 impl Device {
+    /// Get an iterator over the children of this device.
     pub fn children(&self) -> DeviceChildrenIterator {
         DeviceChildrenIterator {
             id: self.obj.id(),

--- a/src/lib/twizzler-driver/src/device/events.rs
+++ b/src/lib/twizzler-driver/src/device/events.rs
@@ -1,3 +1,5 @@
+//! Manage events for a device, including mailbox messages and interrupts.
+
 use std::{
     collections::VecDeque,
     sync::{atomic::Ordering, Arc, Mutex},

--- a/src/lib/twizzler-driver/src/device/info.rs
+++ b/src/lib/twizzler-driver/src/device/info.rs
@@ -1,8 +1,9 @@
 use twizzler_abi::device::SubObjectType;
-use twizzler_object::{ObjID, Object, ObjectInitError, Protections, ObjectInitFlags};
+use twizzler_object::{ObjID, Object, ObjectInitError, ObjectInitFlags, Protections};
 
 use super::Device;
 
+/// A handle to an info subobject.
 pub struct InfoObject<T> {
     obj: Object<T>,
 }
@@ -14,6 +15,7 @@ impl<T> InfoObject<T> {
         })
     }
 
+    /// Get a reference to the data contained within an info type subobject.
     pub fn get_data(&self) -> &T {
         unsafe { self.obj.base_unchecked() }
     }

--- a/src/lib/twizzler-driver/src/device/mmio.rs
+++ b/src/lib/twizzler-driver/src/device/mmio.rs
@@ -1,8 +1,9 @@
-use twizzler_abi::device::{MmioInfo, MMIO_OFFSET, SubObjectType};
-use twizzler_object::{ObjectInitError, Object, Protections, ObjectInitFlags, ObjID};
+use twizzler_abi::device::{MmioInfo, SubObjectType, MMIO_OFFSET};
+use twizzler_object::{ObjID, Object, ObjectInitError, ObjectInitFlags, Protections};
 
 use super::Device;
 
+/// A handle to an MMIO subobject.
 pub struct MmioObject {
     obj: Object<MmioInfo>,
 }
@@ -18,7 +19,7 @@ impl MmioObject {
         })
     }
 
-    // TODO: no unwrap
+    /// Get a reference to an MMIO subobject's info data.
     pub fn get_info(&self) -> &MmioInfo {
         self.obj.base().unwrap()
     }
@@ -36,6 +37,7 @@ impl MmioObject {
 }
 
 impl Device {
+    /// Get a handle to a MMIO type subobject.
     pub fn get_mmio(&self, idx: u8) -> Option<MmioObject> {
         let id = self.get_subobj(SubObjectType::Mmio.into(), idx)?;
         MmioObject::new(id).ok()

--- a/src/lib/twizzler-driver/src/device/mod.rs
+++ b/src/lib/twizzler-driver/src/device/mod.rs
@@ -14,6 +14,7 @@ pub mod events;
 pub mod info;
 pub mod mmio;
 
+/// A handle for a device.
 pub struct Device {
     obj: Object<DeviceRepr>,
 }
@@ -49,23 +50,28 @@ impl Device {
         result.objid()
     }
 
+    /// Get a reference to a device's representation data.
     pub fn repr(&self) -> &DeviceRepr {
         self.obj.base().unwrap()
     }
 
+    /// Get a mutable reference to a device's representation data.
     pub fn repr_mut(&self) -> &mut DeviceRepr {
         unsafe { self.obj.base_mut_unchecked() }
     }
 
+    /// Is this device a bus?
     pub fn is_bus(&self) -> bool {
         let repr = self.repr();
         repr.device_type == DeviceType::Bus
     }
 
+    /// Get the bus type of this device.
     pub fn bus_type(&self) -> BusType {
         self.repr().bus_type
     }
 
+    /// Execute a kaction operation on a device.
     pub fn kaction(
         &self,
         action: KactionCmd,

--- a/src/lib/twizzler-driver/src/device/mod.rs
+++ b/src/lib/twizzler-driver/src/device/mod.rs
@@ -1,3 +1,5 @@
+//! Functions and types for managing a device.
+
 use std::fmt::Display;
 
 pub use twizzler_abi::device::BusType;
@@ -9,10 +11,14 @@ use twizzler_abi::kso::{KactionCmd, KactionFlags, KactionGenericCmd};
 use twizzler_object::Object;
 use twizzler_object::{ObjID, ObjectInitError, ObjectInitFlags, Protections};
 
-pub mod children;
+mod children;
 pub mod events;
-pub mod info;
-pub mod mmio;
+mod info;
+mod mmio;
+
+pub use children::DeviceChildrenIterator;
+pub use info::InfoObject;
+pub use mmio::MmioObject;
 
 /// A handle for a device.
 pub struct Device {

--- a/src/lib/twizzler-driver/src/lib.rs
+++ b/src/lib/twizzler-driver/src/lib.rs
@@ -1,22 +1,26 @@
 #![feature(option_result_unwrap_unchecked)]
 #![feature(generic_associated_types)]
 #![feature(vec_into_raw_parts)]
-use device::children::DeviceChildrenIterator;
+use device::DeviceChildrenIterator;
 use twizzler_abi::kso::{KactionCmd, KactionFlags, KactionGenericCmd};
 use twizzler_object::ObjID;
 
 mod arch;
 pub mod bus;
-pub mod controller;
+mod controller;
 pub mod device;
 pub mod dma;
 pub mod request;
 
+pub use controller::DeviceController;
+
+/// A handle for the root of the bus tree.
 pub struct BusTreeRoot {
     root_id: ObjID,
 }
 
 impl BusTreeRoot {
+    /// Get the children of the bus tree.
     pub fn children(&self) -> DeviceChildrenIterator {
         DeviceChildrenIterator {
             id: self.root_id,
@@ -25,6 +29,7 @@ impl BusTreeRoot {
     }
 }
 
+/// Get a handle to the root of the bus tree.
 pub fn get_bustree_root() -> BusTreeRoot {
     let cmd = KactionCmd::Generic(KactionGenericCmd::GetKsoRoot);
     let id = twizzler_abi::syscall::sys_kaction(cmd, None, 0, 0, KactionFlags::empty())

--- a/src/lib/twizzler-driver/src/request/async_ids.rs
+++ b/src/lib/twizzler-driver/src/request/async_ids.rs
@@ -49,7 +49,7 @@ pub(super) struct AsyncIdAllocator {
 }
 
 impl AsyncIdAllocator {
-    pub fn new(num: usize) -> Self {
+    pub(super) fn new(num: usize) -> Self {
         if num == 0 {
             panic!("cannot set num IDs as 0");
         }
@@ -61,7 +61,8 @@ impl AsyncIdAllocator {
             },
         }
     }
-    pub fn try_next(&self) -> Option<u64> {
+
+    pub(super) fn try_next(&self) -> Option<u64> {
         if self.count.load(Ordering::SeqCst) <= self.max {
             let id = self.count.fetch_add(1, Ordering::SeqCst);
             if id <= self.max {
@@ -73,14 +74,14 @@ impl AsyncIdAllocator {
         inner.ids.pop()
     }
 
-    pub async fn next(&self) -> u64 {
+    pub(super) async fn next(&self) -> u64 {
         if let Some(id) = self.try_next() {
             return id;
         }
         self.bag.clone().await
     }
 
-    pub fn release_id(&self, id: u64) {
+    pub(super) fn release_id(&self, id: u64) {
         let mut inner = self.bag.bag_inner.lock().unwrap();
         inner.ids.push(id);
         while let Some(w) = inner.wakers.pop() {

--- a/src/lib/twizzler-driver/src/request/inflight.rs
+++ b/src/lib/twizzler-driver/src/request/inflight.rs
@@ -93,7 +93,7 @@ impl<R> InFlightInner<R> {
 }
 
 #[derive(Debug)]
-pub struct InFlight<R> {
+pub(crate) struct InFlight<R> {
     len: usize,
     inner: Arc<Mutex<InFlightInner<R>>>,
 }
@@ -134,6 +134,8 @@ impl<R> InFlight<R> {
 }
 
 #[derive(Debug)]
+/// A future for a set of in-flight requests for which we are uninterested in any responses from the device,
+/// we only care if the responses were completed successfully or not. On await, returns a [SubmitSummary].
 pub struct InFlightFuture<R> {
     inflight: Arc<InFlight<R>>,
 }
@@ -168,6 +170,8 @@ impl<R> InFlightFutureWithResponses<R> {
 }
 
 #[derive(Debug)]
+/// A future for a set of in-flight requests for which we are interested in all responses from the device.
+/// On await, returns a [SubmitSummaryWithResponses].
 pub struct InFlightFutureWithResponses<R> {
     inflight: Arc<InFlight<R>>,
 }

--- a/src/lib/twizzler-driver/src/request/mod.rs
+++ b/src/lib/twizzler-driver/src/request/mod.rs
@@ -1,3 +1,24 @@
+//! A system for handling requests and organizing inflight requests while waiting for responses.
+//!
+//! The general structure of this system is that software implements the [RequestDriver] trait with
+//! some struct that we'll call "the request driver" or just "the driver". The driver is then
+//! wrapped by a [Requester], which internally manages the asynchrony of talking to devices.
+//!
+//! A user of the requester can call the [Requester::submit] or [Requester::submit_for_response]
+//! functions to submit a set a requests depending on if the caller wants the responses or just
+//! wants to know if the requests succeeded. The reason this distinction is maintained is that
+//! collecting responses has an overhead. The requester interacts with the driver to submit the requests.
+//!
+//! Internally, the requester assigns IDs to requests for use in communicating with the driver.
+//! These IDs are not necessarily allocated sequentially and can only be relied upon to be unique
+//! while a given request is inflight.
+//!
+//! Once a request is completed by the driver, the driver should send the response data and ID of
+//! the request that completed back to the requester with the [Requester::finish] function. The
+//! request manager will then collate the responses for matching with the requests and any errors
+//! are tracked. Once all requests in a submitted set have been completed, that set of requests is
+//! finished and awaiting on it will return a [SubmitSummary] or a [SubmitSummaryWithResponses].
+
 mod async_ids;
 mod inflight;
 mod requester;

--- a/src/lib/twizzler-driver/src/request/mod.rs
+++ b/src/lib/twizzler-driver/src/request/mod.rs
@@ -6,17 +6,31 @@ mod submit;
 mod summary;
 
 #[async_trait::async_trait]
+/// A trait implemented by a particular driver that can the be used by a [requester::Requester].
 pub trait RequestDriver {
+    /// The type of a request that will be used by the SubmitRequest wrapper to submit requests to
+    /// the driver.
     type Request: Copy + Send;
+    /// The type of a response to a request that we will use to send back to the Requester via the
+    /// [requester::Requester::finish] function.
     type Response: Copy + Send;
+    /// The type of a submit error in case submission fails.
     type SubmitError;
+    /// The actual submit function. The driver should perform whatever device-specific submission
+    /// procedure it needs to to submit all requests.
     async fn submit(&self, reqs: &[SubmitRequest<Self::Request>]) -> Result<(), Self::SubmitError>;
+    /// Manually flush any internal driver submission queue.
     fn flush(&self);
+    /// The number of IDs to have in-flight at a time.
     const NUM_IDS: usize;
 }
 
 // TODO: drop for inflight tracker, so we can remove it to save work?
 
+pub use inflight::InFlightFuture;
+pub use inflight::InFlightFutureWithResponses;
 pub use requester::Requester;
 pub use response_info::ResponseInfo;
 pub use submit::SubmitRequest;
+pub use summary::SubmitSummary;
+pub use summary::SubmitSummaryWithResponses;

--- a/src/lib/twizzler-driver/src/request/response_info.rs
+++ b/src/lib/twizzler-driver/src/request/response_info.rs
@@ -1,4 +1,5 @@
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+/// Information about a response from the driver. Sent by the driver back to the request manager.
 pub struct ResponseInfo<R> {
     resp: R,
     is_err: bool,
@@ -6,22 +7,27 @@ pub struct ResponseInfo<R> {
 }
 
 impl<R: Send> ResponseInfo<R> {
+    /// Construct a new ResponseInfo.
     pub fn new(resp: R, id: u64, is_err: bool) -> Self {
         Self { resp, is_err, id }
     }
 
+    /// Is this response an error?
     pub fn is_err(&self) -> bool {
         self.is_err
     }
 
+    /// Get a reference to the response data.
     pub fn data(&self) -> &R {
         &self.resp
     }
 
+    /// Convert this ResponseInfo into the inner response data.
     pub fn into_inner(self) -> R {
         self.resp
     }
 
+    /// Get the ID of the response (and thus the request with which it is paired).
     pub fn id(&self) -> u64 {
         self.id
     }

--- a/src/lib/twizzler-driver/src/request/submit.rs
+++ b/src/lib/twizzler-driver/src/request/submit.rs
@@ -1,25 +1,34 @@
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+/// Error that can arise from submitting a set of requests.
 pub enum SubmitError<E> {
+    /// Error from the driver.
     DriverError(E),
+    /// The request engine is shutdown.
     IsShutdown,
 }
 // TODO: impl Error
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
+/// A wrapper around a request that adds an ID alongside a request. The ID is automatically
+/// allocated internally by the request manager after the [SubmitRequest] is submitted.
 pub struct SubmitRequest<T> {
     id: u64,
     data: T,
 }
 
 impl<T> SubmitRequest<T> {
+    /// Construct a new [SubmitRequest].
     pub fn new(data: T) -> Self {
         Self { id: 0, data }
     }
 
+    /// Get a reference to the data.
     pub fn data(&self) -> &T {
         &self.data
     }
 
+    /// Get the ID of the request. Note that this number is only meaningful after the request has
+    /// been submitted.
     pub fn id(&self) -> u64 {
         self.id
     }

--- a/src/lib/twizzler-driver/src/request/summary.rs
+++ b/src/lib/twizzler-driver/src/request/summary.rs
@@ -1,7 +1,12 @@
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+/// A summary of the result of submitting a collection of requests to the request manager and having
+/// the device respond. Contains responses.
 pub enum SubmitSummaryWithResponses<R> {
+    /// A vector of responses in the same order as the submitted requests.
     Responses(Vec<R>),
+    /// At least one error occurred. The usize value is the index of the first error.
     Errors(usize),
+    /// The request engine was shutdown while the requests were inflight.
     Shutdown,
 }
 
@@ -14,9 +19,14 @@ pub(crate) enum AnySubmitSummary<R> {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+/// A summary of the result of submitting a collection of requests to the request manager and having
+/// the device respond. Does not contain responses.
 pub enum SubmitSummary {
+    /// All requests completed successfully.
     Done,
+    /// At least one error occurred. The usize value is the index of the first error.
     Errors(usize),
+    /// The request engine was shutdown while the requests were inflight.
     Shutdown,
 }
 


### PR DESCRIPTION
Adds API docs for twizzler-driver requests and events, and a few other things. Part of #83 .