### PR TITLE
Implement IRQ handling for aarch64

### DIFF
--- a/src/kernel/src/arch/aarch64/address.rs
+++ b/src/kernel/src/arch/aarch64/address.rs
@@ -244,7 +244,7 @@ impl PhysAddr {
     ///
     /// # Safety
     /// The provided address must be a valid address.
-    pub unsafe fn new_unchecked(addr: u64) -> Self {
+    pub const unsafe fn new_unchecked(addr: u64) -> Self {
         Self(addr)
     }
 

--- a/src/kernel/src/arch/aarch64/cntp.rs
+++ b/src/kernel/src/arch/aarch64/cntp.rs
@@ -2,12 +2,12 @@
 /// This timer is local to a single core, and timestamps
 /// are synchronized to a global system timer count
 
-use arm64::registers::{CNTFRQ_EL0, CNTPCT_EL0};
-use registers::interfaces::Readable;
+use arm64::registers::{CNTFRQ_EL0, CNTPCT_EL0, CNTP_CTL_EL0, CNTP_TVAL_EL0};
+use registers::interfaces::{Readable, Writeable, ReadWriteable};
 
 use crate::time::{ClockHardware, Ticks};
 
-use twizzler_abi::syscall::{ClockFlags, ClockInfo, FemtoSeconds, TimeSpan};
+use twizzler_abi::syscall::{ClockFlags, ClockInfo, FemtoSeconds, TimeSpan, FEMTOS_PER_SEC};
 
 /// The Non-secure physical timer `CNTP` for EL0.
 pub struct PhysicalTimer {
@@ -17,7 +17,7 @@ pub struct PhysicalTimer {
 impl PhysicalTimer {
     /// According to "AArch64 Programmer's Guides Generic Timer"
     /// the physical timer has an interrupt ID of 30 usually
-    pub const INTERRUPT_ID: u64 = 30;
+    pub const INTERRUPT_ID: u32 = 30;
 
     pub fn new() -> Self {
         // The CNTFRQ_EL0 register holds the value of
@@ -29,10 +29,30 @@ impl PhysicalTimer {
             info: ClockInfo::new(
                 TimeSpan::ZERO,
                 FemtoSeconds(0), // TODO: precision
-                FemtoSeconds(1_000_000_000_000_000 / freq),
+                FemtoSeconds(FEMTOS_PER_SEC / freq),
                 ClockFlags::MONOTONIC,
             ),
         }
+    }
+
+    // TODO: might need to make an API like this visible in ClockHardware
+
+    /// set a timer to fire off an interrupt after some span of time
+    pub fn set_timer(&self, span: TimeSpan) {
+        // TODO: check more fined grained rates other than a second
+        // should this fail if requested span is too low, or implicitly
+        // round up
+
+        // ticks = time / rate => secs / femtos => secs * 10^15 / secs
+        let ticks =  (span.0.0 * FEMTOS_PER_SEC) / self.info.resolution().0;
+
+        // configure the timer to fire after a certain amount of ticks have passed
+        CNTP_TVAL_EL0.set(ticks);
+
+        // clear the interrupt mask and enable the timer
+        CNTP_CTL_EL0.modify(
+            CNTP_CTL_EL0::IMASK::CLEAR + CNTP_CTL_EL0::ENABLE::SET
+        );
     }
 }
 
@@ -51,6 +71,20 @@ impl ClockHardware for PhysicalTimer {
     }
 }
 
+/// The interrupt handler for the aarch64 physical timer,
+/// for now this does not do anything interesting. It merely
+/// prints to the debug console and clears the interrupt.
 pub fn cntp_interrupt_handler() {
-    todo!("handle interrupts for physical timer")
+    emerglogln!("[arch:cntp] Hello from Timer!!");
+    // Disable the timer to clear the interrupt. Software must clear 
+    // the interrupt before deactivating the interrupt in the
+    // interrupt controller, otherwise it will keep firing.
+    //
+    // Alternatively we can mask the interrupt by setting
+    // IMASK, or update the comparator.
+    //
+    // NOTE: disabling the timer does not stop the system
+    // count from running, so reads from CNTPCT_EL0 are
+    // still valid
+    CNTP_CTL_EL0.modify(CNTP_CTL_EL0::ENABLE::CLEAR);
 }

--- a/src/kernel/src/arch/aarch64/cntp.rs
+++ b/src/kernel/src/arch/aarch64/cntp.rs
@@ -1,0 +1,56 @@
+/// The `ClockHardware` interface for the CNTP_EL0 timer
+/// This timer is local to a single core, and timestamps
+/// are synchronized to a global system timer count
+
+use arm64::registers::{CNTFRQ_EL0, CNTPCT_EL0};
+use registers::interfaces::Readable;
+
+use crate::time::{ClockHardware, Ticks};
+
+use twizzler_abi::syscall::{ClockFlags, ClockInfo, FemtoSeconds, TimeSpan};
+
+/// The Non-secure physical timer `CNTP` for EL0.
+pub struct PhysicalTimer {
+    info: ClockInfo,
+}
+
+impl PhysicalTimer {
+    /// According to "AArch64 Programmer's Guides Generic Timer"
+    /// the physical timer has an interrupt ID of 30 usually
+    pub const INTERRUPT_ID: u64 = 30;
+
+    pub fn new() -> Self {
+        // The CNTFRQ_EL0 register holds the value of
+        // the frequency of CNTP. The value is 32 bits
+        // and in Hz.
+        let freq = CNTFRQ_EL0.get();
+        // logln!("[arch:timer] frequency: {} (Hz)", 1_000_000_000_000_000 / freq);
+        Self {
+            info: ClockInfo::new(
+                TimeSpan::ZERO,
+                FemtoSeconds(0), // TODO: precision
+                FemtoSeconds(1_000_000_000_000_000 / freq),
+                ClockFlags::MONOTONIC,
+            ),
+        }
+    }
+}
+
+impl ClockHardware for PhysicalTimer {
+    fn read(&self) -> Ticks {
+        // The CNTPCT_EL0 register holds the current
+        // count of CNTP. It the 64-bit physical timer count
+        let count = CNTPCT_EL0.get();
+        Ticks {
+            value: count, // raw timer ticks (unitless)
+            rate: self.info.resolution(),
+        }
+    }
+    fn info(&self) -> ClockInfo {
+        self.info
+    }
+}
+
+pub fn cntp_interrupt_handler() {
+    todo!("handle interrupts for physical timer")
+}

--- a/src/kernel/src/arch/aarch64/interrupt.rs
+++ b/src/kernel/src/arch/aarch64/interrupt.rs
@@ -4,8 +4,6 @@
 /// general orignate from a device or another processor
 /// which can be routed by an interrupt controller
 
-mod controller;
-
 use twizzler_abi::{
     kso::{InterruptAllocateOptions, InterruptPriority},
 };
@@ -126,19 +124,12 @@ pub fn init_interrupts() {
     
     // initialize interrupt controller
     use crate::machine::interrupt::GICv2;
-    use crate::memory::PhysAddr;
+    use crate::machine::memory::mmio::{GICV2_DISTRIBUTOR, GICV2_CPU_INTERFACE};
 
-    // base address of the GIC distributor
-    const GICD_BASE_ADDR: u64 = 0x08000000;
-    let gic_base = PhysAddr::new(GICD_BASE_ADDR).unwrap();
-    let gicd_vbase = gic_base.kernel_vaddr();
-
-    // the GIC cpu interface in QEMU exists at
-    // an 0x00010000 offset from the base
-    const GIC_CPU_OFF: usize = 0x00010000;
-    let gicc_vbase = gicd_vbase.offset(GIC_CPU_OFF).unwrap();
-
-    let gic = GICv2::new(gicd_vbase, gicc_vbase);
+    let gic = GICv2::new(
+        GICV2_DISTRIBUTOR.start.kernel_vaddr(),
+        GICV2_CPU_INTERFACE.start.kernel_vaddr(),
+    );
 
     gic.print_config();
 

--- a/src/kernel/src/arch/aarch64/mod.rs
+++ b/src/kernel/src/arch/aarch64/mod.rs
@@ -18,78 +18,82 @@ mod start;
 pub use address::{VirtAddr, PhysAddr};
 pub use interrupt::{send_ipi, init_interrupts};
 pub use start::BootInfoSystemTable;
-use twizzler_abi::syscall::TimeSpan;
 
 pub fn init<B: BootInfo>(_boot_info: &B) {
     logln!("[arch::init] initializing exceptions");
     exception::init();
 
-    // intialize an instance of the timer
-    processor::enumerate_clocks();
+    #[cfg(test)]
+    {
+        // intialize an instance of the timer
+        processor::enumerate_clocks();
 
-    use crate::time::TICK_SOURCES;
-    use twizzler_abi::syscall::{NanoSeconds, ClockSource, NANOS_PER_SEC, FEMTOS_PER_SEC};
+        use crate::time::TICK_SOURCES;
+        use twizzler_abi::syscall::{
+            NanoSeconds, ClockSource, NANOS_PER_SEC, FEMTOS_PER_SEC, TimeSpan,
+        };
 
-    let clk_src: u64 = ClockSource::BestMonotonic.into();
-    let cntp = &TICK_SOURCES.lock()[clk_src as usize];
+        let clk_src: u64 = ClockSource::BestMonotonic.into();
+        let cntp = &TICK_SOURCES.lock()[clk_src as usize];
 
-    let info = cntp.info();
-    logln!("[arch::timer] frequency: {} Hz, {} fs, {} ns", 
-        FEMTOS_PER_SEC / info.resolution().0, info.resolution().0, {
-            let femtos = info.resolution();
-            let nanos: NanoSeconds = femtos.into();
-            nanos.0
-        }
-    );
-
-    // read the timer
-    let t = cntp.read();
-    logln!("[arch::timer] current timer count: {}, uptime: {:?}",
-        t.value, t.value * t.rate
-    );
-
-    init_interrupts();
-
-    // set the timer interrupt to be routed to us
-    crate::machine::interrupt::INTERRUPT_CONTROLLER
-        .enable_interrupt(cntp::PhysicalTimer::INTERRUPT_ID);
-
-    // configure the timer to fire off interrupts
-    const WAIT_TIME: TimeSpan = TimeSpan::from_secs(3);
-
-    let phys_timer = cntp::PhysicalTimer::new();
-    phys_timer.set_timer(WAIT_TIME);
-
-    logln!("[arch::timer] firing off an interrupt in {} seconds...", WAIT_TIME.0.0);
-
-    logln!("[kernel::arch] looping forever");
-    let mut count = 0;
-    let mut tick0 = cntp.read();
-    loop {
-        // record start timestamp
-        let start_time = tick0.value * tick0.rate;
-        let mut tick1;
-        let mut end_time;
-        // check if half a second passed
-        loop {
-            tick1 = cntp.read();
-            end_time = tick1.value * tick1.rate;
-            if (end_time - start_time).as_nanos() >= (NANOS_PER_SEC / 2).into() {
-                // reset starting timestamp
-                tick0 = cntp.read();
-                // increment half second counts
-                count += 1;
-                logln!("[kernel:test] 1/2 second has passed: {}", count);
-                break
+        let info = cntp.info();
+        logln!("[arch::timer] frequency: {} Hz, {} fs, {} ns", 
+            FEMTOS_PER_SEC / info.resolution().0, info.resolution().0, {
+                let femtos = info.resolution();
+                let nanos: NanoSeconds = femtos.into();
+                nanos.0
             }
-        }
-        // if 6 seconds have passed
-        if count >= 12 {
-            // reset the interrupt timer count to 5 seconds later
-            logln!("[kernel::test] setting timer to fire in 5 seconds");
-            phys_timer.set_timer(TimeSpan::from_secs(5));
+        );
 
-            count = 0;
+        // read the timer
+        let t = cntp.read();
+        logln!("[arch::timer] current timer count: {}, uptime: {:?}",
+            t.value, t.value * t.rate
+        );
+
+        init_interrupts();
+
+        // set the timer interrupt to be routed to us
+        crate::machine::interrupt::INTERRUPT_CONTROLLER
+            .enable_interrupt(cntp::PhysicalTimer::INTERRUPT_ID);
+
+        // configure the timer to fire off interrupts
+        const WAIT_TIME: TimeSpan = TimeSpan::from_secs(3);
+
+        let phys_timer = cntp::PhysicalTimer::new();
+        phys_timer.set_timer(WAIT_TIME);
+
+        logln!("[arch::timer] firing off an interrupt in {} seconds...", WAIT_TIME.0.0);
+
+        logln!("[kernel::arch] looping forever");
+        let mut count = 0;
+        let mut tick0 = cntp.read();
+        loop {
+            // record start timestamp
+            let start_time = tick0.value * tick0.rate;
+            let mut tick1;
+            let mut end_time;
+            // check if half a second passed
+            loop {
+                tick1 = cntp.read();
+                end_time = tick1.value * tick1.rate;
+                if (end_time - start_time).as_nanos() >= (NANOS_PER_SEC / 2).into() {
+                    // reset starting timestamp
+                    tick0 = cntp.read();
+                    // increment half second counts
+                    count += 1;
+                    logln!("[kernel:test] 1/2 second has passed: {}", count);
+                    break
+                }
+            }
+            // if 6 seconds have passed
+            if count >= 12 {
+                // reset the interrupt timer count to 5 seconds later
+                logln!("[kernel::test] setting timer to fire in 5 seconds");
+                phys_timer.set_timer(TimeSpan::from_secs(5));
+
+                count = 0;
+            }
         }
     }
 }

--- a/src/kernel/src/arch/aarch64/mod.rs
+++ b/src/kernel/src/arch/aarch64/mod.rs
@@ -16,7 +16,7 @@ pub mod thread;
 mod start;
 
 pub use address::{VirtAddr, PhysAddr};
-pub use interrupt::send_ipi;
+pub use interrupt::{send_ipi, init_interrupts};
 pub use start::BootInfoSystemTable;
 
 pub fn init<B: BootInfo>(_boot_info: &B) {
@@ -46,14 +46,12 @@ pub fn init<B: BootInfo>(_boot_info: &B) {
     logln!("[arch::timer] current timer count: {}, uptime: {:?}",
         t.value, t.value * t.rate
     );
+
+    init_interrupts();
 }
 
 pub fn init_secondary() {
     todo!();
-}
-
-pub fn init_interrupts() {
-    todo!()
 }
 
 pub fn set_interrupt(

--- a/src/kernel/src/arch/aarch64/processor.rs
+++ b/src/kernel/src/arch/aarch64/processor.rs
@@ -21,7 +21,10 @@ pub fn enumerate_cpus() -> u32 {
 /// Determine what hardware clock sources are available
 /// on the processor and register them in the time subsystem.
 pub fn enumerate_clocks() {
-    todo!()
+    // for now we utlize the physical timer (CNTPCT_EL0)
+    
+    // save reference to the CNTP clock source into global array
+    crate::time::register_clock(super::cntp::PhysicalTimer::new());
 }
 
 // map out topology of hardware

--- a/src/kernel/src/arch/aarch64/thread.rs
+++ b/src/kernel/src/arch/aarch64/thread.rs
@@ -6,13 +6,13 @@ use crate::{
     thread::Thread,
 };
 
-use super::{interrupt::IsrContext, syscall::Armv8SyscallContext};
+use super::{exception::ExceptionContext, syscall::Armv8SyscallContext};
 
 #[derive(Copy, Clone)]
 pub enum Registers {
     None,
     Syscall(*mut Armv8SyscallContext, Armv8SyscallContext),
-    Interrupt(*mut IsrContext, IsrContext),
+    Interrupt(*mut ExceptionContext, ExceptionContext),
 }
 
 // arch specific thread state

--- a/src/kernel/src/arch/amd64/address.rs
+++ b/src/kernel/src/arch/amd64/address.rs
@@ -197,7 +197,7 @@ impl PhysAddr {
     ///
     /// # Safety
     /// The provided address must be a valid address.
-    pub unsafe fn new_unchecked(addr: u64) -> Self {
+    pub const unsafe fn new_unchecked(addr: u64) -> Self {
         Self(addr)
     }
 

--- a/src/kernel/src/machine/arm/gicv2/gicc.rs
+++ b/src/kernel/src/machine/arm/gicv2/gicc.rs
@@ -1,4 +1,13 @@
-/// GICv2 CPU Interface
+/// A Generic Interrupt Controller (GIC) v2 CPU Interface
+/// 
+/// The full specification can be found here:
+///     https://developer.arm.com/documentation/ihi0048/b?lang=en
+///
+/// Relevant sections include, but are not limited to: 2.3, 4.1.3, 4.3
+///
+/// A summary of its functionality can be found in section 10.6
+/// "ARM Cortex-A Series Programmer’s Guide for ARMv8-A":
+///     https://developer.arm.com/documentation/den0024/a/
 
 use registers::{
     interfaces::{Readable, Writeable},

--- a/src/kernel/src/machine/arm/gicv2/gicc.rs
+++ b/src/kernel/src/machine/arm/gicv2/gicc.rs
@@ -1,0 +1,119 @@
+/// GICv2 CPU Interface
+
+use registers::{
+    interfaces::{Readable, Writeable},
+    register_bitfields, register_structs,
+    registers::ReadWrite,
+};
+
+use super::mmio::MmioRef;
+
+use crate::memory::VirtAddr;
+
+// Each register in the specification is prefixed with GICC_
+register_bitfields! {
+    u32,
+
+    /// CPU Interface Control Register
+    CTLR [
+        // bits [31:1] are reserved
+        Enable OFFSET(0) NUMBITS(1) []
+    ],
+
+    /// Interrupt Priority Mask Register
+    PMR [
+        // bits [8:31] are reserved
+        Priority OFFSET(0) NUMBITS(8) []
+    ],
+
+    /// Interrupt Acknowledge Register
+    IAR [
+        // bits [12:10] are used to identify the CPUID of an SGI
+        InterruptID OFFSET(0) NUMBITS(10) []
+    ],
+
+    /// End of Interrupt Register
+    EOIR [
+        // the EOIINTID field value
+        InterruptID OFFSET(0) NUMBITS(10) []
+    ]
+}
+
+// Each register in the specification is prefixed with GICC_
+register_structs! {
+    #[allow(non_snake_case)]
+    pub CpuInterfaceRegisters {
+        (0x000 => CTLR: ReadWrite<u32, CTLR::Register>),
+        (0x004 => PMR: ReadWrite<u32, PMR::Register>),
+        (0x008 => _reserved1),
+        (0x00C => IAR: ReadWrite<u32, IAR::Register>),
+        (0x010 => EOIR: ReadWrite<u32, EOIR::Register>),
+        (0x014  => @END),
+    }
+}
+
+/// GIC CPU Interface
+pub struct GICC {
+    registers: MmioRef<CpuInterfaceRegisters>,
+}
+
+impl GICC {
+    pub const ACCEPT_ALL: u8 = 255;
+
+    pub fn new(base: VirtAddr) -> Self {
+        Self {
+            registers: MmioRef::new(base.as_ptr::<CpuInterfaceRegisters>()),
+        }
+    }
+
+    /// enable the cpu interface
+    pub fn enable(&self) {
+        // enables interrupts to signal the cpu interface of the processor
+        self.registers.CTLR.write(CTLR::Enable::SET);
+    }
+
+    /// set a threshold for the interrupts that we will be signaled by
+    pub fn set_interrupt_priority_mask(&self, mask: u8) {
+        // A higher priority corresponds to a lower priority field value
+        // A value of zero means that we mask all interrutps to the current processor
+        self.registers.PMR.write(PMR::Priority.val(mask as u32));
+    }
+
+    /// get the interrupt id for a pending interrupt signal
+    pub fn get_pending_interrupt_number(&self) -> u32 {
+        // Reading the interrupt id causes the interrupt
+        // to be marked active in the distributor. This
+        // returns the interrupt id of the highest pending interrupt.
+        // The register could return a spurious interrupt id
+        // with a value of 1023
+        let int_id = self.registers.IAR.read(IAR::InterruptID);
+        if int_id == 1023 {
+            // spurious interrupt only occurs if:
+            // - forwarding from distributor to cpu is disabled
+            // - signaling by cpu interface to processor is disabled
+            // - all pending interrupts are low priority
+            panic!("spurious interrupt id detected!!");
+        }
+        // every read of the IAR must have a matching write to the EOIR
+        int_id.into()
+    }
+
+    /// notify cpu interface that processing of interrupt has completed
+    pub fn finish_active_interrupt(&self, int_id: u32) {
+        // A write to the EOIR corrsponds to the most recent valid
+        // read of the IAR value. A return of a spurious ID from IAR
+        // does not have to be written to EOIR.
+        self.registers.EOIR.write(EOIR::InterruptID.val(int_id as u32));
+    }
+
+    /// print the configuration of the distributor
+    pub fn print_config(&self) {
+        emerglogln!("[gic::gicc] printing configuration");
+        // is it enabled?
+        let enabled = self.registers.CTLR.read(CTLR::Enable);
+        emerglogln!("\tCTLR::Enable: {}", enabled);
+        // what is the priority mask?
+        let mask = self.registers.PMR.read(PMR::Priority);
+        emerglogln!("\tPMR::Priority: {}", mask);
+    }
+}

--- a/src/kernel/src/machine/arm/gicv2/gicd.rs
+++ b/src/kernel/src/machine/arm/gicv2/gicd.rs
@@ -1,0 +1,145 @@
+/// GICv2 Distributor Interface
+
+use registers::{
+    interfaces::{Readable, Writeable},
+    register_bitfields, register_structs,
+    registers::{ReadOnly, ReadWrite},
+};
+
+use super::mmio::MmioRef;
+
+use crate::memory::VirtAddr;
+
+// Each register in the specification is prefixed with GICC_
+register_bitfields! {
+    u32,
+
+    /// Distributor Control Register
+    CTLR [
+        // bits [31:1] are reserved
+        Enable OFFSET(0) NUMBITS(1) []
+    ],
+
+    /// Interrupt Controller Type Register
+    TYPER [
+        // bits [31:16] are reserved
+        CPUNumber OFFSET(5)  NUMBITS(3) [],
+        ITLinesNumber OFFSET(0)  NUMBITS(5) []
+    ],
+
+    /// Distributor Implementer Identification Register
+    IIDR [
+        ProductID OFFSET(24) NUMBITS(8) [],
+        // bits [23:20] are reserved
+        Variant OFFSET(16) NUMBITS(4) [],
+        Revision OFFSET(12) NUMBITS(4) [],
+        Implementer OFFSET(0)  NUMBITS(11) []
+    ],
+
+    /// Interrupt Processor Targets Registers
+    ITARGETSR [
+        TargetOffset3 OFFSET(24) NUMBITS(8) [],
+        TargetOffset2 OFFSET(16) NUMBITS(8) [],
+        TargetOffset1 OFFSET(8)  NUMBITS(8) [],
+        TargetOffset0 OFFSET(0)  NUMBITS(8) []
+    ]
+}
+
+// Each register in the specification is prefixed with GICD_
+register_structs! {
+    /// Distributor Register Map according 
+    /// to Section 4.1.2, Table 4-1. 
+    /// All registers are 32-bits wide.
+    #[allow(non_snake_case)]
+    DistributorRegisters {
+        /// Distributor Control Register
+        (0x000 => CTLR: ReadWrite<u32, CTLR::Register>),
+        /// Interrupt Controller Type Register
+        (0x004 => TYPER: ReadOnly<u32, TYPER::Register>),
+        (0x008 => IIDR: ReadOnly<u32, IIDR::Register>),
+        (0x00C => _reserved1),
+        /// Interrupt Set-Enable Registers. ISENABLER0 is banked which
+        /// holds the enable bits for each connected processor.
+        (0x100 => ISENABLER_BANKED: ReadWrite<u32>),
+        (0x104 => ISENABLER: [ReadWrite<u32>; 31]),
+        (0x180 => _reserved2),
+        // skip the banked ITARGETSR registers for now: int #'s 0-31
+        (0x800 => ITARGETSR_BANKED: [ReadWrite<u32, ITARGETSR::Register>; 8]),
+        // this covers interrupt numbers 32 - 1019
+        (0x820 => ITARGETSR: [ReadWrite<u32, ITARGETSR::Register>; 248]),
+        (0xC00 => @END),
+    }
+}
+
+/// GIC Distributor
+pub struct GICD {
+    registers: MmioRef<DistributorRegisters>,
+}
+
+impl GICD {
+    pub fn new(base: VirtAddr) -> Self {
+        Self {
+            registers: MmioRef::new(base.as_ptr::<DistributorRegisters>()),
+        }
+    }
+
+    /// enable the distributor interface
+    pub fn enable(&self) {
+        // enable forwarding of pending interrupts from Distributor to CPU interfaces.
+        self.registers.CTLR.write(CTLR::Enable::SET);
+    }
+
+    /// print the configuration of the distributor
+    pub fn print_config(&self) {
+        emerglogln!("[gic::gicd] printing configuration");
+        // is it enabled?
+        let enabled = self.registers.CTLR.read(CTLR::Enable);
+        emerglogln!("\tCTLR::Enable: {}", enabled);
+        // how many interrupts does it support?
+        let itl = self.registers.TYPER.read(TYPER::ITLinesNumber);
+        emerglogln!("\tTYPER::ITLinesNumber: N={} => {}", itl, 32 * (itl + 1));
+        // how many cpus does it support?
+        let cpus = self.registers.TYPER.read(TYPER::CPUNumber);
+        emerglogln!("\tTYPER::CPUNumber: {}", cpus + 1);
+        // how many set enable registers are there?
+        let num_int_enable = itl + 1;
+        emerglogln!("\tNumber of ISENABLER registers: {}", num_int_enable);
+        // dump the enable state for ISENABLER0
+        let local_ints = self.registers.ISENABLER_BANKED.get();
+        emerglogln!("\tISENABLER0: {:#x}", local_ints);
+        // what is the interurpt mask for local interrupts routed?
+        // a read of an of the cpu targets returns the number(core id) of the processor reading it
+        let int_mask = self.registers.ITARGETSR_BANKED[0].read(ITARGETSR::TargetOffset0);
+        emerglogln!("\tITARGETSR[0]: cpu number {:#x}", int_mask);
+    }
+
+    /// Set the enable bit for the corresponding interrupt.
+    pub fn enable_interrupt(&self, int_id: u32) {
+        match int_id {
+            0..=31 => {
+                // read register
+                let mut enable = self.registers.ISENABLER_BANKED.get();
+                let bit_index = int_id % 32;
+                // set the local bit copy
+                enable = enable | (1 << bit_index);
+                // write out the value
+                self.registers.ISENABLER_BANKED.set(enable);
+            },
+            _ => todo!("unsupported interrupt number: {}", int_id)
+        }
+    }
+
+    /// configure routing of interrupts to particular cpu cores
+    pub fn set_interrupt_target(&self, int_id: u32, _core: u32) {
+        // change ITARGETSR
+        match int_id {
+            0..=31 => {
+                // find banked index
+                // find bit index
+                // write the value to the register
+            },
+            _ => todo!("unsupported interrupt number: {}", int_id)
+        }
+    }
+    
+}

--- a/src/kernel/src/machine/arm/gicv2/gicd.rs
+++ b/src/kernel/src/machine/arm/gicv2/gicd.rs
@@ -1,4 +1,13 @@
-/// GICv2 Distributor Interface
+/// A Generic Interrupt Controller (GIC) v2 Distributor Interface
+/// 
+/// The full specification can be found here:
+///     https://developer.arm.com/documentation/ihi0048/b?lang=en
+///
+/// Relevant sections include, but are not limited to: 2.2, 4.1.2, 4.3
+///
+/// A summary of its functionality can be found in section 10.6
+/// "ARM Cortex-A Series Programmer’s Guide for ARMv8-A":
+///     https://developer.arm.com/documentation/den0024/a/
 
 use registers::{
     interfaces::{Readable, Writeable},

--- a/src/kernel/src/machine/arm/gicv2/mmio.rs
+++ b/src/kernel/src/machine/arm/gicv2/mmio.rs
@@ -1,0 +1,23 @@
+use core::ops::Deref;
+
+/// A reference to a memory mapped IO region of
+/// memory of type `T`
+pub struct MmioRef<T> {
+    address: *const T,
+}
+
+impl<T> MmioRef<T> {
+    pub fn new(address: *const T) -> Self {
+        Self {
+            address,
+        }
+    }
+}
+
+impl<T> Deref for MmioRef<T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        unsafe { &*self.address }
+    }
+}

--- a/src/kernel/src/machine/arm/gicv2/mmio.rs
+++ b/src/kernel/src/machine/arm/gicv2/mmio.rs
@@ -21,3 +21,6 @@ impl<T> Deref for MmioRef<T> {
         unsafe { &*self.address }
     }
 }
+
+unsafe impl<T> Send for MmioRef<T> {}
+unsafe impl<T> Sync for MmioRef<T> {}

--- a/src/kernel/src/machine/arm/gicv2/mod.rs
+++ b/src/kernel/src/machine/arm/gicv2/mod.rs
@@ -40,7 +40,7 @@ impl GICv2 {
     }
 
     // Enables the interrupt with a given ID to be routed to CPUs.
-    fn enable_interrupt(&self, int_id: u32) {
+    pub fn enable_interrupt(&self, int_id: u32) {
         self.global.enable_interrupt(int_id);
 
         // TODO: set the priority for the corresponding interrupt? see GICD_IPRIORITYRn
@@ -56,12 +56,12 @@ impl GICv2 {
 
     /// Returns the pending interrupt ID from the controller, and
     /// acknowledges the interrupt.
-    fn pending_interrupt(&self) -> u32 {
+    pub fn pending_interrupt(&self) -> u32 {
         self.local.get_pending_interrupt_number()
     }
 
     /// Signal the controller that we have serviced the interrupt
-    fn finish_active_interrupt(&self, int_id: u32) {
+    pub fn finish_active_interrupt(&self, int_id: u32) {
         self.local.finish_active_interrupt(int_id);
     }
 
@@ -71,3 +71,4 @@ impl GICv2 {
         self.local.print_config();
     }
 }
+

--- a/src/kernel/src/machine/arm/gicv2/mod.rs
+++ b/src/kernel/src/machine/arm/gicv2/mod.rs
@@ -1,0 +1,45 @@
+use crate::memory::VirtAddr;
+
+pub struct GICv2;
+
+
+
+impl GICv2 {
+    pub fn new(_distr_base: VirtAddr, _local_base: VirtAddr) -> Self {
+        Self { }
+    }
+
+    /// Configures the interrupt controller. At the end of this function
+    /// the current calling CPU is ready to recieve interrupts.
+    pub fn configure(&self) {
+        todo!()
+    }
+
+    /// Sets the interrupt priority mask for the current calling CPU.
+    fn set_interrupt_mask(&self, mask: u8) {
+        todo!()
+    }
+
+    // Enables the interrupt with a given ID to be routed to CPUs.
+    fn enable_interrupt(&self, int_id: u32) {
+        todo!()
+    }
+
+    /// Programs the interrupt controller to be able to route
+    /// a given interrupt to a particular core.
+    fn route_interrupt(&self, int_id: u32, core: u32) {
+        todo!()
+    }
+
+    /// Returns the pending interrupt ID from the controller, and
+    /// acknowledges the interrupt.
+    fn pending_interrupt(&self) -> u32 {
+        todo!()
+    }
+
+    /// Signal the controller that we have serviced the interrupt
+    fn finish_active_interrupt(&self, int_id: u32) {
+        todo!()
+    }
+
+}

--- a/src/kernel/src/machine/arm/gicv2/mod.rs
+++ b/src/kernel/src/machine/arm/gicv2/mod.rs
@@ -1,3 +1,12 @@
+/// A Generic Interrupt Controller (GIC) v2 driver interface
+/// 
+/// The full specification can be found here:
+///     https://developer.arm.com/documentation/ihi0048/b?lang=en
+///
+/// A summary of its functionality can be found in section 10.6
+/// "ARM Cortex-A Series Programmer’s Guide for ARMv8-A":
+///     https://developer.arm.com/documentation/den0024/a/
+
 mod gicd;
 mod gicc;
 mod mmio;
@@ -7,6 +16,7 @@ use gicc::GICC;
 
 use crate::memory::VirtAddr;
 
+/// A representation of the Generic Interrupt Controller (GIC) v2
 pub struct GICv2 {
     global: GICD,
     local: GICC,

--- a/src/kernel/src/machine/arm/gicv2/mod.rs
+++ b/src/kernel/src/machine/arm/gicv2/mod.rs
@@ -1,45 +1,73 @@
+mod gicd;
+mod gicc;
+mod mmio;
+
+use gicd::GICD;
+use gicc::GICC;
+
 use crate::memory::VirtAddr;
 
-pub struct GICv2;
-
-
+pub struct GICv2 {
+    global: GICD,
+    local: GICC,
+}
 
 impl GICv2 {
-    pub fn new(_distr_base: VirtAddr, _local_base: VirtAddr) -> Self {
-        Self { }
+    pub fn new(distr_base: VirtAddr, local_base: VirtAddr) -> Self {
+        Self {
+            global: GICD::new(distr_base),
+            local: GICC::new(local_base),
+        }
     }
 
     /// Configures the interrupt controller. At the end of this function
     /// the current calling CPU is ready to recieve interrupts.
     pub fn configure(&self) {
-        todo!()
+        // enable the gic distributor
+        self.global.enable();
+
+        // set the interrupt priority mask to accept all interrupts
+        self.set_interrupt_mask(GICC::ACCEPT_ALL);
+
+        // enable the gic cpu interface
+        self.local.enable();
     }
 
     /// Sets the interrupt priority mask for the current calling CPU.
     fn set_interrupt_mask(&self, mask: u8) {
-        todo!()
+        // set the interrupt priority mask that we will accept
+        self.local.set_interrupt_priority_mask(mask);
     }
 
     // Enables the interrupt with a given ID to be routed to CPUs.
     fn enable_interrupt(&self, int_id: u32) {
-        todo!()
+        self.global.enable_interrupt(int_id);
+
+        // TODO: set the priority for the corresponding interrupt? see GICD_IPRIORITYRn
+        // TODO: edge triggered or level sensitive??? see GICD_ICFGRn
     }
 
     /// Programs the interrupt controller to be able to route
     /// a given interrupt to a particular core.
-    fn route_interrupt(&self, int_id: u32, core: u32) {
+    fn route_interrupt(&self, _int_id: u32, _core: u32) {
+        // TODD: route the interrupt to a corresponding core, see GICD_ITARGETSRn
         todo!()
     }
 
     /// Returns the pending interrupt ID from the controller, and
     /// acknowledges the interrupt.
     fn pending_interrupt(&self) -> u32 {
-        todo!()
+        self.local.get_pending_interrupt_number()
     }
 
     /// Signal the controller that we have serviced the interrupt
     fn finish_active_interrupt(&self, int_id: u32) {
-        todo!()
+        self.local.finish_active_interrupt(int_id);
     }
 
+    /// Print the configuration of the GIC
+    pub fn print_config(&self) {
+        self.global.print_config();
+        self.local.print_config();
+    }
 }

--- a/src/kernel/src/machine/arm/mod.rs
+++ b/src/kernel/src/machine/arm/mod.rs
@@ -6,3 +6,4 @@ mod virt;
 pub use virt::*;
 
 mod uart;
+mod gicv2;

--- a/src/kernel/src/machine/arm/virt/interrupt.rs
+++ b/src/kernel/src/machine/arm/virt/interrupt.rs
@@ -1,1 +1,17 @@
-pub use super::super::gicv2::GICv2;
+use lazy_static::lazy_static;
+
+use super::super::gicv2::GICv2;
+
+use crate::machine::memory::mmio::{GICV2_DISTRIBUTOR, GICV2_CPU_INTERFACE};
+
+lazy_static! {
+    /// System-wide reference to the interrupt controller
+    pub static ref INTERRUPT_CONTROLLER: GICv2 = {
+        GICv2::new(
+            // TODO: might need to lock global distributor state,
+            // an possibly CPU interface
+            GICV2_DISTRIBUTOR.start.kernel_vaddr(),
+            GICV2_CPU_INTERFACE.start.kernel_vaddr(),
+        )
+    };
+}

--- a/src/kernel/src/machine/arm/virt/interrupt.rs
+++ b/src/kernel/src/machine/arm/virt/interrupt.rs
@@ -1,2 +1,1 @@
-
-use super::super::gicv2::GICv2;
+pub use super::super::gicv2::GICv2;

--- a/src/kernel/src/machine/arm/virt/interrupt.rs
+++ b/src/kernel/src/machine/arm/virt/interrupt.rs
@@ -1,0 +1,2 @@
+
+use super::super::gicv2::GICv2;

--- a/src/kernel/src/machine/arm/virt/memory.rs
+++ b/src/kernel/src/machine/arm/virt/memory.rs
@@ -1,0 +1,28 @@
+// This interface is temporary until we can utilize something
+// like a Device Tree or ACPI during boot to describe the memory
+// map in addition to the memory map the bootloader gives us.
+pub mod mmio {
+    use crate::memory::{MemoryRegion, MemoryRegionKind, PhysAddr};
+
+    /// The region of the physical memory map that represents
+    /// the MMIO registers of the GICv2 Distributor
+    pub const GICV2_DISTRIBUTOR: MemoryRegion = MemoryRegion {
+        // physical base address in QEMU
+        start: unsafe {
+            PhysAddr::new_unchecked(0x08000000)
+        },
+        length: 0x00010000,
+        kind: MemoryRegionKind::Reserved,
+    };
+
+    /// The region of the physical memory map that represents
+    /// the MMIO registers of the GICv2 CPU Interface
+    pub const GICV2_CPU_INTERFACE: MemoryRegion = MemoryRegion {
+        // physical base address in QEMU
+        start: unsafe {
+            PhysAddr::new_unchecked(0x08010000)
+        },
+        length: 0x00010000,
+        kind: MemoryRegionKind::Reserved,
+    };
+}

--- a/src/kernel/src/machine/arm/virt/mod.rs
+++ b/src/kernel/src/machine/arm/virt/mod.rs
@@ -1,3 +1,5 @@
+pub mod interrupt;
+pub mod memory;
 pub mod serial;
 
 pub fn machine_post_init() {


### PR DESCRIPTION
We implement our first set of interrupt handling routines for aarch64 and test this with the `CNTP` generic timer present in aarch64 systems. Specifically, we implement the `ClockHardware` interface for the timer, register it in the time subsystem and are able to read absolute time from it. We also test if we can generate an interrupt after some time has passed, and handle that as well. The interrupt handler for the timer at the moment does not do anything interesting. This will change as we add more complex functionality to the aarch64 kernel such as scheduling.

This PR is completely independent of #122 , and does not rely on any functionality it has. In the future we plan to actually map in the MMIO as device memory. This would need to be a separate PR, as it requires more functionality in addition to changes in #122.

Summary:
- Implement `ClockHardware` interface for the aarch64 physical timer
- Register the physical timer in the timer subsystem
- Add a generic IRQ handler in the exception vector table
- Implement an interface and driver for the GICv2
- Implement IRQ handling for the aarch64 timer