### PR TITLE
Task Scheduling for aarch64

### DIFF
--- a/src/kernel/src/arch/aarch64/context.rs
+++ b/src/kernel/src/arch/aarch64/context.rs
@@ -20,7 +20,7 @@ pub struct ArchContextInner {
     mapper: Mapper,
 }
 pub struct ArchContext {
-    kernel: u64, // TODO
+    kernel: u64, // TODO: do we always need a copy?
     user: PhysAddr,
     inner: Mutex<ArchContextInner>,
 }
@@ -68,7 +68,7 @@ impl ArchContext {
     }
 
     pub fn new() -> Self {
-        todo!("ArchContext::new")
+        Self::new_kernel()
     }
 
     #[allow(named_asm_labels)]
@@ -114,7 +114,7 @@ impl ArchContext {
     }
 
     pub fn unmap(&self, _cursor: MappingCursor) {
-        todo!("unmap")
+        // TODO: actually unmap pages
     }
 
     pub fn readmap<R>(&self, _cursor: MappingCursor, _f: impl Fn(MapReader) -> R) -> R {

--- a/src/kernel/src/arch/aarch64/interrupt.rs
+++ b/src/kernel/src/arch/aarch64/interrupt.rs
@@ -87,7 +87,7 @@ pub fn set(state: bool) {
     // state singifies if interrupts need to enabled or disabled
     // the state can refer to the previous state of the I bit (IRQ)
     // in DAIF or may be explicitly changed. we unmask (enable) interrupts
-    // if the state is true
+    // if the state is true, and disable if false.
     if state {
         // enable interrupts by unmasking the I bit (the same as state)
         unsafe {
@@ -96,6 +96,8 @@ pub fn set(state: bool) {
                 ENABLE_MASK = const DAIFMaskBits::IRQ.bits(),
             );
         }
+    } else {
+        disable();
     }
 }
 

--- a/src/kernel/src/arch/aarch64/mod.rs
+++ b/src/kernel/src/arch/aarch64/mod.rs
@@ -1,3 +1,6 @@
+use arm64::registers::TPIDR_EL1;
+use registers::interfaces::Writeable;
+
 use crate::{
     clock::Nanoseconds,
     interrupt::{Destination, PinPolarity, TriggerMode},
@@ -24,6 +27,10 @@ pub fn init<B: BootInfo>(_boot_info: &B) {
     exception::init();
     // configure registers needed by the memory management system
     // TODO: configure MAIR
+
+    // On reset, TPIDR_EL1 is initialized to some unknown value.
+    // we set it to zero so that we know it is not initialized.
+    TPIDR_EL1.set(0);
 }
 
 pub fn init_secondary() {

--- a/src/kernel/src/arch/aarch64/mod.rs
+++ b/src/kernel/src/arch/aarch64/mod.rs
@@ -34,7 +34,9 @@ pub fn init<B: BootInfo>(_boot_info: &B) {
 }
 
 pub fn init_secondary() {
-    todo!();
+    // TODO: Initialize secondary processors:
+    // - set up exception handling
+    // - configure the local CPU interrupt controller interface
 }
 
 pub fn set_interrupt(

--- a/src/kernel/src/arch/aarch64/mod.rs
+++ b/src/kernel/src/arch/aarch64/mod.rs
@@ -1,6 +1,8 @@
 use arm64::registers::TPIDR_EL1;
 use registers::interfaces::Writeable;
 
+use twizzler_abi::syscall::TimeSpan;
+
 use crate::{
     clock::Nanoseconds,
     interrupt::{Destination, PinPolarity, TriggerMode},
@@ -53,8 +55,14 @@ pub fn start_clock(_statclock_hz: u64, _stat_cb: fn(Nanoseconds)) {
     // TODO: implement support for the stat clock
 }
 
-pub fn schedule_oneshot_tick(_time: Nanoseconds) {
-    todo!()
+pub fn schedule_oneshot_tick(time: Nanoseconds) {
+    emerglogln!("[arch::tick] setting the timer to fire off after {} ns", time);
+    let old = interrupt::disable();
+    // set timer to fire off after a certian amount of time has passed
+    let phys_timer = cntp::PhysicalTimer::new();
+    let wait_time = TimeSpan::from_nanos(time);
+    phys_timer.set_timer(wait_time);
+    interrupt::set(old);
 }
 
 /// Jump into userspace

--- a/src/kernel/src/arch/aarch64/mod.rs
+++ b/src/kernel/src/arch/aarch64/mod.rs
@@ -50,7 +50,7 @@ pub fn set_interrupt(
 }
 
 pub fn start_clock(_statclock_hz: u64, _stat_cb: fn(Nanoseconds)) {
-    todo!();
+    // TODO: implement support for the stat clock
 }
 
 pub fn schedule_oneshot_tick(_time: Nanoseconds) {

--- a/src/kernel/src/arch/aarch64/processor.rs
+++ b/src/kernel/src/arch/aarch64/processor.rs
@@ -1,7 +1,7 @@
 use alloc::{vec::Vec};
 
-use arm64::registers::MPIDR_EL1;
-use registers::interfaces::Readable;
+use arm64::registers::{MPIDR_EL1, TPIDR_EL1};
+use registers::interfaces::{Readable, Writeable};
 
 use crate::{
     memory::VirtAddr,
@@ -12,8 +12,12 @@ use crate::{
 #[allow(unused_imports)] // DEBUG
 use super::{interrupt::InterProcessorInterrupt};
 
-pub fn init(_tls: VirtAddr) {
-    todo!()
+// initialize processor and any processor specific features
+pub fn init(tls: VirtAddr) {
+    // Save thread local storage to an unused variable.
+    // We use TPIDR_EL1 for this purpose which is free
+    // for the OS to use.
+    TPIDR_EL1.set(tls.raw());
 }
 
 // the core ID of the bootstrap core
@@ -70,7 +74,5 @@ impl Processor {
 }
 
 pub fn tls_ready() -> bool {
-    // TODO: initlialize tls
-    // see TPIDR_EL1
-    false
+    TPIDR_EL1.get() != 0
 }

--- a/src/kernel/src/arch/aarch64/processor.rs
+++ b/src/kernel/src/arch/aarch64/processor.rs
@@ -54,7 +54,12 @@ pub fn enumerate_clocks() {
 
 // map out topology of hardware
 pub fn get_topology() -> Vec<(usize, bool)> {
-    todo!()
+    // TODO: more sophisticated enumeration of CPUs
+    // using something like information in MPIDR_EL1,
+    // Device Tree, or ACPI
+
+    // For now we simply return a single core, the boot core.
+    alloc::vec![(*BOOT_CORE_ID.wait() as usize, false)]
 }
 
 // arch specific implementation of processor specific state

--- a/src/kernel/src/arch/aarch64/start.rs
+++ b/src/kernel/src/arch/aarch64/start.rs
@@ -33,7 +33,8 @@ impl BootInfo for Armv8BootInfo {
     }
 
     fn get_modules(&self) -> &'static [BootModule] {
-        todo!("get modules")
+        // TODO: support loading of modules (programs)
+        &[]
     }
 
     fn kernel_image_info(&self) -> (VirtAddr, usize) {

--- a/src/kernel/src/arch/aarch64/thread.rs
+++ b/src/kernel/src/arch/aarch64/thread.rs
@@ -97,11 +97,16 @@ impl Thread {
         todo!()
     }
 
+    // this does not need to be pub, might not needed for aarch64
     pub unsafe fn init_va(&mut self, _jmptarget: u64) {
         todo!()
     }
 
-    pub unsafe fn init(&mut self, _f: extern "C" fn()) {
-        todo!()
+    pub unsafe fn init(&mut self, entry: extern "C" fn()) {
+        let stack = self.kernel_stack.as_ptr() as *mut u64;
+        // set the stack pointer as the last thing context (x30 + 1)
+        self.arch.context.sp = stack as u64;
+        // set the link register as the second to last entry (x30)
+        self.arch.context.lr = entry as u64;
     }
 }

--- a/src/lib/twizzler-abi/src/syscall/time/time.rs
+++ b/src/lib/twizzler-abi/src/syscall/time/time.rs
@@ -1,6 +1,6 @@
 use core::{time::Duration, ops::Sub};
 
-use super::{NanoSeconds, FemtoSeconds, Seconds, FEMTOS_PER_SEC, NANOS_PER_SEC};
+use super::{NanoSeconds, FemtoSeconds, Seconds, FEMTOS_PER_SEC, NANOS_PER_SEC, FEMTOS_PER_NANO};
 
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct TimeSpan(pub Seconds, pub FemtoSeconds);
@@ -32,9 +32,20 @@ impl TimeSpan {
         )
     }
 
+    pub const fn from_nanos(nanos: u64) -> TimeSpan {
+        TimeSpan(
+            Seconds(nanos / NANOS_PER_SEC),
+            FemtoSeconds(((nanos % NANOS_PER_SEC) as u64) * FEMTOS_PER_NANO)
+        )
+    }
+
     pub fn as_nanos(&self) -> u128 {
         let nanos: NanoSeconds = self.1.into();
         self.0.0 as u128 * NANOS_PER_SEC as u128 + nanos.0 as u128
+    }
+
+    pub fn as_femtos(&self) -> u128 {
+        self.0.0 as u128 * FEMTOS_PER_SEC as u128 + self.1.0 as u128
     }
 
     pub const fn checked_sub(&self, other: TimeSpan) -> Option<TimeSpan> {


### PR DESCRIPTION
We implement some archtecture specific bits needed for task scheduling on ARM. Namely we implement support for: thread-local storage (TLS), thread initialization, context switching, and scheduling ticks driven by the core-local physical timer.

**Summary**
- add in processor enumeration (core local)
- save pointer to kernel TLS to `TPDIR_EL1`
- add dummy topology generation for a single core
- initialize the thread's entry point and stack
- create new `TimeSpan` API in Twizzler ABI
- set the arch CNTP timer to drive scheduling ticks
- context switch (save regs/stack ptr)
- manage interrupt state mask state