### PR TITLE
Improve toolchain build times.

### DIFF
--- a/toolchain/src/config.toml
+++ b/toolchain/src/config.toml
@@ -10,6 +10,7 @@ sysconfdir = "etc"
 #download-ci-llvm = true
 skip-rebuild = false
 targets = "AArch64;X86"
+experimental-targets = ""
 
 [build]
 tools = ["clippy", "rustfmt", "src"] # + "rust-demangler" if `profiler`

--- a/toolchain/src/config.toml
+++ b/toolchain/src/config.toml
@@ -9,6 +9,7 @@ sysconfdir = "etc"
 [llvm]
 #download-ci-llvm = true
 skip-rebuild = false
+targets = "AArch64;X86"
 
 [build]
 tools = ["clippy", "rustfmt", "src"] # + "rust-demangler" if `profiler`

--- a/toolchain/src/config.toml
+++ b/toolchain/src/config.toml
@@ -1,5 +1,3 @@
-# Includes one of the default files in src/bootstrap/defaults
-profile = "user"
 changelog-seen = 2
 
 [install]
@@ -7,13 +5,15 @@ prefix = "../../install"
 sysconfdir = "etc"
 
 [llvm]
-#download-ci-llvm = true
+download-ci-llvm = false
 skip-rebuild = false
 targets = "AArch64;X86"
 experimental-targets = ""
 
 [build]
-tools = ["clippy", "rustfmt", "src"] # + "rust-demangler" if `profiler`
+build-stage = 2
+test-stage = 2
+doc-stage = 2
 docs = false
 target = ["x86_64-unknown-twizzler", "x86_64-unknown-linux-gnu"]
 submodules = false

--- a/tools/xtask/src/toolchain.rs
+++ b/tools/xtask/src/toolchain.rs
@@ -169,7 +169,7 @@ pub(crate) fn do_bootstrap(cli: BootstrapOptions) -> anyhow::Result<()> {
         "toolchain/src/rust/library/",
         &CopyOptions::new(),
     )?;
-
+    
     let status = Command::new("./x.py")
         .arg("install")
         .current_dir("toolchain/src/rust")
@@ -178,7 +178,17 @@ pub(crate) fn do_bootstrap(cli: BootstrapOptions) -> anyhow::Result<()> {
         anyhow::bail!("failed to compile rust toolchain");
     }
 
-    for target in &crate::triple::all_possible_platforms() {
+    let src_status = Command::new("./x.py")
+        .arg("install")
+        .arg("src")
+        .current_dir("toolchain/src/rust")
+        .status()?;
+    if !src_status.success() {
+        anyhow::bail!("failed to install rust source");
+    }
+
+
+       for target in &crate::triple::all_possible_platforms() {
         build_crtx("crti", target)?;
         build_crtx("crtn", target)?;
     }

--- a/tools/xtask/src/toolchain.rs
+++ b/tools/xtask/src/toolchain.rs
@@ -137,6 +137,7 @@ pub(crate) fn do_bootstrap(cli: BootstrapOptions) -> anyhow::Result<()> {
             .arg("update")
             .arg("--init")
             .arg("--recursive")
+            .arg("--depth=1")
             .status()?;
         if !status.success() {
             anyhow::bail!("failed to update git submodules");
@@ -169,7 +170,7 @@ pub(crate) fn do_bootstrap(cli: BootstrapOptions) -> anyhow::Result<()> {
         "toolchain/src/rust/library/",
         &CopyOptions::new(),
     )?;
-    
+
     let status = Command::new("./x.py")
         .arg("install")
         .current_dir("toolchain/src/rust")
@@ -187,8 +188,7 @@ pub(crate) fn do_bootstrap(cli: BootstrapOptions) -> anyhow::Result<()> {
         anyhow::bail!("failed to install rust source");
     }
 
-
-       for target in &crate::triple::all_possible_platforms() {
+    for target in &crate::triple::all_possible_platforms() {
         build_crtx("crti", target)?;
         build_crtx("crtn", target)?;
     }


### PR DESCRIPTION
Building Twizzler requires [compiling all of LLVM and Rust.](https://github.com/twizzler-operating-system/twizzler/blob/main/doc/src/BUILD.md#step-1-building-the-toolchain). We have to do this since we need to teach Rust/LLVM about Twizzler, and provide standard library support. After looking at [config.toml](https://github.com/rust-lang/rust/blob/master/config.toml.example) I realized we can do a lot better.

The biggest improvement was only having LLVM not compile support for unnecessary targets. This resulted in ~25% improvement in from-scratch builds (`cargo bootstrap`) and ~66% improvement for rebuilds (`cargo bootstrap --skip-submodules`) on my machine.

We could get some other improvements, but I want people to weigh in on this:
- The profile chosen is [user](https://github.com/rust-lang/rust/blob/master/src/bootstrap/defaults/config.user.toml), but this makes us [compile all of the tools](https://github.com/rust-lang/rust/blob/9a7cc6c32f1a690f86827e4724bcda85e506ef35/config.toml.example#L291-L308). For some reason it ignores what we put in `config.toml`. We can have it only do the minimum. I tested this and saw further improvement.
- Incremental builds. This build only help rebuild performance. It does however [use more disk space.](https://rustc-dev-guide.rust-lang.org/building/suggested.html#using-incremental-compilation)

That's all I found so far. Improving CI builds is a whole other topic :)