### PR TITLE
Enhance kernel's test framework.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1761,9 +1761,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.15"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "864d3e96a899863136fc6e99f3d7cae289dafe43bf2c5ac19b70df7210c0a145"
+checksum = "8856d8364d252a14d474036ea1358d63c9e6965c8e5c1885c18f73d70bff9c7b"
 dependencies = [
  "proc-macro2",
 ]
@@ -2471,11 +2471,16 @@ dependencies = [
  "slabmalloc",
  "tar-no-std",
  "twizzler-abi",
+ "twizzler-kernel-macros",
  "uart_16550",
  "x86",
  "x86_64",
  "xmas-elf",
 ]
+
+[[package]]
+name = "twizzler-kernel-macros"
+version = "0.0.0"
 
 [[package]]
 name = "twizzler-nando"

--- a/doc/src/develop.md
+++ b/doc/src/develop.md
@@ -129,5 +129,5 @@ the `--tests` argument to your cargo run commands.
 
 When developing for Twizzler, you should write tests that cover code you wrote. This includes both
 userspace and kernelspace code. Note that writing tests for the kernel is slightly different, in
-that a test-case failing causes the whole system to stop, and you need to write `#[test_case]`
-instead of `#[test]`.
+that a test-case failing causes the whole system to stop, and you need to use the `#[kernel_test]`
+attribute from the `twizzler-kernel-macros` crate instead of `#[test]`.

--- a/src/kernel/Cargo.toml
+++ b/src/kernel/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+twizzler-kernel-macros = {version = "*", path = "macros"}
 bitflags = "1.3.2"
 uart_16550 = "0.2.0"
 x86 = "=0.51.0"

--- a/src/kernel/macros/Cargo.toml
+++ b/src/kernel/macros/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "twizzler-kernel-macros"
+version = "0.0.0"
+edition = "2021"
+
+[lib]
+proc-macro = true
+
+[dependencies]

--- a/src/kernel/macros/src/lib.rs
+++ b/src/kernel/macros/src/lib.rs
@@ -1,0 +1,45 @@
+#![feature(extend_one)]
+
+use proc_macro::TokenStream;
+use proc_macro::TokenTree;
+extern crate proc_macro;
+
+#[proc_macro_attribute]
+// Okay, look, I know what you're gonna say. Why do we need to get this complicated just to do tests.
+// The answer is names. See, our friends in the rust community have not fully implemented this issue:
+// https://github.com/rust-lang/rust/issues/50297. Until this is implemented, I don't know how to grab
+// name from a test function in a way that makes the test _runner_ know the names of the tests it's
+// running. So we just embed the name ourselves using #[test_case].
+pub fn kernel_test(_attr: TokenStream, items: TokenStream) -> TokenStream {
+    let mut out = TokenStream::new();
+    let mut it = items.into_iter();
+    let mut name = None;
+    // Extract the test name
+    loop {
+        let item = it.next();
+        if let Some(item) = item {
+            if matches!(item, TokenTree::Ident(ref ident) if ident.to_string() == "fn") {
+                out.extend_one(item);
+                let fname = it.next().unwrap();
+                name = Some(fname.to_string());
+                out.extend_one(fname);
+            } else {
+                out.extend_one(item);
+            }
+        } else {
+            break;
+        }
+    }
+    let name = name.unwrap_or("unknown".to_string());
+    // Write the test caller and the name into a test_case tuple
+    let mut code: TokenStream = format!(
+        "#[test_case] const __X__{}: (&'static str, &'static dyn Fn()) = (\"{}\", &|| {{ {}(); }});",
+        name.to_uppercase(),
+        name,
+        name
+    )
+    .parse()
+    .unwrap();
+    code.extend(out);
+    code
+}

--- a/src/kernel/src/main.rs
+++ b/src/kernel/src/main.rs
@@ -15,9 +15,6 @@
 #![feature(custom_test_frameworks)]
 #![reexport_test_harness_main = "test_main"]
 #![test_runner(crate::test_runner)]
-#![feature(let_chains)]
-#![feature(ptr_metadata)]
-#![feature(fn_traits)]
 
 #[macro_use]
 pub mod log;
@@ -131,12 +128,6 @@ pub fn test_runner(tests: &[&(&str, &dyn Fn())]) {
     }
 
     logln!("[kernel::test] test result: ok.");
-    loop {}
-}
-
-#[twizzler_kernel_macros::kernel_test]
-fn trivial_test() {
-    assert_eq!(0, 0);
 }
 
 pub fn init_threading() -> ! {

--- a/src/kernel/src/main.rs
+++ b/src/kernel/src/main.rs
@@ -15,6 +15,9 @@
 #![feature(custom_test_frameworks)]
 #![reexport_test_harness_main = "test_main"]
 #![test_runner(crate::test_runner)]
+#![feature(let_chains)]
+#![feature(ptr_metadata)]
+#![feature(fn_traits)]
 
 #[macro_use]
 pub mod log;
@@ -43,6 +46,7 @@ pub mod utils;
 extern crate alloc;
 
 extern crate bitflags;
+
 use core::sync::atomic::{AtomicBool, Ordering};
 
 use arch::BootInfoSystemTable;
@@ -118,13 +122,21 @@ fn kernel_main<B: BootInfo>(boot_info: &mut B) -> ! {
 }
 
 #[cfg(test)]
-pub fn test_runner(tests: &[&dyn Fn()]) {
+pub fn test_runner(tests: &[&(&str, &dyn Fn())]) {
     logln!("[kernel::test] running {} tests", tests.len());
     for test in tests {
-        test();
+        log!("test {} ... ", test.0);
+        (test.1)();
+        logln!("ok");
     }
 
     logln!("[kernel::test] test result: ok.");
+    loop {}
+}
+
+#[twizzler_kernel_macros::kernel_test]
+fn trivial_test() {
+    assert_eq!(0, 0);
 }
 
 pub fn init_threading() -> ! {

--- a/src/kernel/src/processor.rs
+++ b/src/kernel/src/processor.rs
@@ -461,12 +461,13 @@ mod test {
     use core::sync::atomic::{AtomicUsize, Ordering};
 
     use alloc::{boxed::Box, sync::Arc};
+    use twizzler_kernel_macros::kernel_test;
 
     use crate::interrupt::Destination;
 
     use super::ALL_PROCESSORS;
 
-    #[test_case]
+    #[kernel_test]
     fn ipi_test() {
         let nr_cpus = unsafe { &ALL_PROCESSORS }.iter().flatten().count();
         let counter = Arc::new(AtomicUsize::new(0));

--- a/tools/xtask/src/build.rs
+++ b/tools/xtask/src/build.rs
@@ -112,7 +112,18 @@ fn maybe_build_tests<'a>(
     if build_config.profile == Profile::Release {
         options.build_config.requested_profile = InternedString::new("release");
     }
-    options.spec = Packages::Packages(packages.iter().map(|p| p.name().to_string()).collect());
+    options.spec = Packages::Packages(
+        packages
+            .iter()
+            .filter_map(|p| {
+                if p.name() == "twizzler-kernel-macros" {
+                    None
+                } else {
+                    Some(p.name().to_string())
+                }
+            })
+            .collect(),
+    );
     options.build_config.force_rebuild = other_options.needs_full_rebuild;
     Ok(Some(cargo::ops::compile(workspace, &options)?))
 }


### PR DESCRIPTION
This patch enables the test runner to print the names of test functions in the kernel when running tests.

At time of writing, doing this either involves extremely cursed unsafe rust to figure out the function pointer address followed by a symbol lookup, or using a proc macro. Which is also arguably cursed, but it is at least all safe and stable rust.

Anyway, to annotate a function as a test function, use the kernel_test attribute from the twizzler-kernel-macros crate that is now compiled into the kernel.

This attribute adds static const item containing a function pointer that will run the test and the name of the test as given by the programmer.