### PR TITLE
Implement physical frame allocation for aarch64

### DIFF
--- a/src/kernel/src/arch/aarch64/address.rs
+++ b/src/kernel/src/arch/aarch64/address.rs
@@ -1,4 +1,13 @@
+/// Values for valid memory regions derived from the
+/// ArmV8-A Address Translation v1.1 document
+/// https://developer.arm.com/documentation/100940/0101/?lang=en
+/// and the Arm Architecture Reference Manual for A-profile architecture
+/// https://developer.arm.com/documentation/ddi0487/latest
+
 use core::{fmt::LowerHex, ops::Sub};
+
+use arm64::registers::ID_AA64MMFR0_EL1;
+use registers::interfaces::Readable;
 
 use crate::once::Once;
 
@@ -21,8 +30,37 @@ impl VirtAddr {
     /// The start of the kernel memory heap.
     pub const HEAP_START: Self = Self(0xffffff0000000000);
 
+    /// The start of the kernel object mapping.
+    const KOBJ_START: Self = Self(0xfffff00000000000);
+    
+    // TTBR0_EL1 points to a page table root for addresses ranging from
+    // 0x0 to 0x0000_FFFF_FFFF_FFFF. Generally this is used to cover
+    // user accessible memory (EL0).
+    
+    /// The start range of valid addresses that TTBR0 covers
+    const TTBR0_EL1_START: u64 = 0x0000_0000_0000_0000;
+    /// The end range of valid addresses that TTBR0 covers
+    const TTBR0_EL1_END: u64 = 0x0000_FFFF_FFFF_FFFF;
+
+    // TTBR1_EL1 -> a pt root for addresses ranging from
+    // 0xFFFF_FFFF_FFFF_FFFF to 0xFFFF_0000_0000_0000
+    // Generally this is used to cover exclusively 
+    // kernel accessible memory (EL1).
+    
+    /// The start range of valid addresses that TTBR1 covers
+    const TTBR1_EL1_START: u64 = 0xFFFF_0000_0000_0000;
+    /// The start range of valid addresses that TTBR1 covers
+    const TTBR1_EL1_END: u64 = 0xFFFF_FFFF_FFFF_FFFF;
+
+    // /// The bits that are valid which are used in address translation
+    const VALID_ADDR_BITS: u32 = 48;
+    /// The valid value for the upper bits of a high address
+    const VALID_HIGH_ADDRESS: u64 = 0xFFFF;
+    /// The valid value for the upper bits of a low address
+    const VALID_LOW_ADDRESS: u64 = 0x0;
+ 
     pub const fn start_kernel_memory() -> Self {
-        todo!()
+        Self(Self::TTBR0_EL1_START)
     }
     
     pub const fn start_kernel_object_memory() -> Self {
@@ -30,20 +68,34 @@ impl VirtAddr {
     }
 
     pub const fn end_kernel_object_memory() -> Self {
-        todo!()
+        todo!(); // doable
     }
+
     pub const fn start_user_memory() -> Self {
-        todo!()
+        // Assuming that user memory is mapped in the lower half of the
+        // virtual address space, we utilize the valid ranges for TTRBR0_EL1
+        Self(Self::TTBR0_EL1_START)
     }
 
     pub const fn end_user_memory() -> Self {
-        todo!()
+        // Assuming that user memory is mapped in the lower half of the
+        // virtual address space, we utilize the valid ranges for TTRBR0_EL1
+        Self(Self::TTBR0_EL1_END)
     }
 
     /// Construct a new virtual address from the provided addr value, only if the provided value is a valid, canonical
     /// address. If not, returns Err.
-    pub const fn new(_addr: u64) -> Result<Self, NonCanonical> {
-        todo!()
+    pub const fn new(addr: u64) -> Result<Self, NonCanonical> {
+        // The most significant 16 bits of an address must be 0xFFFF or 0x0000. 
+        // Any attempt to use a different bit value triggers a fault.
+        // For now we assume that virtual address tagging is disabled.
+        let top_two_bytes = addr
+            .checked_shr(Self::VALID_ADDR_BITS)
+            .unwrap();
+        match top_two_bytes {
+            Self::VALID_HIGH_ADDRESS | Self::VALID_LOW_ADDRESS => Ok(Self(addr)),
+            _ => Err(NonCanonical),
+        }
     }
 
     /// Construct a new virtual address from a u64 without verifying that it is a valid virtual address.
@@ -67,11 +119,13 @@ impl VirtAddr {
     }
 
     pub fn is_kernel(&self) -> bool {
-        todo!()
+        // TODO: should this  be bound by TTBR1_EL1_END
+        self.0 >= Self::TTBR1_EL1_START
     }
 
     pub fn is_kernel_object_memory(&self) -> bool {
-        todo!()
+        self.0 >= Self::start_kernel_object_memory().0
+            && self.0 < Self::end_kernel_object_memory().0
     }
 
     pub fn offset<U: Into<Offset>>(&self, offset: U) -> Result<Self, NonCanonical> {
@@ -161,12 +215,28 @@ static PHYS_ADDR_WIDTH: Once<u64> = Once::new();
 impl PhysAddr {
     fn get_phys_addr_width() -> u64 {
         *PHYS_ADDR_WIDTH.call_once(|| {
-            todo!()
+            // According to the Manual D8.1.6, the physical address width
+            // is determined by the value in ID_AA64MMFR0_EL1.PARange field.
+            match ID_AA64MMFR0_EL1.read_as_enum(ID_AA64MMFR0_EL1::PARange) {
+                Some(ID_AA64MMFR0_EL1::PARange::Value::Bits_32) => 32,
+                Some(ID_AA64MMFR0_EL1::PARange::Value::Bits_36) => 36,
+                Some(ID_AA64MMFR0_EL1::PARange::Value::Bits_40) => 40,
+                Some(ID_AA64MMFR0_EL1::PARange::Value::Bits_42) => 42,
+                Some(ID_AA64MMFR0_EL1::PARange::Value::Bits_44) => 44,
+                Some(ID_AA64MMFR0_EL1::PARange::Value::Bits_48) => 48,
+                Some(ID_AA64MMFR0_EL1::PARange::Value::Bits_52) => 52,
+                _ => unimplemented!("unknown PA size")
+            }
         })
     }
 
-    pub fn new(_addr: u64) -> Result<Self, NonCanonical> {
-        todo!()
+    pub fn new(addr: u64) -> Result<Self, NonCanonical> {
+        let bits = Self::get_phys_addr_width();
+        if addr < 1 << bits {
+            Ok(Self(addr))
+        } else {
+            Err(NonCanonical)
+        }
     }
 
     /// Construct a new physical address from a u64 without verifying that it is a valid physical address.
@@ -178,7 +248,7 @@ impl PhysAddr {
     }
 
     pub fn kernel_vaddr(&self) -> VirtAddr {
-        phys_to_virt(*self)
+        phys_to_virt(*self) // maybe???
     }
 
     pub fn offset<U: Into<Offset>>(&self, offset: U) -> Result<Self, NonCanonical> {

--- a/src/kernel/src/arch/aarch64/exception.rs
+++ b/src/kernel/src/arch/aarch64/exception.rs
@@ -23,7 +23,7 @@ global_asm!(r#"
 // The vector table contains actual code for exception handlers.
 // The table is organized into 4 sections, with 4 entries each.
 // Each entry is 128 bytes, and thus aligned on such a boundary
-// The entries are for handling Synnchronous, IRQ, FIQ, or SError.
+// The entries are for handling Synchronous, IRQ, FIQ, or SError.
 // The virtual address of the EVT is stored in the VBAR register.
 //
 // Currently we only handle exceptions while in the kernel (EL1)

--- a/src/kernel/src/arch/aarch64/interrupt.rs
+++ b/src/kernel/src/arch/aarch64/interrupt.rs
@@ -133,14 +133,14 @@ pub fn init_idt() {
 bitflags::bitflags! {
     /// Interrupt mask bits for the DAIF register which changes PSTATE.
     pub struct DAIFMaskBits: u8 {
-        /// Watchpoint, Breakpoint, and Software Step exceptions
-        const D = 1 << 3;
-        /// SError exceptions
-        const A = 1 << 2;
-        /// IRQ exceptions
-        const I = 1 << 1;
-        /// FIQ exceptions
-        const F = 1 << 0;
+        /// D bit: Watchpoint, Breakpoint, and Software Step exceptions
+        const DEBUG = 1 << 3;
+        /// A bit: SError exceptions
+        const SERROR = 1 << 2;
+        /// I bit: IRQ exceptions
+        const IRQ = 1 << 1;
+        /// F bit: FIQ exceptions
+        const FIQ = 1 << 0;
     }
 }
 
@@ -148,7 +148,7 @@ pub fn disable() -> bool {
     unsafe {
         core::arch::asm!(
             "msr DAIFSet, {DISABLE_MASK}",
-            DISABLE_MASK = const DAIFMaskBits::I.bits(),
+            DISABLE_MASK = const DAIFMaskBits::IRQ.bits(),
         );
     }
     // TODO: We need the current interrupt state,
@@ -163,7 +163,7 @@ pub fn set(_state: bool) {
     unsafe {
         core::arch::asm!(
             "msr DAIFClr, {ENABLE_MASK}",
-           ENABLE_MASK = const DAIFMaskBits::I.bits(),
+           ENABLE_MASK = const DAIFMaskBits::IRQ.bits(),
         );
     }
 }

--- a/src/kernel/src/arch/aarch64/interrupt.rs
+++ b/src/kernel/src/arch/aarch64/interrupt.rs
@@ -130,14 +130,42 @@ pub fn init_idt() {
     todo!()
 }
 
+bitflags::bitflags! {
+    /// Interrupt mask bits for the DAIF register which changes PSTATE.
+    pub struct DAIFMaskBits: u8 {
+        /// Watchpoint, Breakpoint, and Software Step exceptions
+        const D = 1 << 3;
+        /// SError exceptions
+        const A = 1 << 2;
+        /// IRQ exceptions
+        const I = 1 << 1;
+        /// FIQ exceptions
+        const F = 1 << 0;
+    }
+}
+
 pub fn disable() -> bool {
-    todo!("disable interrupts")
-    //   MSR DAIFSet, #imm (0b1111)
+    unsafe {
+        core::arch::asm!(
+            "msr DAIFSet, {DISABLE_MASK}",
+            DISABLE_MASK = const DAIFMaskBits::I.bits(),
+        );
+    }
+    // TODO: We need the current interrupt state,
+    // for now we return true. Since the interrupt state
+    // for aarch64 is more complex, maybe we need this
+    // to be a type. Or we since we are only toggling a bit,
+    // we could keep the bool representation
+    true
 }
 
 pub fn set(_state: bool) {
-    todo!("enable interrupts")
-    //   MSR DAIFClr, #imm (0b1111)
+    unsafe {
+        core::arch::asm!(
+            "msr DAIFClr, {ENABLE_MASK}",
+           ENABLE_MASK = const DAIFMaskBits::I.bits(),
+        );
+    }
 }
 
 pub fn allocate_interrupt_vector(

--- a/src/kernel/src/arch/aarch64/memory.rs
+++ b/src/kernel/src/arch/aarch64/memory.rs
@@ -4,12 +4,16 @@ use super::address::{PhysAddr, VirtAddr};
 pub mod frame;
 pub mod pagetables;
 
-// TODO:
-// start offset into physical memory
-const PHYS_MEM_OFFSET: u64 = 0x0;
+// start offset into physical memory. 
+// 
+// in the future we should determine this at runtime 
+// since we don't know what the CPU supports. We might
+// go about this by making `PhysAddr::get_phys_addr_width()`
+// public and then calculate it that way. For now we assume
+// a 48-bit physical address space.
+const PHYS_MEM_OFFSET: u64 = 0xffff800000000000;
 
 /* TODO: hide this */
 pub fn phys_to_virt(pa: PhysAddr) -> VirtAddr {
-    let raw: u64 = pa.into();
-    VirtAddr::new(raw + PHYS_MEM_OFFSET).unwrap()
+    VirtAddr::new(pa.raw() + PHYS_MEM_OFFSET).unwrap()
 }

--- a/src/kernel/src/arch/aarch64/memory/frame.rs
+++ b/src/kernel/src/arch/aarch64/memory/frame.rs
@@ -1,3 +1,5 @@
-// TODO:
-// arch specific frame (page) size
+// arch specific frame (page) size in bytes.
+// Frame size is chosen from translation granule.
+// In this implementation we go with 4 KiB pages.
+// In the future we could determine this at runtime.
 pub const FRAME_SIZE: usize = 0x1000;

--- a/src/kernel/src/arch/aarch64/mod.rs
+++ b/src/kernel/src/arch/aarch64/mod.rs
@@ -18,27 +18,8 @@ pub use address::{VirtAddr, PhysAddr};
 pub use interrupt::send_ipi;
 pub use start::BootInfoSystemTable;
 
-pub fn kernel_main() -> ! {
-    emerglogln!("[kernel] hello world!!");
-    let boot_info = start::Armv8BootInfo {};
-    init(&boot_info);
-    emerglogln!("[kernel] generating an exception");
-    // generate an exception by executing a
-    // supervisor call (SVC). Value 42 is passed
-    // to the exception handler
-    unsafe {
-        core::arch::asm!(
-            "mov x0, 0xAAAA",
-            "mov x16, 0xBBBC",
-            "svc 42",
-        );
-    }
-    emerglogln!("[kernel] return from exception");
-    loop {}
-}
-
 pub fn init<B: BootInfo>(_boot_info: &B) {
-    emerglogln!("[kernel] initializing exceptions");
+    logln!("[arch::init] initializing exceptions");
     exception::init();
 }
 

--- a/src/kernel/src/arch/aarch64/start.rs
+++ b/src/kernel/src/arch/aarch64/start.rs
@@ -1,8 +1,10 @@
+use alloc::vec::Vec;
+
 use limine::*;
 
 use crate::{
     initrd::BootModule,
-    memory::{MemoryRegion, VirtAddr},
+    memory::{MemoryRegion, MemoryRegionKind, VirtAddr, PhysAddr},
     BootInfo,
 };
 
@@ -10,27 +12,45 @@ pub enum BootInfoSystemTable {
     Unknown
 }
 
-pub struct Armv8BootInfo;
+/// Bootstrap information passed in by the bootloader.
+struct Armv8BootInfo {
+    /// The memory map available to the processor.
+    ///
+    /// It is okay to use Vec here since the memory
+    /// allocator initially uses some reserved stack memory.
+    memory: Vec<MemoryRegion>,
+}
 
 impl BootInfo for Armv8BootInfo {
     fn memory_regions(&self) -> &'static [MemoryRegion] {
-        todo!()
+        unsafe { core::intrinsics::transmute(&self.memory[..]) }
     }
 
     fn get_modules(&self) -> &'static [BootModule] {
-        todo!()
+        todo!("get modules")
     }
 
     fn kernel_image_info(&self) -> (VirtAddr, usize) {
-        todo!()
+        todo!("kernel image info")
     }
 
     fn get_system_table(&self, _table: BootInfoSystemTable) -> VirtAddr {
-        todo!()
+        todo!("get system table")
     }
 
     fn get_cmd_line(&self) -> &'static str {
-        todo!()
+        // TODO
+        ""
+    }
+}
+
+impl From<LimineMemoryMapEntryType> for MemoryRegionKind {
+    fn from(st: LimineMemoryMapEntryType) -> Self {
+        match st {
+            LimineMemoryMapEntryType::Usable => MemoryRegionKind::UsableRam,
+            LimineMemoryMapEntryType::KernelAndModules => MemoryRegionKind::BootloaderReserved,
+            _ => MemoryRegionKind::Reserved,
+        }
     }
 }
 
@@ -38,13 +58,54 @@ impl BootInfo for Armv8BootInfo {
 static ENTRY_POINT: LimineEntryPointRequest = LimineEntryPointRequest::new(0)
     .entry(LiminePtr::new(limine_entry));
 
+#[used]
+static MEMORY_MAP: LimineMmapRequest = LimineMmapRequest::new(0);
+
 #[link_section = ".limine_reqs"]
 #[used]
 static LR1: &'static LimineEntryPointRequest = &ENTRY_POINT;
 
+#[link_section = ".limine_reqs"]
+#[used]
+static LR2: &'static LimineMmapRequest = &MEMORY_MAP;
+
 // the kernel's entry point function from the limine bootloader
 // limine ensures we are in el1 (kernel mode)
 fn limine_entry() -> ! {
-    // let's do something more interesting
-    crate::arch::kernel_main()
+    emerglogln!("[kernel] hello world!!");
+
+    // let's see what's in the memory map from limine
+    let mmap = MEMORY_MAP
+        .get_response() // LiminePtr<LimineMemmapResponse>
+        .get() // Option<'static T>
+        .expect("no memory map specified for kernel") // LimineMemmapResponse
+        .mmap() // Option<&'static [LimineMemmapEntry]>
+        .unwrap(); // &'static [LimineMemmapEntry]
+
+    // emerglogln!("[kernel] printing out memory map");
+
+    // for region in mmap {
+    //     emerglogln!("\tfound: {:#018x} - {:#018x} ({} KB) {:?}",
+    //         region.base,
+    //         region.base + region.len,
+    //         region.len >> 10,
+    //         region.typ)
+    // }
+
+    // generate generic boot info
+    let mut boot_info = Armv8BootInfo {
+        memory: alloc::vec![],
+    };
+
+    // convert memory map from bootloader to memory regions
+    boot_info.memory = mmap
+        .iter()
+        .map(|m| MemoryRegion {
+            kind: m.typ.into(),
+            start: PhysAddr::new(m.base).unwrap(),
+            length: m.len as usize,
+        })
+        .collect();
+
+    crate::kernel_main(&mut boot_info)
 }


### PR DESCRIPTION
This patch implements physical frame allocation for aarch64.

# Summary
  - pass physical memory regions from the bootloader to frame allocator
  - implement architechture specific info needed for `PhysAddr`/`VirtAddr`
  - clean up kernel entry point to call `kernel_main`
  - enable/disable IRQ so we can used `logln!`