### PR TITLE
Enable debug info in release mode.

### DIFF
--- a/src/kernel/.cargo/config.toml
+++ b/src/kernel/.cargo/config.toml
@@ -3,6 +3,7 @@ runner = "cargo run --package simple_boot --"
 rustflags = [
   "-C", "link-arg=--image-base=0xffffffff80100000", "-Cforce-unwind-tables", "-Cforce-frame-pointers=yes",
   "-C", "link-arg=--no-gc-sections",
+  "-C", "debuginfo=2",
 ]
 
 [target.aarch64-unknown-none]

--- a/src/kernel/Cargo.toml
+++ b/src/kernel/Cargo.toml
@@ -37,3 +37,6 @@ features = ["spin_no_std"]
 
 [package.metadata]
 twizzler-build = "kernel"
+
+[profile.release]
+debug = true


### PR DESCRIPTION
Simple change to enable building debug info for the kernel in release mode.