### PR TITLE
Implement page table map operation for aarch64

### DIFF
--- a/src/kernel/src/arch/aarch64/address.rs
+++ b/src/kernel/src/arch/aarch64/address.rs
@@ -249,7 +249,7 @@ impl PhysAddr {
     }
 
     pub fn kernel_vaddr(&self) -> VirtAddr {
-        phys_to_virt(*self) // maybe???
+        phys_to_virt(*self)
     }
 
     pub fn offset<U: Into<Offset>>(&self, offset: U) -> Result<Self, NonCanonical> {

--- a/src/kernel/src/arch/aarch64/context.rs
+++ b/src/kernel/src/arch/aarch64/context.rs
@@ -1,20 +1,54 @@
+use arm64::registers::{TTBR0_EL1, TTBR1_EL1};
+
 use crate::{
-    // arch::memory::pagetables::{Entry, EntryFlags},
+    arch::memory::pagetables::{Entry, EntryFlags, Table},
     memory::{
-        // frame::{alloc_frame, PhysicalFrameFlags},
+        frame::{alloc_frame, PhysicalFrameFlags},
         pagetables::{
-            DeferredUnmappingOps, MapReader, MappingCursor, MappingSettings,
+            DeferredUnmappingOps, Mapper, MapReader, MappingCursor, MappingSettings,
             PhysAddrProvider,
         },
+        PhysAddr,
     },
-    // mutex::Mutex,
-    // spinlock::Spinlock,
+    mutex::Mutex,
+    spinlock::Spinlock,
 };
 
 // this does not need to be pub
-pub struct ArchContextInner;
+pub struct ArchContextInner {
+    // we have a single mapper that covers one part of the address space
+    mapper: Mapper,
+}
+pub struct ArchContext {
+    kernel: u64, // TODO
+    user: PhysAddr,
+    inner: Mutex<ArchContextInner>,
+}
 
-pub struct ArchContext;
+// default kernel mapper that is shared among all kernel instances of ArchContext
+lazy_static::lazy_static! {
+    static ref KERNEL_MAPPER: Spinlock<Mapper> = {
+        let mut m = Mapper::new(
+            // allocate a new physical page frame to hold the
+            // data for the page table root
+            alloc_frame(PhysicalFrameFlags::ZEROED).start_address()
+        );
+        // initialize half of the page table entries
+        for idx in (Table::PAGE_TABLE_ENTRIES/2)..Table::PAGE_TABLE_ENTRIES {
+            // write out PT entries for a top level table
+            // whose entries point to another zeroed page
+            m.set_top_level_table(idx, 
+                Entry::new(
+                    alloc_frame(PhysicalFrameFlags::ZEROED)
+                        .start_address(), 
+                    // intermediate here means another page table
+                    EntryFlags::intermediate()
+                )
+            );
+        }
+        Spinlock::new(m)
+    };
+}
 
 impl Default for ArchContext {
     fn default() -> Self {
@@ -23,26 +57,56 @@ impl Default for ArchContext {
 }
 
 impl ArchContext {
+    /// Construct a new context for the kernel.
     pub fn new_kernel() -> Self {
-        Self::new()
+        let inner = ArchContextInner::new();
+        Self {
+            kernel: KERNEL_MAPPER.lock().root_address().raw(),
+            user: inner.mapper.root_address(),
+            inner: Mutex::new(inner),
+        }
     }
 
     pub fn new() -> Self {
-        Self {}
+        todo!("ArchContext::new")
     }
 
     #[allow(named_asm_labels)]
     pub fn switch_to(&self) {
-        todo!("switch_to")
+        // TODO: make sure the TTBR1_EL1 switch only happens once
+        // write TTBR1
+        TTBR1_EL1.set_baddr(self.kernel);
+        // write TTBR0
+        TTBR0_EL1.set_baddr(self.user.raw());
+        unsafe { 
+            core::arch::asm!(
+                // ensure that all previous instructions have completed
+                "isb",
+                // invalidate all tlb entries (locally)
+                "tlbi vmalle1",
+                // ensure tlb invalidation completes
+                "dsb nsh",
+                // ensure dsb instruction completes
+                "isb",
+            );
+        }
     }
 
     pub fn map(
         &self,
-        _cursor: MappingCursor,
-        _phys: &mut impl PhysAddrProvider,
-        _settings: &MappingSettings,
+        cursor: MappingCursor,
+        phys: &mut impl PhysAddrProvider,
+        settings: &MappingSettings,
     ) {
-        todo!("map")
+        // decide if this goes into the global kernel mappings, or
+        // the local per-context mappings
+        if cursor.start().is_kernel() {
+            // upper half addresses go to TTBR1_EL1
+            KERNEL_MAPPER.lock().map(cursor, phys, settings);
+        } else {
+            // lower half addresses go to TTBR0_EL1
+            self.inner.lock().map(cursor, phys, settings);
+        }
     }
 
     pub fn change(&self, _cursor: MappingCursor, _settings: &MappingSettings) {
@@ -60,16 +124,21 @@ impl ArchContext {
 
 impl ArchContextInner {
     fn new() -> Self {
-        todo!()
+        // we need to create a new mapper object by allocating 
+        // some memory for the page table.
+        let mapper = Mapper::new(
+            alloc_frame(PhysicalFrameFlags::ZEROED).start_address()
+        );
+        Self { mapper }
     }
 
     fn map(
         &mut self,
-        _cursor: MappingCursor,
-        _phys: &mut impl PhysAddrProvider,
-        _settings: &MappingSettings,
+        cursor: MappingCursor,
+        phys: &mut impl PhysAddrProvider,
+        settings: &MappingSettings,
     ) {
-        todo!()
+        self.mapper.map(cursor, phys, settings);
     }
 
     fn change(&mut self, _cursor: MappingCursor, _settings: &MappingSettings) {

--- a/src/kernel/src/arch/aarch64/memory/pagetables/table.rs
+++ b/src/kernel/src/arch/aarch64/memory/pagetables/table.rs
@@ -63,6 +63,8 @@ impl Table {
             1 => true,
             // 2 MiB
             2 => true,
+            // semantically does not make sense, see note from other, etc.
+            3 => true, // but technically allowed to map here
             _ => false,
         }
     }
@@ -79,7 +81,13 @@ impl Table {
 
     /// Read the current count of used entries.
     pub fn read_count(&self) -> usize {
-        todo!("read count")
+        let mut count = 0;
+        for entry in self.entries {
+            if entry.is_present() {
+                count += 1;
+            }
+        }
+        count
     }
 
     /// Is this a leaf (a huge page or page aligned) at a given level

--- a/src/kernel/src/arch/aarch64/processor.rs
+++ b/src/kernel/src/arch/aarch64/processor.rs
@@ -46,5 +46,7 @@ impl Processor {
 }
 
 pub fn tls_ready() -> bool {
-    todo!()
+    // TODO: initlialize tls
+    // see TPIDR_EL1
+    false
 }

--- a/src/kernel/src/arch/amd64/memory/pagetables/entry.rs
+++ b/src/kernel/src/arch/amd64/memory/pagetables/entry.rs
@@ -157,6 +157,11 @@ impl EntryFlags {
     pub fn huge() -> Self {
         Self::HUGE_PAGE
     }
+
+    /// Get the flags needed to indacate a leaf (i.e. page)
+    pub fn leaf() -> Self {
+        EntryFlags::empty()
+    }
 }
 
 impl From<&MappingSettings> for EntryFlags {

--- a/src/kernel/src/memory/context/virtmem.rs
+++ b/src/kernel/src/memory/context/virtmem.rs
@@ -191,11 +191,11 @@ impl VirtContext {
         // the call to prep_smp later.
         let id_len = 0x100000000; // 4GB
         let cursor = MappingCursor::new(
-            VirtAddr::new(Table::level_to_page_size(0).try_into().unwrap()).unwrap(),
+            VirtAddr::new(Table::level_to_page_size(Table::last_level()).try_into().unwrap()).unwrap(),
             id_len,
         );
         let mut phys = ContiguousProvider::new(
-            PhysAddr::new(Table::level_to_page_size(0).try_into().unwrap()).unwrap(),
+            PhysAddr::new(Table::level_to_page_size(Table::last_level()).try_into().unwrap()).unwrap(),
             id_len,
         );
         let settings = MappingSettings::new(

--- a/src/kernel/src/memory/pagetables/table.rs
+++ b/src/kernel/src/memory/pagetables/table.rs
@@ -85,7 +85,6 @@ impl Table {
             .settings()
             .flags()
             .contains(MappingFlags::GLOBAL);
-
         *entry = new_entry;
         let entry_addr = VirtAddr::from(entry as *const _);
         consist.flush(entry_addr);
@@ -136,7 +135,7 @@ impl Table {
                             | if level != Self::last_level() {
                                 EntryFlags::huge()
                             } else {
-                                EntryFlags::empty()
+                                EntryFlags::leaf()
                             },
                     ),
                     cursor.start(),
@@ -227,7 +226,7 @@ impl Table {
                             | if level != Self::last_level() {
                                 EntryFlags::huge()
                             } else {
-                                EntryFlags::empty()
+                                EntryFlags::leaf()
                             },
                     ),
                     cursor.start(),


### PR DESCRIPTION
This patch implements the map operation outlined by the generic page table APIs. It adds some additional functionality to the interface, which requires minimal changes (see the `leaf` function). So at this point we are able to successfully copy the existing mappings set up by the bootloader (which is how Twizzler boots) and also map in new pages.

In summary (aarch64 specific):

- Additional bit flags for page table entries
- More verbose exception handling
- Implement page table entry consistency
- Implement generic map operation
