### PR TITLE
System Calls for aarch64

### DIFF
--- a/src/kernel/src/arch/aarch64/interrupt.rs
+++ b/src/kernel/src/arch/aarch64/interrupt.rs
@@ -14,7 +14,9 @@ use twizzler_abi::{
 use crate::interrupt::{DynamicInterrupt, Destination};
 use crate::machine::interrupt::INTERRUPT_CONTROLLER;
 
-use super::exception::{exception_handler, ExceptionContext};
+use super::exception::{
+    ExceptionContext, exception_handler, save_stack_pointer, restore_stack_pointer,
+};
 use super::cntp::{PhysicalTimer, cntp_interrupt_handler};
 
 // interrupt vector table size/num vectors
@@ -114,7 +116,8 @@ pub fn get() -> bool {
 // The top level interrupt request (IRQ) handler. Deals with
 // interacting with the interrupt controller and acknowledging
 // device interrupts.
-exception_handler!(interrupt_request_handler, irq_exception_handler);
+exception_handler!(interrupt_request_handler_el1, irq_exception_handler, true);
+exception_handler!(interrupt_request_handler_el0, irq_exception_handler, false);
 
 /// Exception handler manages IRQs and calls the appropriate
 /// handler for a given IRQ number. This handler manages state

--- a/src/kernel/src/arch/aarch64/mod.rs
+++ b/src/kernel/src/arch/aarch64/mod.rs
@@ -10,6 +10,7 @@ use crate::{
     clock::Nanoseconds,
     interrupt::{Destination, PinPolarity, TriggerMode},
     BootInfo,
+    syscall::SyscallContext,
 };
 
 pub mod address;
@@ -108,8 +109,10 @@ pub fn schedule_oneshot_tick(time: Nanoseconds) {
 /// Jump into userspace
 /// # Safety
 /// The stack and target must be valid addresses.
-pub unsafe fn jump_to_user(_target: crate::memory::VirtAddr, _stack: crate::memory::VirtAddr, _arg: u64) {
-    todo!("jump to user");
+pub unsafe fn jump_to_user(target: crate::memory::VirtAddr, stack: crate::memory::VirtAddr, arg: u64) {
+    let ctx = syscall::Armv8SyscallContext::create_jmp_context(target, stack, arg);
+    crate::thread::exit_kernel();
+    syscall::return_to_user(&ctx as *const syscall::Armv8SyscallContext);
 }
 
 pub fn debug_shutdown(_code: u32) {

--- a/src/kernel/src/arch/aarch64/mod.rs
+++ b/src/kernel/src/arch/aarch64/mod.rs
@@ -112,7 +112,7 @@ pub fn schedule_oneshot_tick(time: Nanoseconds) {
 pub unsafe fn jump_to_user(target: crate::memory::VirtAddr, stack: crate::memory::VirtAddr, arg: u64) {
     let ctx = syscall::Armv8SyscallContext::create_jmp_context(target, stack, arg);
     crate::thread::exit_kernel();
-    syscall::return_to_user(&ctx as *const syscall::Armv8SyscallContext);
+    syscall::return_to_user(&ctx);
 }
 
 pub fn debug_shutdown(_code: u32) {

--- a/src/kernel/src/arch/aarch64/mod.rs
+++ b/src/kernel/src/arch/aarch64/mod.rs
@@ -1,5 +1,8 @@
-use arm64::registers::{TPIDR_EL1, SPSel, SP_EL0};
-use registers::interfaces::{Readable, Writeable};
+use arm64::registers::{TPIDR_EL1, SPSel};
+use registers::{
+    registers::InMemoryRegister,
+    interfaces::{Readable, Writeable},
+};
 
 use twizzler_abi::syscall::TimeSpan;
 
@@ -34,35 +37,41 @@ pub fn init<B: BootInfo>(_boot_info: &B) {
     // On reset, TPIDR_EL1 is initialized to some unknown value.
     // we set it to zero so that we know it is not initialized.
     TPIDR_EL1.set(0);
-
-    // TODO: check if SPSel is already set to use SP_EL1
-    // TODO: scrub SP_EL0 if we do change SP
-
-    // make it so that we use SP_EL1 in the kernel
-    // when taking an exception.
-    SPSel.write(SPSel::SP::ELx);
-
-    // save the stack pointer from before
-    let old_sp = SP_EL0.get();
-
-    // make it so that the boot stack is in higher half memory
-    //
-    // NOTE: this is currently specific to Limine on aarch64
-    let sp = if VirtAddr::new(old_sp).unwrap().is_kernel() {
-        old_sp
-    } else {
+    
+    // check if SPSel is already set to use SP_EL1
+    let spsel: InMemoryRegister<u64, SPSel::Register> = InMemoryRegister::new(SPSel.get());
+    if spsel.matches_all(SPSel::SP::EL0) {
+        // make it so that we use SP_EL1 in the kernel
+        // when taking an exception.
+        spsel.write(SPSel::SP::ELx);
+        let sp: u64;
         unsafe {
-            PhysAddr::new_unchecked(old_sp).kernel_vaddr().raw()
+            core::arch::asm!(
+                // save the stack pointer from before
+                "mov {0}, sp",
+                // change usage of sp from SP_EL0 to SP_EL1
+                "msr spsel, {1}",
+                // set current stack pointer to previous,
+                // sp is now aliased to SP_EL1
+                "mov sp, {0}",
+                // scrub the value stored in SP_EL0
+                // "msr sp_el0, xzr",
+                out(reg) sp,
+                in(reg) spsel.get(),
+            );
         }
-    };
 
-    // set current stack pointer to previous,
-    // sp is now aliased to SP_EL1
-    unsafe {
-        core::arch::asm!(
-            "mov sp, {}",
-            in(reg) sp,
-        );
+        // make it so that the boot stack is in higher half memory
+        if !VirtAddr::new(sp).unwrap().is_kernel() {
+            unsafe {
+                // we convert it to higher memory that has r/w permissions
+                let new_sp = PhysAddr::new_unchecked(sp).kernel_vaddr().raw();
+                core::arch::asm!(
+                    "mov sp, {}",
+                    in(reg) new_sp,
+                );
+            }
+        }
     }
 }
 

--- a/src/kernel/src/arch/aarch64/syscall.rs
+++ b/src/kernel/src/arch/aarch64/syscall.rs
@@ -1,20 +1,38 @@
+/// System call handling.
+///
+/// The registers used for system call arguments and return values
+/// are chosen based on information in the 64-bit ARM PCS.
+///
+/// "Procedure Call Standard for the Arm® 64-bit Architecture (AArch64)":
+///     https://github.com/ARM-software/abi-aa/releases/download/2023Q1/aapcs64.pdf
+
 use arm64::registers::{ELR_EL1, SP_EL0, SPSR_EL1};
-use registers::interfaces::Writeable;
+use registers::interfaces::{Readable, Writeable};
 
 use twizzler_abi::upcall::UpcallFrame;
 
 use crate::{memory::VirtAddr, syscall::SyscallContext};
 
-use super::thread::UpcallAble;
+use super::{thread::UpcallAble, exception::ExceptionContext};
 
+/// The register state needed to transition between kernel and user.
+///
+/// According to the ARM PCS Section 6, arguments/return values are
+/// passed in via registers x0-x7
 #[derive(Default, Clone, Copy)]
 #[repr(C)]
 pub struct Armv8SyscallContext {
     x0: u64,
+    x1: u64,
+    x2: u64,
+    x3: u64,
+    x4: u64,
+    x5: u64,
+    x6: u64,
+    x7: u64,
     elr: u64,
     sp: u64,
 }
-
 impl From<Armv8SyscallContext> for UpcallFrame {
     fn from(_int: Armv8SyscallContext) -> Self {
         todo!()
@@ -31,6 +49,9 @@ impl UpcallAble for Armv8SyscallContext {
     }
 }
 
+// Arguments 0-5 are passed in via registers x0-x5,
+// the syscall number is passed in register x6,
+// and the return values are passed in via x6/x7
 impl SyscallContext for Armv8SyscallContext {
     fn create_jmp_context(target: VirtAddr, stack: VirtAddr, arg: u64) -> Self {
         Self {
@@ -42,36 +63,38 @@ impl SyscallContext for Armv8SyscallContext {
     }
 
     fn num(&self) -> usize {
-        todo!()
+        self.x6 as usize
     }
     fn arg0<T: From<u64>>(&self) -> T {
-        todo!()
+        T::from(self.x0)
     }
     fn arg1<T: From<u64>>(&self) -> T {
-        todo!()
+        T::from(self.x1)
     }
     fn arg2<T: From<u64>>(&self) -> T {
-        todo!()
+        T::from(self.x2)
     }
     fn arg3<T: From<u64>>(&self) -> T {
-        todo!()
+        T::from(self.x3)
     }
     fn arg4<T: From<u64>>(&self) -> T {
-        todo!()
+        T::from(self.x4)
     }
     fn arg5<T: From<u64>>(&self) -> T {
-        todo!()
+        T::from(self.x5)
     }
     fn pc(&self) -> VirtAddr {
-        todo!()
+        // TODO: save and pass in elr register
+        todo!("get pc")
     }
 
-    fn set_return_values<R1, R2>(&mut self, _ret0: R1, _ret1: R2)
+    fn set_return_values<R1, R2>(&mut self, ret0: R1, ret1: R2)
     where
         u64: From<R1>,
         u64: From<R2>,
     {
-        todo!()
+        self.x6 = u64::from(ret0);
+        self.x7 = u64::from(ret1);
     }
 }
 
@@ -82,6 +105,9 @@ pub unsafe fn return_to_user(context: *const Armv8SyscallContext) -> ! {
     ELR_EL1.set((*context).elr);
     // set the stack pointer
     SP_EL0.set((*context).sp);
+
+    // TODO: enable interrupts
+
     // configure the execution state for EL0:
     // - interrupts masked
     // - el0 exception level
@@ -103,9 +129,38 @@ pub unsafe fn return_to_user(context: *const Armv8SyscallContext) -> ! {
     )
 }
 
-// #[allow(unsupported_naked_functions)] // DEBUG
-#[allow(named_asm_labels)]
-#[naked]
-pub unsafe extern "C" fn syscall_entry() -> ! {
-    core::arch::asm!("nop", options(noreturn))
+/// Service a system call according to the ABI defined in [`twizzler_abi`]
+pub fn handle_syscall(ctx: &mut ExceptionContext) {
+    crate::thread::enter_kernel();
+    // crate::interrupt::set(true);
+
+    // TODO: create syscall context from calling context
+    let mut context: Armv8SyscallContext = Default::default();
+    context.x0 = ctx.x0;
+    context.x1 = ctx.x1;
+    context.x2 = ctx.x2;
+    context.x3 = ctx.x3;
+    context.x4 = ctx.x4;
+    context.x5 = ctx.x5;
+    context.x6 = ctx.x6;
+    context.x7 = ctx.x7;
+
+    // TODO: save this in the incoming exception?
+    context.elr = ELR_EL1.get();
+
+    // TODO: get stack pointer
+
+    crate::syscall::syscall_entry(&mut context);
+    // crate::interrupt::set(false);
+    crate::thread::exit_kernel();
+
+    // copy over register values to exception return context
+
+    // overwrite the calling context with the result values
+    // we use registers x6 and x7 for this purpose
+    ctx.x6 = context.x6;
+    ctx.x7 = context.x7;
+
+    // returning from here will restore the calling context
+    // and then call `eret` to jump back to user space
 }

--- a/src/lib/twizzler-abi/src/arch/aarch64/syscall.rs
+++ b/src/lib/twizzler-abi/src/arch/aarch64/syscall.rs
@@ -1,5 +1,8 @@
 use crate::syscall::Syscall;
 
+/// Magic number used when calling SVC (syscall)
+pub const SYSCALL_MAGIC: u64 = 42;
+
 #[allow(dead_code)]
 /// Call into the kernel to perform a synchronous system call. The args array can be at most 6 long,
 /// and the meaning of the args depends on the system call.
@@ -12,6 +15,34 @@ use crate::syscall::Syscall;
 /// The caller must ensure that the args have the correct meaning for the syscall in question, and
 /// to handle the return values correctly. Additionally, calling the kernel can invoke any kind of
 /// weirdness if you do something wrong.
-pub unsafe fn raw_syscall(_call: Syscall, _args: &[u64]) -> (u64, u64) {
-    todo!()
+pub unsafe fn raw_syscall(call: Syscall, args: &[u64]) -> (u64, u64) {
+    if core::intrinsics::unlikely(args.len() > 6) {
+        crate::print_err("too many arguments to raw_syscall");
+        crate::internal_abort();
+    }
+    let a0 = *args.get(0).unwrap_or(&0u64);
+    let a1 = *args.get(1).unwrap_or(&0u64);
+    let a2 = *args.get(2).unwrap_or(&0u64);
+    let a3 = *args.get(3).unwrap_or(&0u64);
+    let a4 = *args.get(4).unwrap_or(&0u64);
+    let a5 = *args.get(5).unwrap_or(&0u64);
+
+    let mut num = call.num();
+    let ret1: u64;
+    core::arch::asm!(
+        "svc #{magic}",
+        magic = const SYSCALL_MAGIC,
+        in("x0") a0,
+        in("x1") a1,
+        in("x2") a2,
+        in("x3") a3,
+        in("x4") a4,
+        in("x5") a5,
+        // register x6 is used to store the
+        // syscall number, but is overwritten
+        // with the first return value
+        inout("x6") num,
+        out("x7") ret1,
+    );
+    (num, ret1)
 }

--- a/src/lib/twizzler-abi/src/lib.rs
+++ b/src/lib/twizzler-abi/src/lib.rs
@@ -20,6 +20,7 @@
 #![feature(negative_impls)]
 #![feature(rustc_attrs)]
 #![feature(asm_sym)]
+#![feature(asm_const)]
 pub mod arch;
 
 pub mod alloc;


### PR DESCRIPTION
Support for system calls is implemented in this PR. We have defined the syscall calling convention based on our understanding of [the 64-bit ARM PCS](https://github.com/ARM-software/abi-aa/releases/download/2023Q1/aapcs64.pdf) in the twizzler-abi crate, and the receiving end in the kernel. We are able to successfully jump to and from user space. The kernel can now run code in user space and that code can execute syscalls (like writing to the kernel console). Support for full-fledged user programs (i.e. ELF files) will be implemented in the future.

**Summary**
* user context initialization for jumping to user space
* implement syscall ABI in twizzler-abi and kernel
* make stack pointer switch use assembly
* save SP_EL0 when handling exception from user space
