### PR TITLE
Implement kernel compilation flag for xtask build and check

### DIFF
--- a/tools/xtask/src/image.rs
+++ b/tools/xtask/src/image.rs
@@ -19,6 +19,8 @@ fn get_crate_initrd_files(
 ) -> anyhow::Result<Vec<PathBuf>> {
     let unit = comp
         .borrow_user_compilation()
+        .as_ref()
+        .expect("user space not compiled")
         .binaries
         .iter()
         .find(|item| item.unit.pkg.name() == crate_name)

--- a/tools/xtask/src/main.rs
+++ b/tools/xtask/src/main.rs
@@ -56,6 +56,8 @@ struct BuildOptions {
     pub config: BuildConfig,
     #[clap(long, short, help = "Build tests-enabled system.")]
     tests: bool,
+    #[clap(long, short, help = "Only build kernel part of system.")]
+    kernel: bool,
 }
 
 #[derive(Args, Debug)]
@@ -84,6 +86,8 @@ struct CheckOptions {
     pub message_format: MessageFormat,
     #[clap(long, short)]
     pub workspace: bool,
+    #[clap(long, short, help = "Only build kernel part of system.")]
+    kernel: bool,
 }
 
 #[derive(Args, Debug, Clone, Copy)]
@@ -92,6 +96,8 @@ struct ImageOptions {
     pub config: BuildConfig,
     #[clap(long, short, help = "Build tests-enabled system.")]
     tests: bool,
+    #[clap(long, short, help = "Only build kernel part of system.")]
+    kernel: bool,
 }
 
 impl From<ImageOptions> for BuildOptions {
@@ -99,6 +105,7 @@ impl From<ImageOptions> for BuildOptions {
         Self {
             config: io.config,
             tests: io.tests,
+            kernel: io.kernel,
         }
     }
 }
@@ -122,6 +129,7 @@ impl From<&QemuOptions> for ImageOptions {
         Self {
             config: qo.config,
             tests: qo.tests,
+            kernel: false,
         }
     }
 }


### PR DESCRIPTION
Implements `-k`/`--kernel` flag for xtask `build` and `check`. This PR does not implement this flag for `start-qemu`. It should be possible to, for example, only compile the kernel and then start qemu, or only run kernel tests. However, this would require changing the initrd/disk image process.