### PR TITLE
New physical memory manager

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -371,7 +371,7 @@ checksum = "86447ad904c7fb335a790c9d7fe3d0d971dc523b8ccd1561a520de9a85302750"
 dependencies = [
  "atty",
  "bitflags",
- "clap_derive",
+ "clap_derive 3.2.18",
  "clap_lex 0.2.4",
  "indexmap",
  "once_cell",
@@ -387,8 +387,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7db700bc935f9e43e88d00b0850dae18a63773cfbec6d8e070fccf7fef89a39"
 dependencies = [
  "bitflags",
+ "clap_derive 4.0.21",
  "clap_lex 0.3.0",
  "is-terminal",
+ "once_cell",
  "strsim",
  "termcolor",
 ]
@@ -398,6 +400,19 @@ name = "clap_derive"
 version = "3.2.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea0c8bce528c4be4da13ea6fead8965e95b6073585a2f05204bd8f4119f82a65"
+dependencies = [
+ "heck 0.4.0",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0177313f9f02afc995627906bbd8967e2be069f5261954222dac78290c2b9014"
 dependencies = [
  "heck 0.4.0",
  "proc-macro-error",
@@ -1116,6 +1131,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "argh",
+ "clap 4.0.32",
  "fatfs",
  "gpt",
  "locate-cargo-manifest",
@@ -1167,6 +1183,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
 dependencies = [
  "cfg-if 1.0.0",
+]
+
+[[package]]
+name = "intrusive-collections"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f4f90afb01281fdeffb0f8e082d230cbe4f888f837cc90759696b858db1a700"
+dependencies = [
+ "memoffset 0.8.0",
 ]
 
 [[package]]
@@ -1384,6 +1409,15 @@ name = "memoffset"
 version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5aa361d4faea93603064a027415f07bd8e1d5c88c9fbf68bf56a285428fd79ce"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "memoffset"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d61c719bcfbcf5d62b3a09efa6088de8c54bc0bfcd3ea7ae39fcc186108b8de1"
 dependencies = [
  "autocfg",
 ]
@@ -2462,10 +2496,11 @@ dependencies = [
  "backtracer_core",
  "bitflags",
  "fixedbitset",
+ "intrusive-collections",
  "lazy_static",
  "limine",
  "linked_list_allocator",
- "memoffset",
+ "memoffset 0.6.5",
  "nonoverlapping_interval_tree",
  "object",
  "slabmalloc",

--- a/src/kernel/Cargo.toml
+++ b/src/kernel/Cargo.toml
@@ -18,6 +18,7 @@ object = {version = "0.29.0", default-features = false, features = ["read"]}
 addr2line = { version = "0.16.0", default-features = false, features = ["rustc-demangle"] }
 backtracer_core = {git = "https://github.com/twizzler-operating-system/backtracer", branch = "twizzler"}
 limine = "0.1.8"
+intrusive-collections = "0.9.5"
 
 [target.x86_64-unknown-none.dependencies]
 uart_16550 = "0.2.0"

--- a/src/kernel/src/arch/amd64/memory.rs
+++ b/src/kernel/src/arch/amd64/memory.rs
@@ -4,6 +4,8 @@ use twizzler_abi::device::CacheType;
 use x86_64::{structures::paging::PageTable};
 use crate::memory::{VirtAddr, PhysAddr};
 
+pub mod frame;
+
 fn translate_addr_inner(addr: VirtAddr, phys_mem_offset: VirtAddr) -> Option<PhysAddr> {
     use x86_64::registers::control::Cr3;
     use x86_64::structures::paging::page_table::FrameError;

--- a/src/kernel/src/arch/amd64/memory/frame.rs
+++ b/src/kernel/src/arch/amd64/memory/frame.rs
@@ -1,0 +1,1 @@
+pub const FRAME_SIZE: usize = 0x1000;

--- a/src/kernel/src/main.rs
+++ b/src/kernel/src/main.rs
@@ -15,6 +15,7 @@
 #![feature(custom_test_frameworks)]
 #![reexport_test_harness_main = "test_main"]
 #![test_runner(crate::test_runner)]
+#![feature(stmt_expr_attributes)]
 
 #[macro_use]
 pub mod log;

--- a/src/kernel/src/memory/frame.rs
+++ b/src/kernel/src/memory/frame.rs
@@ -24,6 +24,13 @@
 //! needs to be able to access frame data from possibly any CPU, so the whole type must be both Sync
 //! and Send. This would be easy with the lock-around-inner trick, but this plays badly with the
 //! intrusive list, and so we do some cursed manual locking to ensure write isolation.
+//!
+//! Note: This code uses intrusive linked lists (a type of intrusive data structure). These are standard
+//! practice in C kernels, but are rarely needed these days. An intrusive list is a list that stores the
+//! list's link data inside the nodes (`struct Foo {link: Link, ...}`) as opposed to storing the objects in
+//! the list (`struct ListItem<T> {item: T, link: Link}`). They are useful here because they can form
+//! arbitrary containers while ensuring no memory is allocated to store the list, something that is very
+//! important inside an allocator for physical pages. For more information, see: [https://docs.rs/intrusive-collections/latest/intrusive_collections/].
 
 use core::{
     intrinsics::size_of,

--- a/src/kernel/src/memory/frame.rs
+++ b/src/kernel/src/memory/frame.rs
@@ -560,4 +560,11 @@ mod tests {
         let test_frame = get_frame(addr).unwrap();
         assert!(core::ptr::eq(frame as *const _, test_frame as *const _));
     }
+
+    #[kernel_test]
+    fn stress_test_pmm() {
+        for _ in 0..100000 {
+            let x = quick_random();
+        }
+    }
 }

--- a/src/kernel/src/obj/pages.rs
+++ b/src/kernel/src/obj/pages.rs
@@ -4,7 +4,7 @@ use alloc::sync::Arc;
 use twizzler_abi::device::{CacheType, MMIO_OFFSET};
 
 use crate::{
-    arch::memory::phys_to_virt,
+    arch::memory::{frame::FRAME_SIZE, phys_to_virt},
     memory::frame::{self, FrameRef, PhysicalFrameFlags},
     memory::{
         frame::{self, Frame, PhysicalFrameFlags},
@@ -75,7 +75,7 @@ impl Page {
     pub fn as_mut_slice(&self) -> &mut [u8] {
         let len = match self.frame {
             FrameOrWired::Frame(f) => f.size(),
-            FrameOrWired::Wired(_) => 0x1000, // TODO: arch-dep
+            FrameOrWired::Wired(_) => FRAME_SIZE,
         };
         unsafe { core::slice::from_raw_parts_mut(self.as_virtaddr().as_mut_ptr(), len) }
     }

--- a/src/kernel/src/obj/pages.rs
+++ b/src/kernel/src/obj/pages.rs
@@ -14,6 +14,8 @@ use crate::{
 
 use super::{Object, PageNumber};
 
+/// An object page can be either a physical frame (allocatable memory) or a static physical address (wired). This will likely be
+/// overhauled soon.
 #[derive(Debug)]
 enum FrameOrWired {
     Frame(FrameRef),

--- a/src/kernel/src/obj/pages.rs
+++ b/src/kernel/src/obj/pages.rs
@@ -7,7 +7,6 @@ use crate::{
     arch::memory::{frame::FRAME_SIZE, phys_to_virt},
     memory::frame::{self, FrameRef, PhysicalFrameFlags},
     memory::{
-        frame::{self, Frame, PhysicalFrameFlags},
         PhysAddr, VirtAddr,
     },
 };

--- a/src/kernel/src/obj/pages.rs
+++ b/src/kernel/src/obj/pages.rs
@@ -57,7 +57,7 @@ impl Page {
     pub fn as_slice(&self) -> &[u8] {
         let len = match self.frame {
             FrameOrWired::Frame(f) => f.size(),
-            FrameOrWired::Wired(_) => 0x1000, // TODO: arch-dep
+            FrameOrWired::Wired(_) => FRAME_SIZE,
         };
         unsafe { core::slice::from_raw_parts(self.as_virtaddr().as_ptr(), len) }
     }
@@ -145,7 +145,7 @@ impl Object {
     }
 
     pub fn write_base<T>(&self, info: &T) {
-        let mut offset = 0x1000; //TODO: arch-dep
+        let mut offset = FRAME_SIZE;
         unsafe {
             let mut obj_page_tree = self.lock_page_tree();
             let bytes = info as *const T as *const u8;

--- a/src/kernel/src/sched.rs
+++ b/src/kernel/src/sched.rs
@@ -10,6 +10,7 @@ use crate::{
     processor::{current_processor, get_processor, Processor},
     spinlock::Spinlock,
     thread::{current_thread_ref, set_current_thread, Priority, Thread, ThreadRef, ThreadState},
+    utils::quick_random,
 };
 
 #[derive(Clone, Debug, Copy)]
@@ -87,21 +88,6 @@ pub fn set_cpu_topology(root: CPUTopoNode) {
 
 pub fn get_cpu_topology() -> &'static CPUTopoNode {
     CPU_TOPOLOGY_ROOT.poll().unwrap()
-}
-
-#[thread_local]
-static mut RAND_STATE: u32 = 0;
-
-fn quick_random() -> u32 {
-    let mut state = unsafe { RAND_STATE };
-    if state == 0 {
-        state = current_processor().id;
-    }
-    let newstate = state.wrapping_mul(69069).wrapping_add(5);
-    unsafe {
-        RAND_STATE = newstate;
-    }
-    newstate >> 16
 }
 
 struct SearchCPUResult {

--- a/src/kernel/src/utils.rs
+++ b/src/kernel/src/utils.rs
@@ -12,6 +12,13 @@ pub fn align<T: From<usize> + Into<usize>>(val: T, align: usize) -> T {
     res.into()
 }
 
+/// Lock two mutexes in a stable order such that no deadlock cycles are created.
+///
+/// This is VITAL if you want to lock multiple mutexes for objects where you cannot
+/// statically ensure ordering to avoid deadlock. It ensures that any two given mutexes
+/// will be locked in the same order even if you permute the arguments to this function.
+/// It does so by inspecting the addresses of the mutexes themselves to project a total
+/// order onto the locks.
 pub fn lock_two<'a, 'b, A, B>(
     a: &'a Mutex<A>,
     b: &'b Mutex<B>,
@@ -29,7 +36,13 @@ pub fn lock_two<'a, 'b, A, B>(
         (lg_a, lg_b)
     }
 }
-
+/// Lock two spinlocks in a stable order such that no deadlock cycles are created.
+///
+/// This is VITAL if you want to lock multiple mutexes for objects where you cannot
+/// statically ensure ordering to avoid deadlock. It ensures that any two given spinlocks
+/// will be locked in the same order even if you permute the arguments to this function.
+/// It does so by inspecting the addresses of the spinlocks themselves to project a total
+/// order onto the locks.
 pub fn spinlock_two<'a, 'b, A, B, R: RelaxStrategy>(
     a: &'a GenericSpinlock<A, R>,
     b: &'b GenericSpinlock<B, R>,

--- a/src/kernel/src/utils.rs
+++ b/src/kernel/src/utils.rs
@@ -1,4 +1,7 @@
-use crate::mutex::{LockGuard, Mutex};
+use crate::{
+    mutex::{LockGuard, Mutex},
+    spinlock::{self, GenericSpinlock, RelaxStrategy},
+};
 
 pub fn align<T: From<usize> + Into<usize>>(val: T, align: usize) -> T {
     let val = val.into();
@@ -15,6 +18,24 @@ pub fn lock_two<'a, 'b, A, B>(
 ) -> (LockGuard<'a, A>, LockGuard<'b, B>) {
     let a_val = a as *const Mutex<A> as usize;
     let b_val = b as *const Mutex<B> as usize;
+    assert_ne!(a_val, b_val);
+    if a_val > b_val {
+        let lg_b = b.lock();
+        let lg_a = a.lock();
+        (lg_a, lg_b)
+    } else {
+        let lg_a = a.lock();
+        let lg_b = b.lock();
+        (lg_a, lg_b)
+    }
+}
+
+pub fn spinlock_two<'a, 'b, A, B, R: RelaxStrategy>(
+    a: &'a GenericSpinlock<A, R>,
+    b: &'b GenericSpinlock<B, R>,
+) -> (spinlock::LockGuard<'a, A, R>, spinlock::LockGuard<'b, B, R>) {
+    let a_val = a as *const GenericSpinlock<A, R> as usize;
+    let b_val = b as *const GenericSpinlock<B, R> as usize;
     assert_ne!(a_val, b_val);
     if a_val > b_val {
         let lg_b = b.lock();

--- a/src/kernel/src/utils.rs
+++ b/src/kernel/src/utils.rs
@@ -1,5 +1,6 @@
 use crate::{
     mutex::{LockGuard, Mutex},
+    processor::current_processor,
     spinlock::{self, GenericSpinlock, RelaxStrategy},
 };
 
@@ -59,4 +60,20 @@ pub fn spinlock_two<'a, 'b, A, B, R: RelaxStrategy>(
         let lg_b = b.lock();
         (lg_a, lg_b)
     }
+}
+
+#[thread_local]
+static mut RAND_STATE: u32 = 0;
+
+/// A quick, but poor, NON CRYPTOGRAPHIC random number generator.
+pub fn quick_random() -> u32 {
+    let mut state = unsafe { RAND_STATE };
+    if state == 0 {
+        state = current_processor().id;
+    }
+    let newstate = state.wrapping_mul(69069).wrapping_add(5);
+    unsafe {
+        RAND_STATE = newstate;
+    }
+    newstate >> 16
 }


### PR DESCRIPTION
This patch replaces the old physical memory manager with a new one that has a couple new features:

1. we can easily access per-frame metadata given just the address
2. uses an intrusive linked list for management (will be useful during the pagetable code refresh)
