### PR TITLE
Make xtask use openssl source

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -262,6 +262,7 @@ dependencies = [
  "log",
  "memchr",
  "opener",
+ "openssl",
  "os_info",
  "pathdiff",
  "percent-encoding",
@@ -1612,6 +1613,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
+name = "openssl-src"
+version = "111.25.0+1.1.1t"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3173cd3626c43e3854b1b727422a276e568d9ec5fe8cec197822cf52cfb743d6"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "openssl-sys"
 version = "0.9.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1620,6 +1630,7 @@ dependencies = [
  "autocfg",
  "cc",
  "libc",
+ "openssl-src",
  "pkg-config",
  "vcpkg",
 ]

--- a/tools/xtask/Cargo.toml
+++ b/tools/xtask/Cargo.toml
@@ -11,7 +11,7 @@ walkdir = "2.3.2"
 strum = "0.24.0"
 anyhow = "1.0.56"
 strum_macros = "0.24.0"
-cargo = { version = "0.67.0"}
+cargo = { version = "0.67.0", features = ["vendored-openssl"] }
 ouroboros = "0.15.5"
 reqwest = { version = "0.11.10", features = ["stream"] }
 futures-util = "0.3.21"


### PR DESCRIPTION
This "fixes" #109 and makes it so that xtask compiles with openssl source. Although, a deeper investigation is need as to why we can compile xtask/cargo on some machines, but not others.