### PR TITLE
Implement conditional compilation for machine dependent code

### DIFF
--- a/src/kernel/src/arch/aarch64/address.rs
+++ b/src/kernel/src/arch/aarch64/address.rs
@@ -1,119 +1,293 @@
-use core::ops::{Add, AddAssign, Sub};
+use core::{fmt::LowerHex, ops::Sub};
 
-#[derive(Clone, Copy, Debug)]
-pub struct PhysAddr;
+use crate::once::Once;
 
-impl PhysAddr {
-    pub fn new(_address: u64) -> Self {
-        todo!()
-    }
+use super::memory::phys_to_virt;
 
-    pub fn as_u64(self) -> u64 {
-        todo!()
-    }
+/// A representation of a canonical virtual address.
+#[derive(Clone, Copy, PartialEq, PartialOrd, Ord, Eq)]
+#[repr(transparent)]
+pub struct VirtAddr(u64);
 
-    pub fn align_up<U>(self, _alignment: U) -> Self
-    where
-        U: Into<u64>
-    {
-        todo!()
-    }
+/// A representation of a valid physical address.
+#[derive(Clone, Copy, PartialEq, PartialOrd, Ord, Eq)]
+#[repr(transparent)]
+pub struct PhysAddr(u64);
 
-    pub fn align_down<U>(self, _alignment: U) -> Self
-    where
-        U: Into<u64>
-    {
-        todo!()
-    }
-}
-
-#[derive(Clone, Copy, Debug)]
-pub struct VirtAddr;
+#[derive(Debug, Clone, Copy)]
+pub struct NonCanonical;
 
 impl VirtAddr {
-    pub fn new(_address: u64) -> Self {
+    /// The start of the kernel memory heap.
+    pub const HEAP_START: Self = Self(0xffffff0000000000);
+
+    pub const fn start_kernel_memory() -> Self {
         todo!()
     }
 
-    pub fn as_u64(self) -> u64 {
+    pub const fn start_user_memory() -> Self {
         todo!()
     }
 
-    pub fn from_ptr<T>(_ptr: *const T) -> Self {
+    pub const fn end_user_memory() -> Self {
         todo!()
     }
 
-    pub fn as_ptr<T>(self) -> *const T {
-        todo!()
-    } 
-
-    pub fn as_mut_ptr<T>(self) -> *mut T {
+    /// Construct a new virtual address from the provided addr value, only if the provided value is a valid, canonical
+    /// address. If not, returns Err.
+    pub const fn new(_addr: u64) -> Result<Self, NonCanonical> {
         todo!()
     }
 
-    pub fn align_up<U>(self, _alignment: U) -> Self
-    where
-        U: Into<u64>
-    {
+    /// Construct a new virtual address from a u64 without verifying that it is a valid virtual address.
+    ///
+    /// # Safety
+    /// The provided address must be canonical.
+    pub const unsafe fn new_unchecked(addr: u64) -> Self {
+        Self(addr)
+    }
+
+    pub fn as_mut_ptr<T>(&self) -> *mut T {
+        self.0 as *mut T
+    }
+
+    pub fn as_ptr<T>(&self) -> *const T {
+        self.0 as *const T
+    }
+
+    pub fn is_aligned_to(&self, alignment: usize) -> bool {
+        self.0 % alignment as u64 == 0
+    }
+
+    pub fn is_kernel(&self) -> bool {
         todo!()
     }
 
-    pub fn align_down<U>(self, _alignment: U) -> Self
-    where
-        U: Into<u64>
-    {
-        todo!()
+    pub fn offset<U: Into<Offset>>(&self, offset: U) -> Result<Self, NonCanonical> {
+        let offset = offset.into();
+        match offset {
+            Offset::Usize(u) => Self::new(self.0.checked_add(u as u64).ok_or(NonCanonical)?),
+            Offset::Isize(u) => {
+                let abs = u.abs();
+                if u < 0 {
+                    Self::new(self.0.checked_sub(abs as u64).ok_or(NonCanonical)?)
+                } else {
+                    Self::new(self.0.checked_add(abs as u64).ok_or(NonCanonical)?)
+                }
+            }
+        }
+    }
+
+    pub fn raw(&self) -> u64 {
+        self.0
+    }
+
+    pub fn from_ptr<T>(ptr: *const T) -> Self {
+        Self(ptr as u64)
+    }
+
+    pub fn align_down<U: Into<u64>>(&self, align: U) -> Result<Self, NonCanonical> {
+        let align = align.into();
+        assert!(align.is_power_of_two(), "`align` must be a power of two");
+        Self::new(self.raw() & !(align - 1))
+    }
+
+    pub fn align_up<U: Into<u64>>(&self, align: U) -> Result<Self, NonCanonical> {
+        let align = align.into();
+        assert!(align.is_power_of_two(), "`align` must be a power of two");
+        let mask = align - 1;
+        if self.raw() & mask == 0 {
+            Ok(*self)
+        } else if let Some(aligned) = (self.raw() | mask).checked_add(1) {
+            Self::new(aligned)
+        } else {
+            Err(NonCanonical)
+        }
     }
 }
 
-impl Add<usize> for PhysAddr {
-    type Output = Self;
-
-    fn add(self, rhs: usize) -> Self::Output {
-        PhysAddr::new(self.as_u64().checked_add(rhs as u64).unwrap())
+impl<T> From<*mut T> for VirtAddr {
+    fn from(x: *mut T) -> Self {
+        Self(x as usize as u64)
     }
 }
 
-impl Add<u64> for PhysAddr {
-    type Output = Self;
+impl<T> From<*const T> for VirtAddr {
+    fn from(x: *const T) -> Self {
+        Self(x as usize as u64)
+    }
+}
 
-    fn add(self, rhs: u64) -> Self::Output {
-        PhysAddr::new(self.as_u64().checked_add(rhs).unwrap())
+impl TryFrom<u64> for VirtAddr {
+    type Error = NonCanonical;
+
+    fn try_from(addr: u64) -> Result<Self, Self::Error> {
+        Self::new(addr)
+    }
+}
+
+impl TryFrom<usize> for VirtAddr {
+    type Error = NonCanonical;
+
+    fn try_from(addr: usize) -> Result<Self, Self::Error> {
+        Self::new(addr as u64)
+    }
+}
+
+impl From<VirtAddr> for u64 {
+    fn from(addr: VirtAddr) -> Self {
+        addr.0
+    }
+}
+
+impl From<VirtAddr> for usize {
+    fn from(addr: VirtAddr) -> Self {
+        addr.0 as usize
+    }
+}
+
+static PHYS_ADDR_WIDTH: Once<u64> = Once::new();
+impl PhysAddr {
+    fn get_phys_addr_width() -> u64 {
+        *PHYS_ADDR_WIDTH.call_once(|| {
+            todo!()
+        })
+    }
+
+    pub fn new(_addr: u64) -> Result<Self, NonCanonical> {
+        todo!()
+    }
+
+    /// Construct a new physical address from a u64 without verifying that it is a valid physical address.
+    ///
+    /// # Safety
+    /// The provided address must be a valid address.
+    pub unsafe fn new_unchecked(addr: u64) -> Self {
+        Self(addr)
+    }
+
+    pub fn kernel_vaddr(&self) -> VirtAddr {
+        phys_to_virt(*self)
+    }
+
+    pub fn offset<U: Into<Offset>>(&self, offset: U) -> Result<Self, NonCanonical> {
+        let offset = offset.into();
+        match offset {
+            Offset::Usize(u) => Self::new(self.0.checked_add(u as u64).ok_or(NonCanonical)?),
+            Offset::Isize(u) => {
+                let abs = u.abs();
+                if u < 0 {
+                    Self::new(self.0.checked_sub(abs as u64).ok_or(NonCanonical)?)
+                } else {
+                    Self::new(self.0.checked_add(abs as u64).ok_or(NonCanonical)?)
+                }
+            }
+        }
+    }
+
+    pub fn is_aligned_to(&self, alignment: usize) -> bool {
+        self.0 % alignment as u64 == 0
+    }
+
+    pub fn raw(&self) -> u64 {
+        self.0
+    }
+
+    pub fn align_down<U: Into<u64>>(&self, align: U) -> Result<Self, NonCanonical> {
+        let align = align.into();
+        assert!(align.is_power_of_two(), "`align` must be a power of two");
+        Self::new(self.raw() & !(align - 1))
+    }
+
+    pub fn align_up<U: Into<u64>>(&self, align: U) -> Result<Self, NonCanonical> {
+        let align = align.into();
+        assert!(align.is_power_of_two(), "`align` must be a power of two");
+        let mask = align - 1;
+        if self.raw() & mask == 0 {
+            Ok(*self)
+        } else if let Some(aligned) = (self.raw() | mask).checked_add(1) {
+            Self::new(aligned)
+        } else {
+            panic!("added with overflow")
+        }
+    }
+}
+
+impl TryFrom<u64> for PhysAddr {
+    type Error = NonCanonical;
+
+    fn try_from(addr: u64) -> Result<Self, Self::Error> {
+        Self::new(addr)
+    }
+}
+
+impl TryFrom<usize> for PhysAddr {
+    type Error = NonCanonical;
+
+    fn try_from(addr: usize) -> Result<Self, Self::Error> {
+        Self::new(addr as u64)
+    }
+}
+
+impl From<PhysAddr> for u64 {
+    fn from(addr: PhysAddr) -> Self {
+        addr.0
+    }
+}
+
+impl From<PhysAddr> for usize {
+    fn from(addr: PhysAddr) -> Self {
+        addr.0 as usize
+    }
+}
+
+pub enum Offset {
+    Usize(usize),
+    Isize(isize),
+}
+
+impl From<isize> for Offset {
+    fn from(x: isize) -> Self {
+        Self::Isize(x)
+    }
+}
+
+impl From<usize> for Offset {
+    fn from(x: usize) -> Self {
+        Self::Usize(x)
     }
 }
 
 impl Sub<PhysAddr> for PhysAddr {
-    type Output = u64;
+    type Output = usize;
 
-    fn sub(self, rhs: Self) -> Self::Output {
-        self.as_u64().checked_sub(rhs.as_u64()).unwrap()
+    fn sub(self, rhs: PhysAddr) -> Self::Output {
+        (self.0.checked_sub(rhs.0).unwrap()) as usize
     }
 }
 
-impl core::fmt::LowerHex for PhysAddr {
-    fn fmt(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
-        core::fmt::LowerHex::fmt(&self.as_u64(), f)
+impl Sub<VirtAddr> for VirtAddr {
+    type Output = usize;
+
+    fn sub(self, rhs: VirtAddr) -> Self::Output {
+        (self.0.checked_sub(rhs.0).unwrap()) as usize
     }
 }
 
-impl Add<usize> for VirtAddr {
-    type Output = Self;
-
-    fn add(self, rhs: usize) -> Self::Output {
-        VirtAddr::new(self.as_u64().checked_add(rhs as u64).unwrap())
+impl LowerHex for PhysAddr {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        LowerHex::fmt(&self.0, f)
     }
 }
 
-impl Add<u64> for VirtAddr {
-    type Output = Self;
-
-    fn add(self, rhs: u64) -> Self::Output {
-        VirtAddr::new(self.as_u64().checked_add(rhs).unwrap())
+impl core::fmt::Debug for VirtAddr {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "V(0x{:x})", self.0)
     }
 }
 
-impl AddAssign<usize> for VirtAddr {
-    fn add_assign(&mut self, rhs: usize) {
-        *self = *self + rhs
+impl core::fmt::Debug for PhysAddr {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(f, "PHYS(0x{:x})", self.0)
     }
 }

--- a/src/kernel/src/arch/aarch64/context.rs
+++ b/src/kernel/src/arch/aarch64/context.rs
@@ -1,0 +1,126 @@
+use crate::{
+    // arch::memory::pagetables::{Entry, EntryFlags},
+    memory::{
+        frame::{alloc_frame, PhysicalFrameFlags},
+        pagetables::{
+            DeferredUnmappingOps, MapReader, Mapper, MappingCursor, MappingSettings,
+            PhysAddrProvider,
+        },
+    },
+    mutex::Mutex,
+    spinlock::Spinlock,
+};
+
+pub struct ArchContextInner {
+    mapper: Mapper,
+}
+
+pub struct ArchContext {
+    target: u64,
+    inner: Mutex<ArchContextInner>,
+}
+
+lazy_static::lazy_static! {
+    static ref KERNEL_MAPPER: Spinlock<Mapper> = {
+        let m = Mapper::new(alloc_frame(PhysicalFrameFlags::ZEROED).start_address());
+        // TODO ?
+        // for idx in 256..512 {
+        //     m.set_top_level_table(idx, Entry::new(alloc_frame(PhysicalFrameFlags::ZEROED).start_address(), EntryFlags::intermediate()));
+        // }
+        Spinlock::new(m)
+    };
+}
+
+impl Default for ArchContext {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ArchContext {
+    pub fn new_kernel() -> Self {
+        Self::new()
+    }
+
+    pub fn new() -> Self {
+        let inner = ArchContextInner::new();
+        let target = inner.mapper.root_address().into();
+        Self {
+            target,
+            inner: Mutex::new(inner),
+        }
+    }
+
+    #[allow(named_asm_labels)]
+    pub fn switch_to(&self) {
+        todo!()
+    }
+
+    pub fn map(
+        &self,
+        cursor: MappingCursor,
+        phys: &mut impl PhysAddrProvider,
+        settings: &MappingSettings,
+    ) {
+        if cursor.start().is_kernel() {
+            KERNEL_MAPPER.lock().map(cursor, phys, settings);
+        } else {
+            self.inner.lock().map(cursor, phys, settings);
+        }
+    }
+
+    pub fn change(&self, cursor: MappingCursor, settings: &MappingSettings) {
+        if cursor.start().is_kernel() {
+            KERNEL_MAPPER.lock().change(cursor, settings);
+        } else {
+            self.inner.lock().change(cursor, settings);
+        }
+    }
+
+    pub fn unmap(&self, cursor: MappingCursor) {
+        let ops = if cursor.start().is_kernel() {
+            KERNEL_MAPPER.lock().unmap(cursor)
+        } else {
+            self.inner.lock().unmap(cursor)
+        };
+        ops.run_all();
+    }
+
+    pub fn readmap<R>(&self, cursor: MappingCursor, f: impl Fn(MapReader) -> R) -> R {
+        let r = if cursor.start().is_kernel() {
+            f(KERNEL_MAPPER.lock().readmap(cursor))
+        } else {
+            f(self.inner.lock().mapper.readmap(cursor))
+        };
+        r
+    }
+}
+
+impl ArchContextInner {
+    fn new() -> Self {
+        let mapper = Mapper::new(alloc_frame(PhysicalFrameFlags::ZEROED).start_address());
+        // let km = KERNEL_MAPPER.lock();
+        // TODO ?
+        // for idx in 256..512 {
+        //     mapper.set_top_level_table(idx, km.get_top_level_table(idx));
+        // }
+        Self { mapper }
+    }
+
+    fn map(
+        &mut self,
+        cursor: MappingCursor,
+        phys: &mut impl PhysAddrProvider,
+        settings: &MappingSettings,
+    ) {
+        self.mapper.map(cursor, phys, settings);
+    }
+
+    fn change(&mut self, cursor: MappingCursor, settings: &MappingSettings) {
+        self.mapper.change(cursor, settings);
+    }
+
+    fn unmap(&mut self, cursor: MappingCursor) -> DeferredUnmappingOps {
+        self.mapper.unmap(cursor)
+    }
+}

--- a/src/kernel/src/arch/aarch64/memory.rs
+++ b/src/kernel/src/arch/aarch64/memory.rs
@@ -1,106 +1,15 @@
-use twizzler_abi::device::CacheType;
 
-use crate::memory::context::MapFlags;
-use crate::memory::{VirtAddr, PhysAddr, MapFailed, MappingInfo};
+use super::address::{PhysAddr, VirtAddr};
 
+pub mod frame;
+pub mod pagetables;
+
+// TODO:
 // start offset into physical memory
 const PHYS_MEM_OFFSET: u64 = 0x0;
 
 /* TODO: hide this */
-pub fn phys_to_virt(_pa: PhysAddr) -> VirtAddr {
-    todo!()
-}
-
-#[derive(Clone, Copy, Debug)]
-#[repr(transparent)]
-pub struct Table {
-    frame: PhysAddr,
-}
-
-impl From<PhysAddr> for Table {
-    fn from(frame: PhysAddr) -> Self {
-        Self { frame }
-    }
-}
-pub struct ArchMemoryContext {
-    table_root: Table,
-}
-
-pub struct ArchMemoryContextSwitchInfo {
-    target: u64,
-}
-
-// arch specific page sizes supported
-const PAGE_SIZE_HUGE: usize = 1024 * 1024 * 1024;
-const PAGE_SIZE_LARGE: usize = 2 * 1024 * 1024;
-const PAGE_SIZE: usize = 0x1000;
-
-impl ArchMemoryContext {
-    pub fn new_blank() -> Self {
-        todo!()
-    }
-
-    pub fn root(&self) -> PhysAddr {
-        self.table_root.frame
-    }
-
-    pub fn get_switch_info(&self) -> ArchMemoryContextSwitchInfo {
-        todo!()
-    }
-
-    pub fn clone_empty_user(&self) -> Self {
-        todo!()
-    }
-
-    pub fn from_existing_tables(_table_root: PhysAddr) -> Self {
-        todo!()
-    }
-
-    pub fn current_tables() -> Self {
-        todo!()
-    }
-
-    pub fn get_map(&self, _va: VirtAddr) -> Option<MappingInfo> {
-        todo!()
-    }
-
-    #[optimize(speed)]
-    pub fn premap(
-        &mut self,
-        _start: VirtAddr,
-        _length: usize,
-        _page_size: usize,
-        _flags: MapFlags,
-    ) -> Result<(), MapFailed> {
-        todo!()
-    }
-
-    pub fn unmap(&mut self, _start: VirtAddr, _length: usize) {
-        /* TODO: Free frames? */
-        todo!()
-    }
-
-    pub fn map(
-        &mut self,
-        _start: VirtAddr,
-        _phys: PhysAddr,
-        mut _length: usize,
-        _flags: MapFlags,
-        _cache_type: CacheType,
-    ) -> Result<(), MapFailed> {
-        todo!()
-    }
-}
-
-impl ArchMemoryContextSwitchInfo {
-    /// Switch context.
-    /// # Safety
-    /// The context must be valid.
-    pub unsafe fn switch(&self) {
-        todo!()
-    }
-}
-
-pub unsafe fn flush_tlb() {
-    todo!()
+pub fn phys_to_virt(pa: PhysAddr) -> VirtAddr {
+    let raw: u64 = pa.into();
+    VirtAddr::new(raw + PHYS_MEM_OFFSET).unwrap()
 }

--- a/src/kernel/src/arch/aarch64/memory/frame.rs
+++ b/src/kernel/src/arch/aarch64/memory/frame.rs
@@ -1,0 +1,3 @@
+// TODO:
+// arch specific frame (page) size
+pub const FRAME_SIZE: usize = 0x1000;

--- a/src/kernel/src/arch/aarch64/memory/pagetables.rs
+++ b/src/kernel/src/arch/aarch64/memory/pagetables.rs
@@ -1,0 +1,7 @@
+mod consistency;
+mod entry;
+mod table;
+
+pub use consistency::{ArchCacheLineMgr, ArchTlbMgr};
+pub use entry::{Entry, EntryFlags};
+pub use table::Table;

--- a/src/kernel/src/arch/aarch64/memory/pagetables/consistency.rs
+++ b/src/kernel/src/arch/aarch64/memory/pagetables/consistency.rs
@@ -1,0 +1,152 @@
+// use alloc::boxed::Box;
+
+use crate::{
+    arch::address::{PhysAddr, VirtAddr},
+    // interrupt::Destination,
+};
+
+// TODO:
+const MAX_INVALIDATION_INSTRUCTIONS: usize = 0;
+#[derive(Clone)]
+struct TlbInvData {
+    // target_cr3: u64,
+    instructions: [InvInstruction; MAX_INVALIDATION_INSTRUCTIONS],
+    len: u8,
+    flags: u8,
+}
+
+fn tlb_non_global_inv() {
+    todo!("non global tlb invalidation")
+}
+
+fn tlb_global_inv() {
+    todo!("tlb global invalidation")
+}
+
+impl TlbInvData {
+    // TODO: tlb invalidation flags
+    const GLOBAL: u8 = 0;
+    const FULL: u8 = 0;
+
+    fn set_global(&mut self) {
+        self.flags |= Self::GLOBAL;
+    }
+
+    fn set_full(&mut self) {
+        self.flags |= Self::FULL;
+    }
+
+    fn full(&self) -> bool {
+        self.flags & Self::FULL != 0
+    }
+
+    fn global(&self) -> bool {
+        self.flags & Self::GLOBAL != 0
+    }
+
+    fn target(&self) -> u64 {
+        todo!()
+    }
+
+    fn instructions(&self) -> &[InvInstruction] {
+        &self.instructions[0..(self.len as usize)]
+    }
+
+    fn enqueue(&mut self, inst: InvInstruction) {
+        if inst.is_global() {
+            self.set_global();
+        }
+
+        if self.len as usize == MAX_INVALIDATION_INSTRUCTIONS {
+            self.set_full();
+            return;
+        }
+
+        self.instructions[self.len as usize] = inst;
+        self.len += 1;
+    }
+
+    unsafe fn do_invalidation(&self) {
+        todo!()
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+#[repr(transparent)]
+struct InvInstruction(u64);
+
+impl InvInstruction {
+    fn new(_addr: VirtAddr, _is_global: bool, _is_terminal: bool, _level: u8) -> Self {
+        todo!()
+    }
+
+    fn addr(&self) -> VirtAddr {
+        todo!()
+    }
+
+    fn is_global(&self) -> bool {
+        todo!()
+    }
+
+    fn is_terminal(&self) -> bool {
+        todo!()
+    }
+
+    fn level(&self) -> u8 {
+        todo!()
+    }
+
+    fn execute(&self) {
+        todo!();
+    }
+}
+
+#[derive(Default)]
+/// An object that manages cache line invalidations during page table updates.
+pub struct ArchCacheLineMgr {
+    dirty: Option<u64>,
+}
+
+// TODO:
+const CACHE_LINE_SIZE: u64 = 0;
+impl ArchCacheLineMgr {
+    /// Flush a given cache line when this [ArchCacheLineMgr] is dropped. Subsequent flush requests for the same cache
+    /// line will be batched. Flushes for different cache lines will cause older requests to flush immediately, and the
+    /// new request will be flushed when this object is dropped.
+    pub fn flush(&mut self, _line: VirtAddr) {
+        todo!()
+    }
+
+    fn do_flush(&mut self) {
+        todo!()
+    }
+}
+
+impl Drop for ArchCacheLineMgr {
+    fn drop(&mut self) {
+        self.do_flush();
+    }
+}
+
+/// A management object for TLB invalidations that occur during a page table operation.
+pub struct ArchTlbMgr {
+    data: TlbInvData,
+}
+
+impl ArchTlbMgr {
+    /// Construct a new [ArchTlbMgr].
+    pub fn new(_target: PhysAddr) -> Self {
+        todo!()
+    }
+
+    /// Enqueue a new TLB invalidation. is_global should be set iff the page is global, and is_terminal should be set
+    /// iff the invalidation is for a leaf.
+    pub fn enqueue(&mut self, _addr: VirtAddr, _is_global: bool, _is_terminal: bool, _level: usize) {
+        todo!()
+    }
+
+    /// Execute all queued invalidations.
+    pub fn finish(&mut self) {
+        todo!()
+    }
+}

--- a/src/kernel/src/arch/aarch64/memory/pagetables/entry.rs
+++ b/src/kernel/src/arch/aarch64/memory/pagetables/entry.rs
@@ -1,0 +1,176 @@
+use twizzler_abi::{device::CacheType, object::Protections};
+
+use crate::{
+    arch::address::PhysAddr,
+    memory::pagetables::{MappingFlags, MappingSettings},
+};
+
+#[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Ord, Eq)]
+#[repr(transparent)]
+/// The type of a single entry in a page table.
+pub struct Entry(u64);
+
+impl Entry {
+    fn new_internal(_addr: PhysAddr, _flags: EntryFlags) -> Self {
+        todo!()
+    }
+
+    /// Construct a new _present_ [Entry] out of an address and flags.
+    pub fn new(addr: PhysAddr, flags: EntryFlags) -> Self {
+        Self::new_internal(addr, flags | EntryFlags::PRESENT)
+    }
+
+    /// Get the raw u64.
+    pub fn raw(&self) -> u64 {
+        self.0
+    }
+
+    /// Construct a new, unused [Entry].
+    pub fn new_unused() -> Self {
+        Self(0)
+    }
+
+    pub(super) fn get_avail_bit(&self) -> bool {
+        todo!()
+    }
+
+    pub(super) fn set_avail_bit(&mut self, _value: bool) {
+        todo!()
+    }
+
+    /// Is this a huge page, or a page table?
+    pub fn is_huge(&self) -> bool {
+        todo!()
+    }
+
+    /// Is the entry mapped Present?
+    pub fn is_present(&self) -> bool {
+        self.flags().contains(EntryFlags::PRESENT)
+    }
+
+    /// Address contained in the [Entry].
+    pub fn addr(&self) -> PhysAddr {
+        todo!()
+    }
+
+    /// Set the address.
+    pub fn set_addr(&mut self, addr: PhysAddr) {
+        *self = Entry::new_internal(addr, self.flags());
+    }
+
+    /// Clear the entry.
+    pub fn clear(&mut self) {
+        todo!()
+    }
+
+    /// Get the flags.
+    pub fn flags(&self) -> EntryFlags {
+        EntryFlags::from_bits_truncate(self.0)
+    }
+
+    /// Set the flags.
+    pub fn set_flags(&mut self, flags: EntryFlags) {
+        *self = Entry::new_internal(self.addr(), flags);
+    }
+}
+
+// TODO:
+bitflags::bitflags! {
+    /// The possible flags in an AArch64 page table entry.
+    pub struct EntryFlags: u64 {
+        const PRESENT = 0;
+        const WRITE = 0;
+        const USER = 0;
+        const WRITE_THROUGH = 0;
+        const CACHE_DISABLE = 0;
+        const ACCESSED = 0;
+        const DIRTY = 0;
+        const HUGE_PAGE = 0;
+        const GLOBAL = 0;
+        const NO_EXECUTE = 0;
+    }
+}
+
+impl EntryFlags {
+    /// Convert the flags to a [MappingSettings].
+    pub fn settings(&self) -> MappingSettings {
+        MappingSettings::new(self.perms(), self.cache_type(), self.flags())
+    }
+
+    /// Extract the [MappingFlags].
+    pub fn flags(&self) -> MappingFlags {
+        let mut flags = MappingFlags::empty();
+        if self.contains(EntryFlags::GLOBAL) {
+            flags.insert(MappingFlags::GLOBAL);
+        }
+        if self.contains(EntryFlags::USER) {
+            flags.insert(MappingFlags::USER);
+        }
+        flags
+    }
+
+    /// Get the represented permissions as a [Protections].
+    pub fn perms(&self) -> Protections {
+        let rw = if self.contains(Self::WRITE) {
+            Protections::WRITE | Protections::READ
+        } else {
+            Protections::READ
+        };
+        let ex = if self.contains(Self::NO_EXECUTE) {
+            Protections::empty()
+        } else {
+            Protections::EXEC
+        };
+        rw | ex
+    }
+
+    /// Retrieve the [CacheType].
+    pub fn cache_type(&self) -> CacheType {
+        if self.contains(Self::CACHE_DISABLE) {
+            CacheType::Uncacheable
+        } else if self.contains(Self::WRITE_THROUGH) {
+            CacheType::WriteThrough
+        } else {
+            CacheType::WriteBack
+        }
+    }
+
+    /// Get the set of flags to use for an intermediate (page table) entry.
+    pub fn intermediate() -> Self {
+        Self::USER | Self::WRITE | Self::PRESENT
+    }
+
+    /// Get the flags needed to indicate a huge page.
+    pub fn huge() -> Self {
+        Self::HUGE_PAGE
+    }
+}
+
+impl From<&MappingSettings> for EntryFlags {
+    fn from(settings: &MappingSettings) -> Self {
+        let c = match settings.cache() {
+            CacheType::WriteBack => EntryFlags::empty(),
+            CacheType::WriteThrough => EntryFlags::WRITE_THROUGH,
+            CacheType::WriteCombining => EntryFlags::empty(),
+            CacheType::Uncacheable => EntryFlags::CACHE_DISABLE,
+        };
+        let mut p = EntryFlags::empty();
+        if settings.perms().contains(Protections::WRITE) {
+            p |= EntryFlags::WRITE;
+        }
+        if !settings.perms().contains(Protections::EXEC) {
+            p |= EntryFlags::NO_EXECUTE;
+        }
+        let f = if settings.flags().contains(MappingFlags::GLOBAL) {
+            EntryFlags::GLOBAL
+        } else {
+            EntryFlags::empty()
+        };
+        let u = if settings.flags().contains(MappingFlags::USER) {
+            EntryFlags::USER
+        } else {
+            EntryFlags::empty()
+        };
+        p | c | f | u
+    }
+}

--- a/src/kernel/src/arch/aarch64/memory/pagetables/table.rs
+++ b/src/kernel/src/arch/aarch64/memory/pagetables/table.rs
@@ -1,0 +1,83 @@
+use core::ops::{Index, IndexMut};
+
+use crate::{arch::address::VirtAddr, memory::PhysAddr};
+
+use super::Entry;
+
+#[repr(transparent)]
+/// Representation of a page table. Can be indexed with [].
+pub struct Table {
+    entries: [Entry; Self::PAGE_TABLE_ENTRIES],
+}
+
+impl Table {
+    // TODO:
+    /// The number of entries in this table.
+    pub const PAGE_TABLE_ENTRIES: usize = 2;
+
+    /// Get the current root table.
+    pub fn current() -> PhysAddr {
+        todo!()
+    }
+
+    /// The top level of a complete set of page tables.
+    pub fn top_level() -> usize {
+        // TODO: support 5-level paging
+        todo!()
+    }
+
+    /// Does this system support mapping a huge page at this level?
+    pub fn can_map_at_level(level: usize) -> bool {
+        match level {
+            0 => true,
+            1 => true,
+            // TODO: check cpuid
+            2 => true,
+            _ => false,
+        }
+    }
+
+    /// Set the current count of used entries.
+    ///
+    /// Note: On some architectures that make available bits in the page table entries,
+    /// this function may choose to do something clever, like store the count in the available bits. But it could also
+    /// make this function a no-op, and make [Table::read_count] just count the entries.
+    pub fn set_count(&mut self, _count: usize) {
+        // NOTE: this function doesn't need cache line or TLB flushing because the hardware never reads these bits.
+        todo!()
+    }
+
+    /// Read the current count of used entries.
+    pub fn read_count(&self) -> usize {
+        todo!()
+    }
+
+    /// Is this a leaf (a huge page or page aligned) at a given level
+    pub fn is_leaf(_addr: VirtAddr, _level: usize) -> bool {
+        todo!()
+    }
+
+    /// Get the index for the next table for an address.
+    pub fn get_index(_addr: VirtAddr, _level: usize) -> usize {
+        todo!()
+    }
+
+    /// Get the page size of a given level.
+    pub fn level_to_page_size(_level: usize) -> usize {
+        todo!()
+    }
+}
+
+impl Index<usize> for Table {
+    type Output = Entry;
+
+    fn index(&self, index: usize) -> &Self::Output {
+        &self.entries[index]
+    }
+}
+
+impl IndexMut<usize> for Table {
+    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+        &mut self.entries[index]
+    }
+}

--- a/src/kernel/src/arch/aarch64/mod.rs
+++ b/src/kernel/src/arch/aarch64/mod.rs
@@ -4,7 +4,8 @@ use crate::{
     BootInfo,
 };
 
-mod address;
+pub mod address;
+pub mod context;
 pub mod interrupt;
 pub mod memory;
 pub mod processor;

--- a/src/kernel/src/arch/aarch64/thread.rs
+++ b/src/kernel/src/arch/aarch64/thread.rs
@@ -49,7 +49,7 @@ where
 }
 
 impl Thread {
-    pub fn arch_queue_upcall(&self, _target: usize, _info: UpcallInfo) {
+    pub fn arch_queue_upcall(&self, _target: super::address::VirtAddr, _info: UpcallInfo) {
         todo!()
     }
 

--- a/src/kernel/src/machine/arm/linker.ld
+++ b/src/kernel/src/machine/arm/linker.ld
@@ -9,6 +9,7 @@ PHDRS
     text    PT_LOAD    FLAGS((1 << 0) | (1 << 2)) ; /* Execute + Read */
     rodata  PT_LOAD    FLAGS((1 << 2)) ;            /* Read only */
     data    PT_LOAD    FLAGS((1 << 1) | (1 << 2)) ; /* Write + Read */
+    tls     PT_TLS     FLAGS((1 << 2)) ;            /* Read only */
 }
 
 SECTIONS
@@ -31,6 +32,16 @@ SECTIONS
     .rodata : {
         *(.rodata .rodata.*)
     } :rodata
+
+    /* Thread Local Storage sections  */
+    .tdata : { 
+            *(.tdata .tdata.*) 
+    } :tls
+
+    .tbss : {
+        *(.tbss .tbss.*) 
+        *(.tcommon) 
+    } :tls
 
     /* Move to the next memory page for .data */
     . += CONSTANT(MAXPAGESIZE);

--- a/src/kernel/src/machine/arm/mod.rs
+++ b/src/kernel/src/machine/arm/mod.rs
@@ -1,6 +1,8 @@
-pub mod serial;
-mod uart;
+/// QEMU virt target for aarch64
+#[cfg(machine = "virt")]
+mod virt;
 
-pub fn machine_post_init() {
-    // TODO?
-}
+#[cfg(machine = "virt")]
+pub use virt::*;
+
+mod uart;

--- a/src/kernel/src/machine/arm/virt/mod.rs
+++ b/src/kernel/src/machine/arm/virt/mod.rs
@@ -1,0 +1,5 @@
+pub mod serial;
+
+pub fn machine_post_init() {
+    // TODO?
+}

--- a/src/kernel/src/machine/arm/virt/serial.rs
+++ b/src/kernel/src/machine/arm/virt/serial.rs
@@ -1,12 +1,12 @@
 use lazy_static::lazy_static;
 
-use super::uart::PL011;
+use super::super::uart::PL011;
 
 lazy_static! {
     // TODO: add a spinlock here
-    pub static ref SERIAL: super::uart::PL011 = {
+    pub static ref SERIAL: PL011 = {
         const SERIAL_PORT_BASE_ADDRESS: usize = 0x0900_0000; // specific to QEMU
-        let serial_port = unsafe { super::uart::PL011::new(SERIAL_PORT_BASE_ADDRESS) };
+        let serial_port = unsafe { PL011::new(SERIAL_PORT_BASE_ADDRESS) };
         const CLOCK: u32 = 0x16e3600; // 24 MHz, TODO: get clock rate
         const BAUD: u32 = 115200;
         unsafe { serial_port.init(CLOCK, BAUD); }

--- a/tools/xtask/src/main.rs
+++ b/tools/xtask/src/main.rs
@@ -53,7 +53,7 @@ impl BuildConfig {
         self.arch == Arch::X86_64
     }
 
-    fn is_default_machine(&self) -> bool {
+    pub fn is_default_machine(&self) -> bool {
         self.machine == Machine::Unknown
     }
 
@@ -134,6 +134,8 @@ struct QemuOptions {
     qemu_options: Vec<String>,
     #[clap(long, short, help = "Run tests instead of booting normally.")]
     tests: bool,
+    #[clap(long, short, help = "Only build kernel part of system.")]
+    kernel: bool,
 }
 
 impl From<&QemuOptions> for ImageOptions {
@@ -141,7 +143,7 @@ impl From<&QemuOptions> for ImageOptions {
         Self {
             config: qo.config,
             tests: qo.tests,
-            kernel: false,
+            kernel: qo.kernel,
         }
     }
 }

--- a/tools/xtask/src/qemu.rs
+++ b/tools/xtask/src/qemu.rs
@@ -1,56 +1,114 @@
-use std::{fs::File, process::Command};
+use std::{path::Path, process::{Command, ExitStatus}};
 
-use crate::QemuOptions;
+use crate::{QemuOptions, triple::Arch, image::ImageInfo};
+
+struct QemuCommand {
+    cmd: Command,
+    arch: Arch,
+}
+
+impl QemuCommand {
+    pub fn new(cli: &QemuOptions) -> Self {
+        let cmd = match cli.config.arch {
+            Arch::X86_64 => "qemu-system-x86_64",
+            Arch::Aarch64 => "qemu-system-aarch64",
+        };
+        Self {
+            cmd: Command::new(cmd),
+            arch: cli.config.arch,
+        }
+    }
+
+    pub fn config(&mut self, options: &QemuOptions, image_info: ImageInfo) {
+        // Set up the basic stuff, memory and bios, etc.
+        self.cmd.arg("-m").arg("1024,slots=4,maxmem=8G");
+
+        // configure architechture specific parameters
+        self.arch_config(options);
+
+        // Connect disk image
+        self.cmd.arg("-drive").arg(format!(
+            "format=raw,file={}",
+            image_info.disk_image.as_path().display()
+        ));
+        
+        self.cmd
+            .arg("--no-reboot") // exit instead of rebooting
+            .arg("-s") // shorthand for -gdb tcp::1234
+            .arg("-serial")
+            .arg("mon:stdio");
+        //-serial mon:stdio creates a multiplexed stdio backend connected 
+        // to the serial port and the QEMU monitor, and 
+        // -nographic also multiplexes the console and the monitor to stdio.
+
+        // add additional options for qemu
+        self.cmd.args(&options.qemu_options);
+
+        //self.cmd.arg("-smp").arg("4,sockets=1,cores=2,threads=2");
+    }
+
+    fn arch_config(&mut self, options: &QemuOptions) {
+        match self.arch {
+            Arch::X86_64 => {
+                // bios, cpu, platform
+                self.cmd.arg("-bios").arg("toolchain/install/OVMF.fd");
+                self.cmd.arg("-machine").arg("q35,nvdimm=on");
+                self.cmd
+                    .arg("-cpu")
+                    .arg("host,+x2apic,+tsc-deadline,+invtsc,+tsc,+tsc_scale,+rdtscp");
+                // add qemu exit device for testing
+                if options.tests { // x86 specific
+                    self.cmd
+                        .arg("-device")
+                        .arg("isa-debug-exit,iobase=0xf4,iosize=0x04");
+                }
+
+                // check if host is same as qemu, and if kvm exists
+                if std::env::consts::ARCH == self.arch.to_string()
+                    && Path::new("/dev/kvm").exists() 
+                {
+                    self.cmd.arg("-enable-kvm"); // machine specific 
+                }
+
+                // Connect some nvdimms
+                /*
+                self.cmd.arg("-object").arg(format!(
+                    "memory-backend-file,id=mem1,share=on,mem-path={},size=4G",
+                    make_path(build_info, true, "pmem.img")
+                ));
+                self.cmd.arg("-device").arg("nvdimm,id=nvdimm1,memdev=mem1");
+                */
+                // File::create("target/nvme.img")
+                // .and_then(|f| f.set_len(0x10000000))
+                // .unwrap();
+                // self.cmd
+                //     .arg("-drive")
+                //     .arg("file=target/nvme.img,if=none,id=nvme")
+                //     .arg("-device")
+                //     .arg("nvme,serial=deadbeef,drive=nvme");
+            },
+            Arch::Aarch64 => {
+                self.cmd.arg("-bios").arg("toolchain/install/OVMF-AA64.fd");
+                self.cmd.arg("-net").arg("none");
+                // use qemu virt machine by default
+                self.cmd.arg("-machine").arg("virt");//,gic-version=max");
+                self.cmd
+                    .arg("-cpu").arg("cortex-a72");
+                self.cmd.arg("-nographic");
+            }
+        }
+    }
+
+    pub fn status(&mut self) -> std::io::Result<ExitStatus> {
+        self.cmd.status()
+    }
+}
 
 pub(crate) fn do_start_qemu(cli: QemuOptions) -> anyhow::Result<()> {
     let image_info = crate::image::do_make_image((&cli).into())?;
 
-    let mut run_cmd = Command::new("qemu-system-x86_64");
-
-    // Set up the basic stuff, memory and bios, etc.
-    run_cmd.arg("-m").arg("1024,slots=4,maxmem=8G");
-    run_cmd.arg("-enable-kvm");
-    run_cmd.arg("-bios").arg("toolchain/install/OVMF.fd");
-
-    run_cmd.arg("-machine").arg("q35,nvdimm=on");
-    run_cmd
-        .arg("-cpu")
-        .arg("host,+x2apic,+tsc-deadline,+invtsc,+tsc,+tsc_scale,+rdtscp");
-
-    // Connect disk image
-    run_cmd.arg("-drive").arg(format!(
-        "format=raw,file={}",
-        image_info.disk_image.as_path().display()
-    ));
-    // Connect some nvdimms
-    /*
-    run_cmd.arg("-object").arg(format!(
-        "memory-backend-file,id=mem1,share=on,mem-path={},size=4G",
-        make_path(build_info, true, "pmem.img")
-    ));
-    run_cmd.arg("-device").arg("nvdimm,id=nvdimm1,memdev=mem1");
-    */
-    File::create("target/nvme.img")
-        .and_then(|f| f.set_len(0x10000000))
-        .unwrap();
-    run_cmd
-        .arg("-drive")
-        .arg("file=target/nvme.img,if=none,id=nvme")
-        .arg("-device")
-        .arg("nvme,serial=deadbeef,drive=nvme");
-    run_cmd
-        .arg("--no-reboot")
-        .arg("-s")
-        .arg("-serial")
-        .arg("mon:stdio");
-
-    if cli.tests {
-        run_cmd
-            .arg("-device")
-            .arg("isa-debug-exit,iobase=0xf4,iosize=0x04");
-    }
-    run_cmd.args(cli.qemu_options);
-    //run_cmd.arg("-smp").arg("4,sockets=1,cores=2,threads=2");
+    let mut run_cmd = QemuCommand::new(&cli);
+    run_cmd.config(&cli, image_info);
 
     let exit_status = run_cmd.status()?;
     if exit_status.success() {

--- a/tools/xtask/src/triple.rs
+++ b/tools/xtask/src/triple.rs
@@ -4,6 +4,7 @@ use strum_macros::EnumIter;
 pub enum Machine {
     Unknown,
     Rpi3,
+    Virt,
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, EnumIter, clap::ArgEnum)]
@@ -73,6 +74,7 @@ impl From<Machine> for String {
         match m {
             Machine::Unknown => "unknown",
             Machine::Rpi3 => "rpi3",
+            Machine::Virt => "virt",
         }
         .to_string()
     }


### PR DESCRIPTION
This patch includes support for conditional compilation of a specific target machine (e.g, QEMU's aarch64 virt target). Among other things we implement:
- support for invoking QEMU in an arch-specific way
- conditional compilation flag for machine on xtask cli
- reorganization of existing `machine/arm` code specific to `virt`
- stubs for to keep up with changes to the memory management system
- inclusion of TLS section in aarch64 binary

The only things we need to make this change functional for the remote server to host Limine efi and firmware binaries for aarch64. And then we would have to change the bootstrap phase. The `OVMF.fd` and `BOOTX64.EFI` files downloaded do not work. I have been using EDK II's ArmVirt platform and Limine's 4.x release of `BOOTAA64.EFI`. The firmware can be obtained from the `qemu-efi-aarch64` package on Ubuntu machines. Installed at `/usr/share/qemu-efi-aarch64/QEMU_EFI.fd` I believe.  And Limine has a convenient [releases branch](https://github.com/limine-bootloader/limine#binary-releases). Or both can be compiled/installed from source.