### PR TITLE
TLB and PTE cache consistency for aarch64

### DIFF
--- a/src/kernel/src/arch/aarch64/interrupt.rs
+++ b/src/kernel/src/arch/aarch64/interrupt.rs
@@ -63,6 +63,7 @@ bitflags::bitflags! {
     }
 }
 
+/// Set the current interrupt enable state to disabled and return the old state.
 pub fn disable() -> bool {
     // check if interrutps were already enabled.
     // if the I bit is set, then IRQ exceptions
@@ -83,6 +84,7 @@ pub fn disable() -> bool {
     irq_enabled
 }
 
+/// Set the current interrupt enable state.
 pub fn set(state: bool) {
     // state singifies if interrupts need to enabled or disabled
     // the state can refer to the previous state of the I bit (IRQ)
@@ -99,6 +101,14 @@ pub fn set(state: bool) {
     } else {
         disable();
     }
+}
+
+/// Get the current interrupt enable state without modifying it.
+pub fn get() -> bool {
+    // if the I bit is set, then IRQ exceptions are masked (disabled)
+    // We return false for masked interrupts and true for
+    // unmasked (enabled) interrupts
+    !DAIF.is_set(DAIF::I)
 }
 
 // The top level interrupt request (IRQ) handler. Deals with

--- a/src/kernel/src/arch/aarch64/memory/pagetables/consistency.rs
+++ b/src/kernel/src/arch/aarch64/memory/pagetables/consistency.rs
@@ -5,117 +5,12 @@ use crate::{
     // interrupt::Destination,
 };
 
-// TODO:
-const MAX_INVALIDATION_INSTRUCTIONS: usize = 0;
-#[derive(Clone)]
-struct TlbInvData {
-    // target_cr3: u64,
-    // instructions: [InvInstruction; MAX_INVALIDATION_INSTRUCTIONS],
-    len: u8,
-    // flags: u8,
-    addresses: [
-        VirtAddr; Self::MAX_OUTSTANDING_INVALIDATIONS
-    ],
-}
-
-fn tlb_non_global_inv() {
-    todo!("non global tlb invalidation")
-}
-
-fn tlb_global_inv() {
-    todo!("tlb global invalidation")
-}
-
-impl TlbInvData {
-    // TODO: tlb invalidation flags
-    const GLOBAL: u8 = 0;
-    const FULL: u8 = 0;
-
-    // the maximum number of tlb invalidations that can
-    // be enqueued
-    const MAX_OUTSTANDING_INVALIDATIONS: usize = 16;
-
-    // fn set_global(&mut self) {
-    //     self.flags |= Self::GLOBAL;
-    // }
-
-    // fn set_full(&mut self) {
-    //     self.flags |= Self::FULL;
-    // }
-
-    // fn full(&self) -> bool {
-    //     self.flags & Self::FULL != 0
-    // }
-
-    // fn global(&self) -> bool {
-    //     self.flags & Self::GLOBAL != 0
-    // }
-
-    // fn target(&self) -> u64 {
-    //     todo!()
-    // }
-
-    // fn instructions(&self) -> &[InvInstruction] {
-    //     &self.instructions[0..(self.len as usize)]
-    // }
-
-    // fn enqueue(&mut self, inst: InvInstruction) {
-    //     if inst.is_global() {
-    //         self.set_global();
-    //     }
-
-    //     if self.len as usize == MAX_INVALIDATION_INSTRUCTIONS {
-    //         self.set_full();
-    //         return;
-    //     }
-
-    //     self.instructions[self.len as usize] = inst;
-    //     self.len += 1;
-    // }
-
-    // unsafe fn do_invalidation(&self) {
-    //     todo!()
-    // }
-}
-
-#[derive(Debug, Clone, Copy)]
-#[repr(transparent)]
-struct InvInstruction(u64);
-
-impl InvInstruction {
-    fn new(_addr: VirtAddr, _is_global: bool, _is_terminal: bool, _level: u8) -> Self {
-        todo!()
-    }
-
-    fn addr(&self) -> VirtAddr {
-        todo!()
-    }
-
-    fn is_global(&self) -> bool {
-        todo!()
-    }
-
-    fn is_terminal(&self) -> bool {
-        todo!()
-    }
-
-    fn level(&self) -> u8 {
-        todo!()
-    }
-
-    fn execute(&self) {
-        todo!();
-    }
-}
-
 #[derive(Default)]
 /// An object that manages cache line invalidations during page table updates.
 pub struct ArchCacheLineMgr {
     dirty: Option<u64>, // a single cacheline address to flush
 }
 
-// TODO:
-const CACHE_LINE_SIZE: u64 = 64;
 impl ArchCacheLineMgr {
     /// Flush a given cache line when this [ArchCacheLineMgr] is dropped. Subsequent flush requests for the same cache
     /// line will be batched. Flushes for different cache lines will cause older requests to flush immediately, and the
@@ -123,8 +18,8 @@ impl ArchCacheLineMgr {
     pub fn flush(&mut self, line: VirtAddr) {
         // logln!("[arch::cacheln] flush called on: {:#018x}", line.raw());
         let addr: u64 = line.into();
-        // TODO: not sure if we need this step
-        // let addr = addr & !(CACHE_LINE_SIZE - 1);
+        // According to the AArch64 instruction manual:
+        // "No alignment restrictions apply to this VA."
         if let Some(dirty) = self.dirty {
             if dirty != addr {
                 self.do_flush();
@@ -136,20 +31,20 @@ impl ArchCacheLineMgr {
     }
 
     fn do_flush(&mut self) {
-        if let Some(_addr) = self.dirty {
-            // logln!("[arch::cacheln] flush something: {:#018x}", addr);
+        if let Some(addr) = self.dirty {
             unsafe {
                 core::arch::asm!(
-                    // flush the data part of the cache line
-                    // TODO: do we need to use `dc cvac addr`?
+                    // clean to point of coherency so all observers see the same thing
+                    // dc - data cache
+                    // cvac - clean by va to point of coherency
+                    "dc cvac, {}",
                     // ensure the change to the table entry is visible to the MMU
                     "dsb ishst",
                     // ensure that the dsb has completed before the next instruction
                     "isb",
+                    in(reg) addr
                 );
             }
-        } else {
-            // logln!("[arch::cacheln] flush something: None");
         }
     }
 }
@@ -160,9 +55,88 @@ impl Drop for ArchCacheLineMgr {
     }
 }
 
+#[derive(Clone, Copy, Default)]
+struct TlbInvData(u64);
+
+impl TlbInvData {
+    const TLBI_SHIFT: usize = 12;
+    fn new(addr: VirtAddr) -> Self {
+        let va: u64 = addr.into();
+        TlbInvData(va >> Self::TLBI_SHIFT)
+    }
+
+    fn data(&self) -> u64 {
+        self.0
+    }
+
+    fn addr(&self) -> u64 {
+        self.0 << Self::TLBI_SHIFT
+    }
+
+    fn execute(&self) {
+        // logln!("[arch::tlb] addr: {:#018x}", self.addr());
+        // TODO: can we batch sync barriers?
+        unsafe {
+            core::arch::asm!(
+                // wait for other data modifications to finish
+                "dsb ishst",
+                // e1 - EL1
+                // va - by virtual address
+                // is - inner sharable
+                "tlbi vae1is, {}",
+                // wait for tlbi instruction to finish
+                "dsb ish",
+                // wait for data sync barrier to finish
+                "isb",
+                in(reg) self.data()
+            );
+        }
+    }
+}
+
+// A queue of TLB invalidations containg the data arguments
+struct TlbInvQueue {
+    data: [TlbInvData; Self::MAX_OUTSTANDING_INVALIDATIONS],
+    len: u8
+}
+
+impl TlbInvQueue {
+    const MAX_OUTSTANDING_INVALIDATIONS: usize = 16;
+
+    fn new() -> Self {
+        Self { 
+            data: [TlbInvData::default(); Self::MAX_OUTSTANDING_INVALIDATIONS], 
+            len: 0 
+        }
+    }
+
+    fn enqueue(&mut self, addr: VirtAddr) {
+        // check if the queue is full
+        if self.is_full() {
+            self.drain();
+        }
+        // enqueue tlb invalidation data
+        let next = self.len as usize;
+        self.data[next] = TlbInvData::new(addr);
+        self.len += 1;
+    }
+
+    fn is_full(&self) -> bool {
+        self.len as usize == Self::MAX_OUTSTANDING_INVALIDATIONS
+    }
+
+    fn drain(&mut self) {
+        for i in 0..self.len as usize {
+            let inv = &self.data[i];
+            inv.execute();
+        }
+        self.len = 0;
+    }
+}
+
 /// A management object for TLB invalidations that occur during a page table operation.
 pub struct ArchTlbMgr {
-    data: TlbInvData,
+    queue: TlbInvQueue,
     root: PhysAddr
 }
 
@@ -170,26 +144,28 @@ impl ArchTlbMgr {
     /// Construct a new [ArchTlbMgr].
     pub fn new(table_root: PhysAddr) -> Self {
         Self {
-            data: TlbInvData { 
-                addresses: [
-                    unsafe {
-                        VirtAddr::new_unchecked(0)
-                    }; TlbInvData::MAX_OUTSTANDING_INVALIDATIONS
-                ],
-                len: 0,
-            },
+            queue: TlbInvQueue::new(),
             root: table_root,
         }
     }
 
     /// Enqueue a new TLB invalidation. is_global should be set iff the page is global, and is_terminal should be set
     /// iff the invalidation is for a leaf.
-    pub fn enqueue(&mut self, _addr: VirtAddr, _is_global: bool, _is_terminal: bool, _level: usize) {
-        todo!()
+    pub fn enqueue(&mut self, addr: VirtAddr, _is_global: bool, is_terminal: bool, _level: usize) {
+        // only invalidate leaves
+        if is_terminal {
+            self.queue.enqueue(addr);
+        }
     }
 
     /// Execute all queued invalidations.
     pub fn finish(&mut self) {
-        todo!()
+        self.queue.drain()
+    }
+}
+
+impl Drop for ArchTlbMgr {
+    fn drop(&mut self) {
+        self.finish();
     }
 }

--- a/src/kernel/src/arch/aarch64/memory/pagetables/entry.rs
+++ b/src/kernel/src/arch/aarch64/memory/pagetables/entry.rs
@@ -94,6 +94,8 @@ impl Entry {
             1 => PhysAddr::new(self.0 & Self::LVL1_BLK_ADDR_MASK).unwrap(),
             2 => PhysAddr::new(self.0 & Self::LVL2_BLK_ADDR_MASK).unwrap(),
             3 => PhysAddr::new(self.0 & Self::LVL3_PAGE_ADDR_MASK).unwrap(),
+            // this is used when changing/unmapping entries
+            0 => self.table_addr(),
             _ => todo!("getting the address from this level: {}", level)
         }
     }

--- a/src/kernel/src/arch/aarch64/mod.rs
+++ b/src/kernel/src/arch/aarch64/mod.rs
@@ -43,7 +43,18 @@ pub fn init<B: BootInfo>(_boot_info: &B) {
     SPSel.write(SPSel::SP::ELx);
 
     // save the stack pointer from before
-    let sp = SP_EL0.get();
+    let old_sp = SP_EL0.get();
+
+    // make it so that the boot stack is in higher half memory
+    //
+    // NOTE: this is currently specific to Limine on aarch64
+    let sp = if VirtAddr::new(old_sp).unwrap().is_kernel() {
+        old_sp
+    } else {
+        unsafe {
+            PhysAddr::new_unchecked(old_sp).kernel_vaddr().raw()
+        }
+    };
 
     // set current stack pointer to previous,
     // sp is now aliased to SP_EL1


### PR DESCRIPTION
This patch implements cache consistency for the data cache that may contain page table entries and the TLB which caches translations. From my understanding, the consistency is maintained system wide. So in ARM-speak to the point of coherency (PoC) and inner sharable. Page table entries are already marked inner sharable. https://github.com/twizzler-operating-system/twizzler/blob/167025d28e14e0029a239400081522ba49d69847/src/kernel/src/arch/aarch64/memory/pagetables/entry.rs#L26-L35

A better explanation of inner sharable can be found [here](https://developer.arm.com/documentation/den0013/d/Caches/Point-of-coherency-and-unification). According to the[ Arm Armv8-A Architecture Registers](https://developer.arm.com/documentation/ddi0595/2021-06/AArch64-Instructions/TLBI-VAE1IS--TLBI-VAE1ISNXS--TLB-Invalidate-by-VA--EL1--Inner-Shareable?lang=en) document the TLB invalidation instruction "applies to all PEs in the same Inner Shareable shareability domain as the PE that executes [that] System instruction."

The implementation of the TLB management code drains the queue of TLB invalidations on an enqueue operation if the queue is full, and also drains the queue when it is dropped (much like `ArchCacheLineMgr`). This is different from the x86 implementation and functionally from the generic code. This is due to `finish` never being called.
https://github.com/twizzler-operating-system/twizzler/blob/0a4120a43058fd28f2d4383be056edbdfe070a31/src/kernel/src/memory/pagetables/consistency.rs#L48-L51

**Summary**
* implement `unmap` and `map` operations for `ArchContext`
* implement TLB invalidations (`tlbi`)
* ensure that the stack pointer is in higher memory
* implement interrupt `get` state
