### PR TITLE
Implement Thread-Local Storage Variant I

### DIFF
--- a/src/kernel/src/arch/aarch64/image.rs
+++ b/src/kernel/src/arch/aarch64/image.rs
@@ -1,0 +1,10 @@
+/// TLS initialization for the kernel image
+
+use crate::{
+    image::{TlsInfo, TlsVariant},
+    memory::VirtAddr,
+};
+
+pub fn init_tls(tls_template: TlsInfo) -> VirtAddr {
+    crate::image::init_tls(TlsVariant::Variant1, tls_template)
+}

--- a/src/kernel/src/arch/aarch64/mod.rs
+++ b/src/kernel/src/arch/aarch64/mod.rs
@@ -13,6 +13,7 @@ pub mod address;
 mod cntp;
 pub mod context;
 mod exception;
+pub mod image;
 pub mod interrupt;
 pub mod memory;
 pub mod processor;

--- a/src/kernel/src/arch/amd64/image.rs
+++ b/src/kernel/src/arch/amd64/image.rs
@@ -1,0 +1,10 @@
+/// TLS initialization for the kernel image
+
+use crate::{
+    image::{TlsInfo, TlsVariant},
+    memory::VirtAddr,
+};
+
+pub fn init_tls(tls_template: TlsInfo) -> VirtAddr {
+    image::init_tls(TlsVariant::Variant2, tls_template)
+}

--- a/src/kernel/src/arch/amd64/image.rs
+++ b/src/kernel/src/arch/amd64/image.rs
@@ -6,5 +6,5 @@ use crate::{
 };
 
 pub fn init_tls(tls_template: TlsInfo) -> VirtAddr {
-    image::init_tls(TlsVariant::Variant2, tls_template)
+    crate::image::init_tls(TlsVariant::Variant2, tls_template)
 }

--- a/src/kernel/src/arch/amd64/mod.rs
+++ b/src/kernel/src/arch/amd64/mod.rs
@@ -14,6 +14,7 @@ pub mod address;
 pub mod context;
 //mod desctables;
 mod gdt;
+pub mod image;
 pub mod interrupt;
 pub mod ioapic;
 pub mod lapic;

--- a/src/kernel/src/image.rs
+++ b/src/kernel/src/image.rs
@@ -118,3 +118,23 @@ fn variant2(tls_template: TlsInfo) -> VirtAddr {
 
     tcb_base
 }
+
+
+#[cfg(test)]
+mod test {
+    use twizzler_kernel_macros::kernel_test;
+
+    // the correct value that the TLS var should be set to
+    const TLS_TEST_MAGIC: u64 = 0x900dc0ffee123abc;
+
+    #[thread_local]
+    static SOME_INT: u64 = TLS_TEST_MAGIC;
+
+    #[kernel_test]
+    fn tls_test() {
+        // get the initial value of TLS var
+        assert_eq!(SOME_INT, TLS_TEST_MAGIC,
+            "TLS var not initialized correctly: {:#x}", SOME_INT
+        );
+    }
+}

--- a/src/kernel/src/image.rs
+++ b/src/kernel/src/image.rs
@@ -112,7 +112,7 @@ fn variant2(tls_template: TlsInfo) -> VirtAddr {
 
         tls
     };
-    let tcb_base = VirtAddr::from_ptr(tls).offset(full_tls_size).unwrap();
+    let tcb_base = VirtAddr::from_ptr(tls).offset(tls_size).unwrap();
 
     unsafe { *(tcb_base.as_mut_ptr()) = tcb_base.raw() };
 

--- a/src/kernel/src/image.rs
+++ b/src/kernel/src/image.rs
@@ -1,3 +1,5 @@
+use core::alloc::Layout;
+
 use xmas_elf::program::{self};
 
 use crate::memory::VirtAddr;
@@ -28,4 +30,99 @@ pub fn get_tls() -> TlsInfo {
         }
     }
     panic!("failed to find TLS program header in kernel image");
+}
+
+#[derive(Copy, Clone)]
+pub enum TlsVariant {
+    Variant1,
+    Variant2,
+}
+
+pub fn init_tls(variant: TlsVariant, tls_template: TlsInfo) -> VirtAddr {
+    match variant {
+        TlsVariant::Variant1 => variant1(tls_template),
+        TlsVariant::Variant2 => variant2(tls_template),
+    }
+}
+
+fn variant1(tls_template: TlsInfo) -> VirtAddr {
+    // TODO: reserved region may be arch specific. aarch64 reserves two
+    // words after the thread pointer (TP) before and TLS blocks
+    let reserved_bytes = core::mem::size_of::<*const u64>() * 2;
+    // the size of the TLS region in memory
+    let tls_size = tls_template.mem_size + reserved_bytes;
+
+    // generate a layout where the size is rounded up if not aligned
+    let layout =
+        Layout::from_size_align(tls_size, tls_template.align).expect("failed to unwrap TLS layout");
+    logln!("[kernel::tls] size of layout to alloc: {}", layout.size());
+
+    // allocate/initialize a region of memory for the thread-local data
+    let tls_region = unsafe {
+        // allocate a region of memory initialized to zero
+        let tcb_base = alloc::alloc::alloc_zeroed(layout);
+        
+        // copy from the kernel's ELF TLS to the allocated region of memory
+        // the layout of this region in memory is architechture dependent.
+        //
+        // Architechtures that use TLS Variant I (e.g. ARM) have the thread pointer 
+        // point to the start of the TCB and thread-local vars are defined 
+        // before this in higher memory addresses. So accessing a thread
+        // local var adds some offset to the thread pointer
+
+        // we need a pointer offset of reserved_bytes. add here increments
+        // the pointer offset by sizeof u8 bytes.
+        let tls_base = tcb_base.add(reserved_bytes);
+
+        logln!("[kernel::tls] copy {} from {:#018x} to {:#018x} ({})",
+            tls_template.file_size,
+            tls_template.start_addr.raw(),
+            tls_base as u64,
+            tls_size,
+        );
+
+        core::ptr::copy_nonoverlapping(tls_template.start_addr.as_ptr(), tls_base, tls_template.file_size);
+
+        tcb_base
+    };
+    
+    // the TP points to the base of the TCB which exists in lower memory.
+    let tcb_base = VirtAddr::from_ptr(tls_region);
+    
+    tcb_base
+}
+
+const MIN_TLS_ALIGN: usize = 16;
+
+fn variant2(tls_template: TlsInfo) -> VirtAddr {
+    let mut tls_size = tls_template.mem_size;
+    let alignment = tls_template.align;
+
+    let start_address_ptr = tls_template.start_addr.as_ptr();
+
+    // The rhs of the below expression essentially calculates the amount of padding
+    // we will have to introduce within the TLS region in order to achieve the desired
+    // alignment.
+    tls_size += (((!tls_size) + 1) - (start_address_ptr as usize)) & (alignment - 1);
+
+    let tls_align = core::cmp::max(alignment, MIN_TLS_ALIGN);
+    let full_tls_size = (core::mem::size_of::<*const u8>() + tls_size + tls_align + MIN_TLS_ALIGN
+        - 1)
+        & ((!MIN_TLS_ALIGN) + 1);
+
+    let layout =
+        Layout::from_size_align(full_tls_size, tls_align).expect("failed to unwrap TLS layout");
+
+    let tls = unsafe {
+        let tls = alloc::alloc::alloc_zeroed(layout);
+
+        core::ptr::copy_nonoverlapping(start_address_ptr, tls, tls_template.file_size);
+
+        tls
+    };
+    let tcb_base = VirtAddr::from_ptr(tls).offset(full_tls_size).unwrap();
+
+    unsafe { *(tcb_base.as_mut_ptr()) = tcb_base.raw() };
+
+    tcb_base
 }

--- a/src/kernel/src/machine/arm/linker.ld
+++ b/src/kernel/src/machine/arm/linker.ld
@@ -23,11 +23,6 @@ SECTIONS
 
     /* Move to the next memory page for .rodata */
     . += CONSTANT(MAXPAGESIZE);
-
-    .limine_reqs : {
-        KEEP(*(.limine_reqs))
-        QUAD(0)
-    } :rodata
     
     .rodata : {
         *(.rodata .rodata.*)
@@ -42,6 +37,11 @@ SECTIONS
         *(.tbss .tbss.*) 
         *(.tcommon) 
     } :tls
+
+    .limine_reqs : {
+        KEEP(*(.limine_reqs))
+        QUAD(0)
+    } :rodata
 
     /* Move to the next memory page for .data */
     . += CONSTANT(MAXPAGESIZE);

--- a/src/kernel/target-spec/aarch64-unknown-none.json
+++ b/src/kernel/target-spec/aarch64-unknown-none.json
@@ -3,7 +3,7 @@
     "arch": "aarch64",
     "data-layout": "e-m:e-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128",
     "disable-redzone": true,
-    "features": "+strict-align,-neon,-fp-armv8",
+    "features": "+strict-align,-neon,-fp-armv8,+tpidr-el1",
     "linker": "rust-lld",
     "linker-flavor": "ld.lld",
     "llvm-target": "aarch64-unknown-none",


### PR DESCRIPTION
Thread Local Storage (TLS) has [two variants](https://www.akkadia.org/drepper/tls.pdf) and that choice is architecture specific. A summary of TLS can be found [here](https://maskray.me/blog/2021-02-14-all-about-thread-local-storage). `x86-64` uses variant II for backwards compatibility, and `aarch64` uses variant I. Given this difference, we cannot assume a particular variant when initializing TLS (`processor::init_tls`). We move TLS initialization out of the `processor` module and into the `image`, where both variants are implemented. The choice of which variant to choose is done in an architecture specific `image` module.

**Summary**
- Change kernel to use `TPDIR_EL1` when compiled for `aarch64`.
- Move around sections in linker script (`aarch64`) so that TLS sections show up.
- Implement variant I of TLS (used by `aarch64`)
- Change TLS initialization to be arch specific