### PR TITLE
Implement initialization of the init program for aarch64

### DIFF
--- a/src/kernel/src/arch/aarch64/context.rs
+++ b/src/kernel/src/arch/aarch64/context.rs
@@ -110,7 +110,7 @@ impl ArchContext {
     }
 
     pub fn change(&self, _cursor: MappingCursor, _settings: &MappingSettings) {
-        todo!("change")
+        // TODO: change page table entry
     }
 
     pub fn unmap(&self, _cursor: MappingCursor) {

--- a/src/kernel/src/arch/aarch64/exception.rs
+++ b/src/kernel/src/arch/aarch64/exception.rs
@@ -49,7 +49,7 @@ b default_exception_handler
 // Taking an exception from the current EL with SP_EL1 (kernel)
 // The exception is handled from EL1->EL1. The stack pointer from
 // the kernel is preserved.
-b default_exception_handler
+b sync_exception_handler
 .align {VECTOR_ALIGNMENT}
 b interrupt_request_handler
 .align {VECTOR_ALIGNMENT}
@@ -301,6 +301,73 @@ fn debug_handler(ctx: &mut ExceptionContext) {
     emerglog!("[kernel::exception] dumping register state: {}", ctx);
 
     panic!("caught unhandled exception!!!")
+}
+
+// Exception handler that services synchronous exceptions
+exception_handler!(sync_exception_handler, sync_handler);
+
+/// Exception handler deals with synchronous exceptions
+/// such as Data Aborts (i.e. page faults)
+fn sync_handler(ctx: &mut ExceptionContext) {
+    // read of raw value for ESR
+    let esr = ESR_EL1.get();
+    let esr_reg: InMemoryRegister<u64, ESR_EL1::Register> = InMemoryRegister::new(esr);
+    match esr_reg.read_as_enum(ESR_EL1::EC) {
+        Some(ESR_EL1::EC::Value::DataAbortCurrentEL) => {
+            // iss: syndrome
+            let iss = esr_reg.read(ESR_EL1::ISS);
+            // is the fault address register valid?
+            let far_valid = iss & (1 << 10) == 0;
+            // print faulting address (ELR/FAR)
+            let far = arm64::registers::FAR_EL1.get();
+            if !far_valid {
+                panic!("FAR is not valid!!");
+            }
+
+            // was fault caused by a write to memory or a read?
+            let write_fault = iss & (1 << 6) != 0;
+            let cause = if write_fault {
+                MemoryAccessKind::Write
+            } else {
+                MemoryAccessKind::Read
+            };
+
+            // TODO: support for PRESENT and INVALID flags
+            let flags = PageFaultFlags::empty();
+
+            let far_va = VirtAddr::new(far as u64).unwrap();
+
+            // DFSC bits[5:0] indicate the type of fault
+            let dfsc = iss & 0b111111;
+            if dfsc & 0b111100 == 0b001000 {
+                // we have an access fault
+                let level = dfsc & 0b11;
+                todo!("Access flag fault, level {}", level);
+                // TODO: set the access flag
+            } else if dfsc & 0b001100 == 0b001100 {
+                let level = dfsc & 0b11;
+                todo!("Permission fault, level {}", level);
+            }
+            crate::thread::enter_kernel();
+            // crate::interrupt::set(true);
+            let elr = ELR_EL1.get();
+            if let Ok(elr_va) = VirtAddr::new(elr) {
+                crate::memory::context::virtmem::page_fault(
+                    far_va,
+                    cause,
+                    flags,
+                    elr_va,
+                );
+            } else {
+                todo!("send upcall exception info");
+            }
+            // crate::interrupt::set(false);
+            crate::thread::exit_kernel();
+        },
+        Some(ESR_EL1::EC::Value::Unknown) | _ => {
+            debug_handler(ctx)
+        },
+    }
 }
 
 /// Initializes the exception vector table by writing the address of 

--- a/src/kernel/src/clock.rs
+++ b/src/kernel/src/clock.rs
@@ -346,9 +346,12 @@ pub fn fill_with_every_first(slice: &mut [Clock], start: u64) -> Result<usize, R
         // check that we don't go out of slice bounds
         if clocks_added < slice.len() {
             // does this allocate new kernel memory?
+            let info = {
+                TICK_SOURCES.lock()[clock_list.first().unwrap().0 as usize].info()
+            };
             slice[clocks_added].set(
                 // each semantic clock will have at least one element
-                { TICK_SOURCES.lock()[clock_list.first().unwrap().0 as usize].info() },
+                info,
                 clock_list[0],
                 (i as u64).into(),
             );
@@ -379,7 +382,10 @@ pub fn fill_with_kind(
     for id in &clock_list[start as usize..] {
         // check that we don't go out of slice bounds
         if clocks_added < slice.len() {
-            slice[clocks_added].set({ TICK_SOURCES.lock()[id.0 as usize].info() }, *id, clock);
+            let info = {
+                TICK_SOURCES.lock()[id.0 as usize].info()
+            };
+            slice[clocks_added].set(info, *id, clock);
             clocks_added += 1;
         } else {
             break;
@@ -400,7 +406,10 @@ pub fn fill_with_first_kind(
     // check that we don't go out of slice bounds
     if slice.len() >= 1 {
         let id = clock_list.first().unwrap();
-        slice[0].set({ TICK_SOURCES.lock()[id.0 as usize].info() }, *id, clock);
+        let info = {
+            TICK_SOURCES.lock()[id.0 as usize].info()
+        };
+        slice[0].set(info, *id, clock);
         return Ok(clocks_added);
     } else {
         return Err(ReadClockListError::InvalidArgument);

--- a/src/kernel/src/obj/mod.rs
+++ b/src/kernel/src/obj/mod.rs
@@ -8,9 +8,10 @@ use alloc::{
     sync::{Arc, Weak},
     vec::Vec,
 };
-use twizzler_abi::object::ObjID;
+use twizzler_abi::object::{ObjID, MAX_SIZE};
 
 use crate::{
+    arch::memory::frame::FRAME_SIZE,
     idcounter::{IdCounter, SimpleId, StableId},
     memory::{
         context::{kernel_context, Context, ContextRef, UserContext},
@@ -91,7 +92,7 @@ impl PageNumber {
         self.0
     }
 
-    pub const PAGE_SIZE: usize = 0x1000; //TODO: arch-dep
+    pub const PAGE_SIZE: usize = FRAME_SIZE;
 
     pub fn is_zero(&self) -> bool {
         self.0 == 0
@@ -102,7 +103,7 @@ impl PageNumber {
     }
 
     pub fn from_address(addr: VirtAddr) -> Self {
-        PageNumber(((addr.raw() % (1 << 30)) / 0x1000) as usize) //TODO: arch-dep
+        PageNumber((addr.raw() as usize % MAX_SIZE) / Self::PAGE_SIZE)
     }
 
     pub fn next(&self) -> Self {

--- a/src/kernel/src/thread.rs
+++ b/src/kernel/src/thread.rs
@@ -579,7 +579,7 @@ extern "C" fn user_init() {
             twizzler_abi::slot::RESERVED_TEXT,
             obj_text,
             vm.clone(),
-            Protections::READ | Protections::EXEC,
+            Protections::READ | Protections::EXEC | Protections::WRITE,
         )
         .unwrap();
         crate::operations::map_object_into_context(

--- a/src/kernel/src/thread.rs
+++ b/src/kernel/src/thread.rs
@@ -577,7 +577,7 @@ extern "C" fn user_init() {
         let obj_name = create_name_object();
         crate::operations::map_object_into_context(
             twizzler_abi::slot::RESERVED_TEXT,
-            obj_text,
+            obj_text.clone(),
             vm.clone(),
             Protections::READ | Protections::EXEC | Protections::WRITE,
         )
@@ -599,7 +599,7 @@ extern "C" fn user_init() {
         crate::operations::map_object_into_context(
             twizzler_abi::slot::RESERVED_KERNEL_INIT,
             obj_name,
-            vm,
+            vm.clone(),
             Protections::READ,
         )
         .unwrap();
@@ -651,6 +651,14 @@ extern "C" fn user_init() {
 
         aux = append_aux(aux, AuxEntry::ExecId(init_obj.id()));
         append_aux(aux, AuxEntry::Null);
+
+        // remove permission mappings from text segment
+        let page_tree = obj_text.lock_page_tree();
+        for r in page_tree.range(0.into()..usize::MAX.into()) {
+            let range = *r.0..r.0.offset(r.1.length);
+            vm.invalidate_object(obj_text.id(), &range, crate::obj::InvalidateMode::WriteProtect);
+        }
+
         (aux_start, elf.header.pt2.entry_point())
     };
 


### PR DESCRIPTION
This PR implements some of the arch-specific functionality described by https://github.com/twizzler-operating-system/twizzler/blob/328649966ea6d907b72c5238321ca32fd6cbe418/src/kernel/src/thread.rs#L568

We implemented page fault handling for user pages while in the kernel so that we can initalize the memory context used by the init program. We also changed the mapping required by the text segment (initially read-only) to be writable, and the remove this permission later. The execution gets to `jump_to_user` which will be implemented in a future patch.

**Summary**
* change stack pointer to user `SP_EL1` instead of `SP_EL0`
* create a synchronous exception handler
* service page faults to user pages while in the kernel
* modify permissions on the text segment of the init program
* fix some misc warnings
* make `PageNumber` arch-dep