### PR TITLE
Implement page table reader for aarch64

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
 
 [[package]]
+name = "aarch64-cpu"
+version = "9.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb711c57d60565ba8f6523eb371e6243639617d817b4df1ae09af250af1af411"
+dependencies = [
+ "tock-registers",
+]
+
+[[package]]
 name = "acpi"
 version = "4.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2514,6 +2523,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
+name = "tock-registers"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "696941a0aee7e276a165a978b37918fd5d22c55c3d6bda197813070ca9c0f21c"
+
+[[package]]
 name = "tokio"
 version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2645,6 +2660,7 @@ dependencies = [
 name = "twizzler-kernel"
 version = "0.1.0"
 dependencies = [
+ "aarch64-cpu",
  "acpi",
  "addr2line",
  "backtracer_core",
@@ -2659,6 +2675,7 @@ dependencies = [
  "object",
  "slabmalloc",
  "tar-no-std",
+ "tock-registers",
  "twizzler-abi",
  "twizzler-kernel-macros",
  "twizzler-queue-raw",

--- a/src/kernel/src/arch/aarch64/context.rs
+++ b/src/kernel/src/arch/aarch64/context.rs
@@ -1,35 +1,20 @@
 use crate::{
     // arch::memory::pagetables::{Entry, EntryFlags},
     memory::{
-        frame::{alloc_frame, PhysicalFrameFlags},
+        // frame::{alloc_frame, PhysicalFrameFlags},
         pagetables::{
-            DeferredUnmappingOps, MapReader, Mapper, MappingCursor, MappingSettings,
+            DeferredUnmappingOps, MapReader, MappingCursor, MappingSettings,
             PhysAddrProvider,
         },
     },
-    mutex::Mutex,
-    spinlock::Spinlock,
+    // mutex::Mutex,
+    // spinlock::Spinlock,
 };
 
-pub struct ArchContextInner {
-    mapper: Mapper,
-}
+// this does not need to be pub
+pub struct ArchContextInner;
 
-pub struct ArchContext {
-    target: u64,
-    inner: Mutex<ArchContextInner>,
-}
-
-lazy_static::lazy_static! {
-    static ref KERNEL_MAPPER: Spinlock<Mapper> = {
-        let m = Mapper::new(alloc_frame(PhysicalFrameFlags::ZEROED).start_address());
-        // TODO ?
-        // for idx in 256..512 {
-        //     m.set_top_level_table(idx, Entry::new(alloc_frame(PhysicalFrameFlags::ZEROED).start_address(), EntryFlags::intermediate()));
-        // }
-        Spinlock::new(m)
-    };
-}
+pub struct ArchContext;
 
 impl Default for ArchContext {
     fn default() -> Self {
@@ -43,84 +28,55 @@ impl ArchContext {
     }
 
     pub fn new() -> Self {
-        let inner = ArchContextInner::new();
-        let target = inner.mapper.root_address().into();
-        Self {
-            target,
-            inner: Mutex::new(inner),
-        }
+        Self {}
     }
 
     #[allow(named_asm_labels)]
     pub fn switch_to(&self) {
-        todo!()
+        todo!("switch_to")
     }
 
     pub fn map(
         &self,
-        cursor: MappingCursor,
-        phys: &mut impl PhysAddrProvider,
-        settings: &MappingSettings,
+        _cursor: MappingCursor,
+        _phys: &mut impl PhysAddrProvider,
+        _settings: &MappingSettings,
     ) {
-        if cursor.start().is_kernel() {
-            KERNEL_MAPPER.lock().map(cursor, phys, settings);
-        } else {
-            self.inner.lock().map(cursor, phys, settings);
-        }
+        todo!("map")
     }
 
-    pub fn change(&self, cursor: MappingCursor, settings: &MappingSettings) {
-        if cursor.start().is_kernel() {
-            KERNEL_MAPPER.lock().change(cursor, settings);
-        } else {
-            self.inner.lock().change(cursor, settings);
-        }
+    pub fn change(&self, _cursor: MappingCursor, _settings: &MappingSettings) {
+        todo!("change")
     }
 
-    pub fn unmap(&self, cursor: MappingCursor) {
-        let ops = if cursor.start().is_kernel() {
-            KERNEL_MAPPER.lock().unmap(cursor)
-        } else {
-            self.inner.lock().unmap(cursor)
-        };
-        ops.run_all();
+    pub fn unmap(&self, _cursor: MappingCursor) {
+        todo!("unmap")
     }
 
-    pub fn readmap<R>(&self, cursor: MappingCursor, f: impl Fn(MapReader) -> R) -> R {
-        let r = if cursor.start().is_kernel() {
-            f(KERNEL_MAPPER.lock().readmap(cursor))
-        } else {
-            f(self.inner.lock().mapper.readmap(cursor))
-        };
-        r
+    pub fn readmap<R>(&self, _cursor: MappingCursor, _f: impl Fn(MapReader) -> R) -> R {
+        todo!("readmap")
     }
 }
 
 impl ArchContextInner {
     fn new() -> Self {
-        let mapper = Mapper::new(alloc_frame(PhysicalFrameFlags::ZEROED).start_address());
-        // let km = KERNEL_MAPPER.lock();
-        // TODO ?
-        // for idx in 256..512 {
-        //     mapper.set_top_level_table(idx, km.get_top_level_table(idx));
-        // }
-        Self { mapper }
+        todo!()
     }
 
     fn map(
         &mut self,
-        cursor: MappingCursor,
-        phys: &mut impl PhysAddrProvider,
-        settings: &MappingSettings,
+        _cursor: MappingCursor,
+        _phys: &mut impl PhysAddrProvider,
+        _settings: &MappingSettings,
     ) {
-        self.mapper.map(cursor, phys, settings);
+        todo!()
     }
 
-    fn change(&mut self, cursor: MappingCursor, settings: &MappingSettings) {
-        self.mapper.change(cursor, settings);
+    fn change(&mut self, _cursor: MappingCursor, _settings: &MappingSettings) {
+        todo!()
     }
 
-    fn unmap(&mut self, cursor: MappingCursor) -> DeferredUnmappingOps {
-        self.mapper.unmap(cursor)
+    fn unmap(&mut self, _cursor: MappingCursor) -> DeferredUnmappingOps {
+        todo!()
     }
 }

--- a/src/kernel/src/arch/aarch64/memory.rs
+++ b/src/kernel/src/arch/aarch64/memory.rs
@@ -4,13 +4,14 @@ use super::address::{PhysAddr, VirtAddr};
 pub mod frame;
 pub mod pagetables;
 
-// start offset into physical memory. 
-// 
-// in the future we should determine this at runtime 
-// since we don't know what the CPU supports. We might
-// go about this by making `PhysAddr::get_phys_addr_width()`
-// public and then calculate it that way. For now we assume
-// a 48-bit physical address space.
+/// The start offset into physical memory.
+///
+/// The kernel is designed to run in the higher
+/// half of the virtual address space, and as such expects
+/// a region of virtual memory to identity map
+/// all physical memory. This is convenient since
+/// calculating a physical to virtual address is simply
+/// va = base + offset
 const PHYS_MEM_OFFSET: u64 = 0xffff800000000000;
 
 /* TODO: hide this */

--- a/src/kernel/src/arch/aarch64/memory/frame.rs
+++ b/src/kernel/src/arch/aarch64/memory/frame.rs
@@ -1,5 +1,13 @@
-// arch specific frame (page) size in bytes.
-// Frame size is chosen from translation granule.
-// In this implementation we go with 4 KiB pages.
-// In the future we could determine this at runtime.
-pub const FRAME_SIZE: usize = 0x1000;
+/// The architechture specific frame (page) size in bytes.
+///
+/// Frame size is chosen from translation granule.
+/// In this implementation we go with 4 KiB pages.
+pub const FRAME_SIZE: usize = FrameSize::Size4KiB as usize;
+
+/// The possible frame sizes for a page of memory 
+/// mapped by a page table.
+enum FrameSize {
+    Size4KiB = 1 << 12,
+    Size16KiB = 1 << 14,
+    Size64KiB = 1 << 16,
+}

--- a/src/kernel/src/arch/aarch64/memory/pagetables/entry.rs
+++ b/src/kernel/src/arch/aarch64/memory/pagetables/entry.rs
@@ -1,5 +1,9 @@
 use twizzler_abi::{device::CacheType, object::Protections};
 
+use arm64::registers::MAIR_EL1;
+use registers::interfaces::Readable;
+use registers::registers::InMemoryRegister;
+
 use crate::{
     arch::address::PhysAddr,
     memory::pagetables::{MappingFlags, MappingSettings},
@@ -8,11 +12,17 @@ use crate::{
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Ord, Eq)]
 #[repr(transparent)]
 /// The type of a single entry in a page table.
+///
+/// Page table entries in aarch64 nomenclature are known
+/// as translation table descriptors. The descriptors themselves 
+/// can be different types, and mean different things depending
+/// on what level we are in. It can also vary depending on
+/// the size of the physical address space used (e.g., 48-bit)
 pub struct Entry(u64);
 
 impl Entry {
     fn new_internal(_addr: PhysAddr, _flags: EntryFlags) -> Self {
-        todo!()
+        todo!("new_internal")
     }
 
     /// Construct a new _present_ [Entry] out of an address and flags.
@@ -31,36 +41,60 @@ impl Entry {
     }
 
     pub(super) fn get_avail_bit(&self) -> bool {
-        todo!()
+        todo!("get_avail_bit")
     }
 
     pub(super) fn set_avail_bit(&mut self, _value: bool) {
-        todo!()
+        todo!("set_avail_bit")
     }
 
     /// Is this a huge page, or a page table?
     pub fn is_huge(&self) -> bool {
-        todo!()
+        // The meaning of this bit is only valid at levels != 3
+        // If this bit is set then this entry points to another
+        // page table. If this bit is set at level 3, then we are
+        // looking at a page
+        !self.flags().contains(EntryFlags::TABLE_OR_HUGE_PAGE)
     }
 
     /// Is the entry mapped Present?
     pub fn is_present(&self) -> bool {
+        // if the last bit is 0, then this entry is invalid
         self.flags().contains(EntryFlags::PRESENT)
     }
 
+    // bits [47:30]
+    const LVL1_BLK_ADDR_MASK: u64 = 0x0000_FFFF_C000_0000;
+    // bits [47:21]
+    const LVL2_BLK_ADDR_MASK: u64 = 0x0000_FFFF_FFE0_0000;
+    // bits [47:12]
+    const LVL3_PAGE_ADDR_MASK: u64 = 0x0000_FFFF_FFFF_F000;
+    
     /// Address contained in the [Entry].
-    pub fn addr(&self) -> PhysAddr {
-        todo!()
+    pub fn addr(&self, level: usize) -> PhysAddr {
+        // The bits that indicate the address depends on
+        // the translation granule used and the descriptor 
+        // type which depends on the level. For now we are
+        // assuming a 4KiB translation granule.
+        //
+        // we assume the user wants the address of a page given
+        // the level the entry is currently in
+        match level {
+            1 => PhysAddr::new(self.0 & Self::LVL1_BLK_ADDR_MASK).unwrap(),
+            2 => PhysAddr::new(self.0 & Self::LVL2_BLK_ADDR_MASK).unwrap(),
+            3 => PhysAddr::new(self.0 & Self::LVL3_PAGE_ADDR_MASK).unwrap(),
+            _ => todo!("getting the address from this level: {}", level)
+        }
     }
 
     /// Set the address.
-    pub fn set_addr(&mut self, addr: PhysAddr) {
-        *self = Entry::new_internal(addr, self.flags());
+    pub fn set_addr(&mut self, _addr: PhysAddr) {
+        todo!("setting the address on aarch64 depends on the level")
     }
 
     /// Clear the entry.
     pub fn clear(&mut self) {
-        todo!()
+        todo!("clear")
     }
 
     /// Get the flags.
@@ -69,25 +103,114 @@ impl Entry {
     }
 
     /// Set the flags.
-    pub fn set_flags(&mut self, flags: EntryFlags) {
-        *self = Entry::new_internal(self.addr(), flags);
+    pub fn set_flags(&mut self, _flags: EntryFlags) {
+        todo!("setting the flags on aarch64 depends on the level")
+    }
+
+    const NEXT_LVL_TABLE_ADDR_MASK: u64 = 0x0000_FFFF_FFFF_F000;
+
+    /// Get the base address of the next page table.
+    pub fn table_addr(&self) -> PhysAddr {
+        // aarch64 next level table address bits [47:12]
+        // bits [47:12] map to table address [47:12]
+        // this is true for a 4 KiB translation granule
+        // with 48-bit addressing
+        PhysAddr::new(self.0 & Self::NEXT_LVL_TABLE_ADDR_MASK).unwrap()
     }
 }
 
-// TODO:
 bitflags::bitflags! {
     /// The possible flags in an AArch64 page table entry.
     pub struct EntryFlags: u64 {
-        const PRESENT = 0;
-        const WRITE = 0;
-        const USER = 0;
+        /// Indicates if the entry is valid
+        const PRESENT = 1 << 0;
+        /// Indicates if this entry is a Table/Huge Page at a given level.
+        const TABLE_OR_HUGE_PAGE = 1 << 1;
+        
+        // Here we are assuming bit flags that corrspond to the upper/lower
+        // attributes found in a block/page descriptor in a stage 1 translation.
+
+        // Lower Attributes
+        
+        // AttrIndx[2:0] (deals with cache type)
+        //
+        // Since the bitflags type only maps to a single flag
+        // and not a range (bits [4:2]), we encode each bit from
+        // AttrIndex so that its value is saved when calling
+        // `from_bits_truncate`
+        
+        /// AttrIndx bit 0.
+        const ATTR_INDX_0 =  1 << 2;
+        /// AttrIndx bit 1.
+        const ATTR_INDX_1 =  1 << 3;
+        /// AttrIndx bit 2.
+        const ATTR_INDX_2 =  1 << 4;
+
+        /// The output address of a descriptor is to non-secure memory.
+        const NS = 1 << 5;
+        
+        // [7:6] => AP[2:1] 
+        //   - data Access Permissions bits (AP[2:1]).
+        //   - AP[2]: read only / read/write access
+        //   - AP[1]: EL0/app control or priviledged exception level
+        //   - AP[1]=0, no data access at EL0; AP[1]=1, EL0 access with AP[2] permissions
+        
+        /// Access permission bit 1: User accessible/kernel only.
+        const AP1_USER_OR_KERNEL = 1 << 6;
+        /// Access permission bit 2: Read only or read-write permission.
+        const AP2_READ_OR_RW = 1 << 7;
+
+        // [9:8] => OA[51:50]
+        //   - if the Effective value of TCR_Elx.DS is 1.
+
+        // [10] => AF
+        //   - access flag, memory region accessed since last set to 0
+        //   - descriptors with AF set to 0 cannot be cached in TLB
+        //   - either managed by hw or sw, depending on FEAT_HAFDBS
+
+        /// Indicates if memory has been accessed since last set to 0.
+        /// The flag might be managed by either hardware or software.
+        const ACCESS = 1 << 10;
+        
+        // [11] => nG
+        //   - not global bit (nG).
+        //   - for translations that use ASID
+        /// Indicates if the mapping is not global.
+        const NOT_GLOBAL = 1 << 11;
+
+        // [15:12] => OA (block descriptor bits)
+        //   - RES0 if FEAT_LPA is not implemented
+        // [16] => nT
+        //   - If FEAT_BBM is not implemented
+        //   - when changing block size accesses do not break coherency
+
+        // Upper Attributes
+        
+        // [50] => GP
+        //   - If FEAT_BTI is implemented, then Gaurd page for stage 1
+        // [51] => DBM
+        //   - RES0 if FEAT_HAFDBS is not implemented.
+        //   - Dirty Bit Modifier. Hw managed dirty state
+        // [52] => Contiguous
+        //   - descr. belongs to group of adj entries that point to contig OA
+
+        // [53] => PXN
+        //   - RES0 for a translation regime that cannot apply to execution at EL0.
+        //   - priviledged execute never
+        /// PXN bit: Priviledged execute-never.
+        const KERNEL_NO_EXECUTE = 1 << 53;
+        // [54] => UXN or XN
+        //   - UXN for a translation regime that can apply to execution at EL0, otherwise XN.
+        /// UXN bit: Unpriviledged execute-never.
+        const USER_NO_EXECUTE = 1 << 54;
+
+        // [58:55] => Ignored/Reserved for software use
+        // [62:59] => PBHA
+        //   - IGNORED if FEAT_HPDS2 is not implemented
+        //   - Page based hardware attributes
+        // [63] => Ignored
         const WRITE_THROUGH = 0;
         const CACHE_DISABLE = 0;
-        const ACCESSED = 0;
-        const DIRTY = 0;
-        const HUGE_PAGE = 0;
-        const GLOBAL = 0;
-        const NO_EXECUTE = 0;
     }
 }
 
@@ -100,10 +223,11 @@ impl EntryFlags {
     /// Extract the [MappingFlags].
     pub fn flags(&self) -> MappingFlags {
         let mut flags = MappingFlags::empty();
-        if self.contains(EntryFlags::GLOBAL) {
+        // TODO: do we need to check if we are using ASIDs?
+        if !self.contains(EntryFlags::NOT_GLOBAL) {
             flags.insert(MappingFlags::GLOBAL);
         }
-        if self.contains(EntryFlags::USER) {
+        if self.contains(EntryFlags::AP1_USER_OR_KERNEL) {
             flags.insert(MappingFlags::USER);
         }
         flags
@@ -111,12 +235,13 @@ impl EntryFlags {
 
     /// Get the represented permissions as a [Protections].
     pub fn perms(&self) -> Protections {
-        let rw = if self.contains(Self::WRITE) {
-            Protections::WRITE | Protections::READ
-        } else {
+        let rw = if self.contains(Self::AP2_READ_OR_RW) {
             Protections::READ
+        } else {
+            Protections::WRITE | Protections::READ
         };
-        let ex = if self.contains(Self::NO_EXECUTE) {
+        // TODO: decide on more sophisitcated execution permissions
+        let ex = if self.contains(Self::KERNEL_NO_EXECUTE) || self.contains(Self::USER_NO_EXECUTE) {
             Protections::empty()
         } else {
             Protections::EXEC
@@ -126,48 +251,109 @@ impl EntryFlags {
 
     /// Retrieve the [CacheType].
     pub fn cache_type(&self) -> CacheType {
-        if self.contains(Self::CACHE_DISABLE) {
-            CacheType::Uncacheable
-        } else if self.contains(Self::WRITE_THROUGH) {
-            CacheType::WriteThrough
-        } else {
-            CacheType::WriteBack
+        // The cache type depends on the type of memory
+        // assigned to this entry which is indicated by
+        // the AttrIndex field. This is used to index into the
+        // MAIR_EL1 register
+
+        // Get the attribute index of the entry
+        // bits [4:2] => AttrIndex[2:0]
+        let i = (self.bits() >> 2) & 0b111;
+
+        // we have to read the MAIR register to determine
+        // the properties of this mapped memory
+        let mair = MAIR_EL1.get(); // the raw value
+
+        // get the attribute based on the index
+        const MAIR_LEN: u64 = 8;
+        const MAIR_MASK: u64 = 0xFF;
+        let attr = (mair >> (i * MAIR_LEN))  & MAIR_MASK;
+
+        // match the attribute to the cache type
+        let cache: InMemoryRegister<u64, MAIR_EL1::Register> = InMemoryRegister::new(attr);
+
+        // NOTE: transient is basically a hint to the cacheing system
+        // so we can place it in the same class as other non-transient
+        // memory in this case
+        match cache.read_as_enum(MAIR_EL1::Attr0_Normal_Outer) {
+            // is this device memory or uncacheable memory?
+            Some(MAIR_EL1::Attr0_Normal_Outer::Value::Device) 
+                | Some(MAIR_EL1::Attr0_Normal_Outer::Value::NonCacheable) => CacheType::Uncacheable,
+            // is this memory write-through?
+            Some(MAIR_EL1::Attr0_Normal_Outer::Value::WriteThrough_Transient_WriteAlloc)
+                | Some(MAIR_EL1::Attr0_Normal_Outer::Value::WriteThrough_Transient_ReadAlloc)
+                | Some(MAIR_EL1::Attr0_Normal_Outer::Value::WriteThrough_Transient_ReadWriteAlloc)
+                | Some(MAIR_EL1::Attr0_Normal_Outer::Value::WriteThrough_NonTransient)
+                | Some(MAIR_EL1::Attr0_Normal_Outer::Value::WriteThrough_NonTransient_WriteAlloc)
+                | Some(MAIR_EL1::Attr0_Normal_Outer::Value::WriteThrough_NonTransient_ReadAlloc)
+                | Some(MAIR_EL1::Attr0_Normal_Outer::Value::WriteThrough_NonTransient_ReadWriteAlloc) => CacheType::WriteThrough,
+            // is this memory write-back?
+            Some(MAIR_EL1::Attr0_Normal_Outer::Value::WriteBack_Transient_WriteAlloc)
+                | Some(MAIR_EL1::Attr0_Normal_Outer::Value::WriteBack_Transient_ReadAlloc)
+                | Some(MAIR_EL1::Attr0_Normal_Outer::Value::WriteBack_Transient_ReadWriteAlloc)
+                | Some(MAIR_EL1::Attr0_Normal_Outer::Value::WriteBack_NonTransient)
+                | Some(MAIR_EL1::Attr0_Normal_Outer::Value::WriteBack_NonTransient_WriteAlloc)
+                | Some(MAIR_EL1::Attr0_Normal_Outer::Value::WriteBack_NonTransient_ReadAlloc)
+                | Some(MAIR_EL1::Attr0_Normal_Outer::Value::WriteBack_NonTransient_ReadWriteAlloc) => CacheType::WriteBack,
+            None => todo!("unrecognized cache type"),
         }
     }
 
     /// Get the set of flags to use for an intermediate (page table) entry.
     pub fn intermediate() -> Self {
-        Self::USER | Self::WRITE | Self::PRESENT
+        todo!("intermediate flags")
     }
 
     /// Get the flags needed to indicate a huge page.
     pub fn huge() -> Self {
-        Self::HUGE_PAGE
+        todo!("huge page flags")
+    }
+}
+
+impl From<CacheType> for EntryFlags {
+    fn from(cache: CacheType) -> Self {
+        // TODO: actually read the MAIR register, and see if 
+        // cache type matches an index, or maybe we statically assign
+        // certian entries in mair to a particular memory type
+
+        // TODO: differentiate between normal and device memory
+
+        // unsupported cache types result in `EntryFlags::empty()`
+        // in this, it defaults to normal cacheble memory (index 0)
+        let attr_idx = match cache {
+            CacheType::WriteBack | _ => 0,
+        };
+
+        // convert the numerical index to a set of flags
+        // AttrIndx[2:0] is mapped to EntryFlags bits [4:2]
+        EntryFlags::from_bits_truncate(attr_idx << 2)
     }
 }
 
 impl From<&MappingSettings> for EntryFlags {
     fn from(settings: &MappingSettings) -> Self {
-        let c = match settings.cache() {
-            CacheType::WriteBack => EntryFlags::empty(),
-            CacheType::WriteThrough => EntryFlags::WRITE_THROUGH,
-            CacheType::WriteCombining => EntryFlags::empty(),
-            CacheType::Uncacheable => EntryFlags::CACHE_DISABLE,
-        };
+        // here 0/EntryFlags::empty() is a valid memory type
+        // so even if we do not support a certain type of memory, 
+        // it gets set as the default (WriteBack)
+        let c = EntryFlags::from(settings.cache());
+
         let mut p = EntryFlags::empty();
-        if settings.perms().contains(Protections::WRITE) {
-            p |= EntryFlags::WRITE;
+        if !settings.perms().contains(Protections::WRITE) {
+            // set this flag if we only want read-only permissions
+            // in other words, do not set if we desire write permissions
+            p |= EntryFlags::AP2_READ_OR_RW;
         }
         if !settings.perms().contains(Protections::EXEC) {
-            p |= EntryFlags::NO_EXECUTE;
+            p |= EntryFlags::KERNEL_NO_EXECUTE | EntryFlags::USER_NO_EXECUTE;
         }
         let f = if settings.flags().contains(MappingFlags::GLOBAL) {
-            EntryFlags::GLOBAL
-        } else {
+            // pages are global if we do not set this flag
             EntryFlags::empty()
+        } else {
+            EntryFlags::NOT_GLOBAL
         };
         let u = if settings.flags().contains(MappingFlags::USER) {
-            EntryFlags::USER
+            EntryFlags::AP1_USER_OR_KERNEL
         } else {
             EntryFlags::empty()
         };

--- a/src/kernel/src/arch/aarch64/memory/pagetables/entry.rs
+++ b/src/kernel/src/arch/aarch64/memory/pagetables/entry.rs
@@ -209,8 +209,6 @@ bitflags::bitflags! {
         //   - IGNORED if FEAT_HPDS2 is not implemented
         //   - Page based hardware attributes
         // [63] => Ignored
-        const WRITE_THROUGH = 0;
-        const CACHE_DISABLE = 0;
     }
 }
 

--- a/src/kernel/src/arch/aarch64/memory/pagetables/table.rs
+++ b/src/kernel/src/arch/aarch64/memory/pagetables/table.rs
@@ -1,5 +1,8 @@
 use core::ops::{Index, IndexMut};
 
+use arm64::registers::TTBR1_EL1;
+use registers::interfaces::Readable;
+
 use crate::{arch::address::VirtAddr, memory::PhysAddr};
 
 use super::Entry;
@@ -11,27 +14,54 @@ pub struct Table {
 }
 
 impl Table {
-    // TODO:
     /// The number of entries in this table.
-    pub const PAGE_TABLE_ENTRIES: usize = 2;
+    ///
+    /// The number of entries on aarch64 depends on the translation granule size
+    /// In this case we are going with a 4 KiB page size, so we have 512 entries
+    /// at each level.
+    pub const PAGE_TABLE_ENTRIES: usize = 512;
+
+    /// The level of the last level page table.
+    ///
+    /// This depends on the translation granule size for aarch64.
+    /// A 4 KiB translation size results in 4 level page tables (0-3)
+    const MAX_LEVEL: usize = 3;
+
+    /// The top level of the first page table in address translation.
+    ///
+    /// For 4 KiB pages, this means we start at stage 0/level 0 in the translation
+    /// process. We assume that we are using 48-bits of address space.
+    const TOP_LEVEL: usize = 0;
+
+    /// The mask for indices encoded into a virtual address
+    const INDEX_MASK: usize = 0x1FF;
 
     /// Get the current root table.
     pub fn current() -> PhysAddr {
-        todo!()
+        // Here we assume that we need the higher half of
+        // the address space (kernel). This is only used to bootstrap
+        // memory management. So we ignore TTBR0_EL1 which is for the
+        // lower half.
+        let ttbr1 = TTBR1_EL1.get();
+        PhysAddr::new(ttbr1).unwrap()
     }
 
     /// The top level of a complete set of page tables.
     pub fn top_level() -> usize {
-        // TODO: support 5-level paging
-        todo!()
+        Self::TOP_LEVEL
     }
 
     /// Does this system support mapping a huge page at this level?
     pub fn can_map_at_level(level: usize) -> bool {
+        // huge pages, meaning larger than 4KiB (2MiB, 1GiB)
+        // Seems like ARM does have huge pages, at certan levels
         match level {
-            0 => true,
+            // check if TCR_EL0.DS is 1 (52-bit addr space)
+            // if so then we can support 512 GiB at level 0
+
+            // 1 GiB
             1 => true,
-            // TODO: check cpuid
+            // 2 MiB
             2 => true,
             _ => false,
         }
@@ -43,28 +73,45 @@ impl Table {
     /// this function may choose to do something clever, like store the count in the available bits. But it could also
     /// make this function a no-op, and make [Table::read_count] just count the entries.
     pub fn set_count(&mut self, _count: usize) {
-        // NOTE: this function doesn't need cache line or TLB flushing because the hardware never reads these bits.
-        todo!()
+        // for now let's make this a no-op
+        // the pt entries on arm does have some spare bits
     }
 
     /// Read the current count of used entries.
     pub fn read_count(&self) -> usize {
-        todo!()
+        todo!("read count")
     }
 
     /// Is this a leaf (a huge page or page aligned) at a given level
     pub fn is_leaf(_addr: VirtAddr, _level: usize) -> bool {
-        todo!()
+        todo!("is_leaf")
     }
 
     /// Get the index for the next table for an address.
-    pub fn get_index(_addr: VirtAddr, _level: usize) -> usize {
-        todo!()
+    pub fn get_index(addr: VirtAddr, level: usize) -> usize {
+        // for a 4kib translation granule, a virtual address
+        // is cut up int 5 pieces. This means that each
+        // index is 9 address bits, with the first 12 bits
+        // being a part of the block offset/physical address
+        usize::from(addr) >> (9 * (Self::MAX_LEVEL - level) + 12) & Self::INDEX_MASK
     }
 
     /// Get the page size of a given level.
-    pub fn level_to_page_size(_level: usize) -> usize {
-        todo!()
+    pub fn level_to_page_size(level: usize) -> usize {
+        // frame size * num entries ** (3-level)
+        1 << (12 + 9 * (Self::MAX_LEVEL - level)) 
+    }
+
+    /// Get the level of the last page table.
+    pub fn last_level() -> usize {
+        Self::MAX_LEVEL
+    }
+
+    /// Get the value of the next level given the current level.
+    pub fn next_level(level: usize) -> usize {
+        // the levels of page tables on aarch64 begin with 0
+        // and then increment from there
+        level + 1
     }
 }
 

--- a/src/kernel/src/arch/amd64/memory/pagetables/entry.rs
+++ b/src/kernel/src/arch/amd64/memory/pagetables/entry.rs
@@ -56,7 +56,7 @@ impl Entry {
     }
 
     /// Address contained in the [Entry].
-    pub fn addr(&self) -> PhysAddr {
+    pub fn addr(&self, _level: usize) -> PhysAddr {
         PhysAddr::new(self.0 & 0x000f_ffff_ffff_f000).unwrap()
     }
 
@@ -78,7 +78,12 @@ impl Entry {
 
     /// Set the flags.
     pub fn set_flags(&mut self, flags: EntryFlags) {
-        *self = Entry::new_internal(self.addr(), flags);
+        *self = Entry::new_internal(self.addr(0), flags);
+    }
+
+    /// Get the base address of the next page table.
+    pub fn table_addr(&self) -> PhysAddr {
+        self.addr(0)
     }
 }
 

--- a/src/kernel/src/arch/amd64/memory/pagetables/table.rs
+++ b/src/kernel/src/arch/amd64/memory/pagetables/table.rs
@@ -14,6 +14,12 @@ impl Table {
     /// The number of entries in this table.
     pub const PAGE_TABLE_ENTRIES: usize = 512;
 
+    /// The top level of a set of page tables.
+    const TOP_LEVEL: usize = 3;
+
+    /// The last level of a set of page tables.
+    const LAST_LEVEL: usize = 0;
+
     /// Get the current root table.
     pub fn current() -> PhysAddr {
         let cr3 = unsafe { x86::controlregs::cr3() };
@@ -23,7 +29,7 @@ impl Table {
     /// The top level of a complete set of page tables.
     pub fn top_level() -> usize {
         // TODO: support 5-level paging
-        3
+        Self::TOP_LEVEL
     }
 
     /// Does this system support mapping a huge page at this level?
@@ -65,7 +71,7 @@ impl Table {
 
     /// Is this a leaf (a huge page or page aligned) at a given level
     pub fn is_leaf(addr: VirtAddr, level: usize) -> bool {
-        level == 0 || addr.is_aligned_to(1 << (12 + 9 * level))
+        level == Self::LAST_LEVEL || addr.is_aligned_to(1 << (12 + 9 * level))
     }
 
     /// Get the index for the next table for an address.
@@ -76,15 +82,17 @@ impl Table {
 
     /// Get the page size of a given level.
     pub fn level_to_page_size(level: usize) -> usize {
-        if level > 3 {
+        if level > Self::TOP_LEVEL {
             panic!("invalid level");
         }
+        // frame size * (num entries) ^ level
+        // 4096 * 512 ^ (level)
         1 << (12 + 9 * level)
     }
 
     /// Get the level of the last page table.
     pub fn last_level() -> usize {
-        0
+        Self::LAST_LEVEL
     }
 
     /// Get the value of the next level given the current level.

--- a/src/kernel/src/arch/amd64/memory/pagetables/table.rs
+++ b/src/kernel/src/arch/amd64/memory/pagetables/table.rs
@@ -81,6 +81,16 @@ impl Table {
         }
         1 << (12 + 9 * level)
     }
+
+    /// Get the level of the last page table.
+    pub fn last_level() -> usize {
+        0
+    }
+
+    /// Get the value of the next level given the current level.
+    pub fn next_level(level: usize) -> usize {
+        level - 1
+    }
 }
 
 impl Index<usize> for Table {

--- a/src/kernel/src/memory/pagetables/table.rs
+++ b/src/kernel/src/memory/pagetables/table.rs
@@ -17,7 +17,7 @@ impl Table {
         if !entry.is_present() || entry.is_huge() {
             return None;
         }
-        let addr = entry.addr().kernel_vaddr();
+        let addr = entry.table_addr().kernel_vaddr();
         unsafe { Some(&mut *(addr.as_mut_ptr::<Table>())) }
     }
 
@@ -26,7 +26,7 @@ impl Table {
         if !entry.is_present() || entry.is_huge() {
             return None;
         }
-        let addr = entry.addr().kernel_vaddr();
+        let addr = entry.table_addr().kernel_vaddr();
         unsafe { Some(&*(addr.as_ptr::<Table>())) }
     }
 
@@ -35,7 +35,7 @@ impl Table {
         if !entry.is_present() || entry.is_huge() {
             return None;
         }
-        let addr: u64 = entry.addr().into();
+        let addr: u64 = entry.table_addr().into();
         get_frame(PhysAddr::new(addr).unwrap())
     }
 
@@ -215,7 +215,7 @@ impl Table {
             let entry = &mut self[idx];
             let is_present = entry.is_present();
             let is_huge = entry.is_huge();
-            let addr = entry.addr();
+            let addr = entry.addr(level);
 
             if is_present && (is_huge || level == 0) {
                 self.update_entry(
@@ -253,7 +253,7 @@ impl Table {
         if entry.is_present() && (entry.is_huge() || level == 0) {
             Ok(MapInfo::new(
                 cursor.start(),
-                entry.addr(),
+                entry.addr(level),
                 entry.flags().settings(),
                 Self::level_to_page_size(level),
             ))

--- a/src/kernel/src/memory/pagetables/table.rs
+++ b/src/kernel/src/memory/pagetables/table.rs
@@ -148,7 +148,7 @@ impl Table {
                 assert_ne!(level, Self::last_level());
                 self.populate(idx, EntryFlags::intermediate());
                 let next_table = self.next_table_mut(idx).unwrap();
-                next_table.map(consist, cursor, Self:;next_level(level), phys, settings);
+                next_table.map(consist, cursor, Self::next_level(level), phys, settings);
             }
 
             if let Some(next) = cursor.align_advance(Self::level_to_page_size(level)) {

--- a/src/kernel/src/memory/pagetables/table.rs
+++ b/src/kernel/src/memory/pagetables/table.rs
@@ -115,7 +115,7 @@ impl Table {
         for idx in start_index..Table::PAGE_TABLE_ENTRIES {
             let entry = &mut self[idx];
 
-            if entry.is_present() && (entry.is_huge() || level == 0) {
+            if entry.is_present() && (entry.is_huge() || level == Self::last_level()) {
                 phys.consume(Self::level_to_page_size(level));
                 if let Some(next) = cursor.align_advance(Self::level_to_page_size(level)) {
                     cursor = next;
@@ -133,7 +133,7 @@ impl Table {
                     Entry::new(
                         paddr.0,
                         EntryFlags::from(settings)
-                            | if level != 0 {
+                            | if level != Self::last_level() {
                                 EntryFlags::huge()
                             } else {
                                 EntryFlags::empty()
@@ -145,10 +145,10 @@ impl Table {
                 );
                 phys.consume(Self::level_to_page_size(level));
             } else {
-                assert_ne!(level, 0);
+                assert_ne!(level, Self::last_level());
                 self.populate(idx, EntryFlags::intermediate());
                 let next_table = self.next_table_mut(idx).unwrap();
-                next_table.map(consist, cursor, level - 1, phys, settings);
+                next_table.map(consist, cursor, Self:;next_level(level), phys, settings);
             }
 
             if let Some(next) = cursor.align_advance(Self::level_to_page_size(level)) {
@@ -169,7 +169,7 @@ impl Table {
         for idx in start_index..Table::PAGE_TABLE_ENTRIES {
             let entry = &mut self[idx];
 
-            if entry.is_present() && (entry.is_huge() || level == 0) {
+            if entry.is_present() && (entry.is_huge() || level == Self::last_level()) {
                 self.update_entry(
                     consist,
                     idx,
@@ -178,10 +178,10 @@ impl Table {
                     true,
                     level,
                 );
-            } else if entry.is_present() && level != 0 {
+            } else if entry.is_present() && level != Self::last_level() {
                 let next_table = self.next_table_mut(idx).unwrap();
-                next_table.unmap(consist, cursor, level - 1);
-                if next_table.read_count() == 0 && level < Table::top_level() {
+                next_table.unmap(consist, cursor, Self::next_level(level));
+                if next_table.read_count() == 0 && level != Table::top_level() {
                     // Unwrap-Ok: The entry is present, and not a leaf, so it must be a table.
                     consist.free_frame(self.next_table_frame(idx).unwrap());
                     self.update_entry(
@@ -217,14 +217,14 @@ impl Table {
             let is_huge = entry.is_huge();
             let addr = entry.addr(level);
 
-            if is_present && (is_huge || level == 0) {
+            if is_present && (is_huge || level == Self::last_level()) {
                 self.update_entry(
                     consist,
                     idx,
                     Entry::new(
                         addr,
                         EntryFlags::from(settings)
-                            | if level != 0 {
+                            | if level != Self::last_level() {
                                 EntryFlags::huge()
                             } else {
                                 EntryFlags::empty()
@@ -234,9 +234,9 @@ impl Table {
                     true,
                     level,
                 );
-            } else if is_present && level != 0 {
+            } else if is_present && level != Self::last_level() {
                 let next_table = self.next_table_mut(idx).unwrap();
-                next_table.change(consist, cursor, level - 1, settings);
+                next_table.change(consist, cursor, Self::next_level(level), settings);
             }
 
             if let Some(next) = cursor.align_advance(Self::level_to_page_size(level)) {
@@ -250,16 +250,16 @@ impl Table {
     pub(super) fn readmap(&self, cursor: &MappingCursor, level: usize) -> Result<MapInfo, usize> {
         let index = Self::get_index(cursor.start(), level);
         let entry = &self[index];
-        if entry.is_present() && (entry.is_huge() || level == 0) {
+        if entry.is_present() && (entry.is_huge() || level == Self::last_level()) {
             Ok(MapInfo::new(
                 cursor.start(),
                 entry.addr(level),
                 entry.flags().settings(),
                 Self::level_to_page_size(level),
             ))
-        } else if entry.is_present() && level != 0 {
+        } else if entry.is_present() && level != Self::last_level() {
             let next_table = self.next_table(index).unwrap();
-            next_table.readmap(cursor, level - 1)
+            next_table.readmap(cursor, Self::next_level(level))
         } else {
             Err(Table::level_to_page_size(level))
         }


### PR DESCRIPTION
This PR implements part of the paging system which deals with reading the memory mappings created by the bootloader. It assumes, for now, that the hardware supports a 4 KiB translation table granule and that the bootloader uses this granule size to set up our initial page tables.

The biggest change is a slight modification of the APIs between the aarch specific code and the generic code for memory management. Specifically to determine certain properties (i.e., physical address) in a PTE for aarch64, we need to know what level we are at. For x86_64 this is a different story, and the bits in the PTE corresponding to the physical address are more/less in the same.

# Summary
- code required to read the page table entries
- define the page table structure for 4 KiB pages
- cleanup code (comments, organize address, etc.)