### PR TITLE
Implement TLS Variant I in the Twizzler ABI

### DIFF
--- a/src/kernel/src/arch/aarch64/thread.rs
+++ b/src/kernel/src/arch/aarch64/thread.rs
@@ -8,6 +8,9 @@
 /// "Procedure Call Standard for the Arm® 64-bit Architecture (AArch64)":
 ///     https://github.com/ARM-software/abi-aa/releases/download/2023Q1/aapcs64.pdf
 
+use arm64::registers::TPIDR_EL0;
+use registers::interfaces::Writeable;
+
 use twizzler_abi::upcall::{UpcallFrame, UpcallInfo};
 
 use crate::thread::Thread;
@@ -87,8 +90,9 @@ impl Thread {
         todo!()
     }
 
-    pub fn set_tls(&self, _tls: u64) {
-        todo!()
+    pub fn set_tls(&self, tls: u64) {
+        // TODO: save TLS pointer in thread state, and track in context switches
+        TPIDR_EL0.set(tls);
     }
 
     /// Architechture specific CPU context switch.

--- a/src/lib/twizzler-abi/src/arch/aarch64/mod.rs
+++ b/src/lib/twizzler-abi/src/arch/aarch64/mod.rs
@@ -2,3 +2,9 @@
 pub(crate) mod rt0;
 pub mod syscall;
 pub(crate) mod upcall;
+
+#[cfg(feature = "rt")]
+pub(crate) fn new_thread_tls() -> Option<(usize, *mut u8, usize, usize)> {
+    // aarch64 uses variant I for TLS
+    crate::rt1::tls_variant1()
+}

--- a/src/lib/twizzler-abi/src/arch/x86_64/mod.rs
+++ b/src/lib/twizzler-abi/src/arch/x86_64/mod.rs
@@ -2,3 +2,9 @@
 pub(crate) mod rt0;
 pub mod syscall;
 pub(crate) mod upcall;
+
+#[cfg(feature = "rt")]
+pub(crate) fn new_thread_tls() -> Option<(usize, *mut u8, usize, usize)> {
+    // x86_64 uses variant II for TLS
+    crate::rt1::tls_variant2()
+}

--- a/src/lib/twizzler-abi/src/rt1.rs
+++ b/src/lib/twizzler-abi/src/rt1.rs
@@ -93,6 +93,7 @@ pub(crate) fn get_load_seg(nr: usize) -> Option<(usize, usize)> {
     }
 }
 
+#[allow(dead_code)]
 const MIN_TLS_ALIGN: usize = 16;
 use core::alloc::Layout;
 fn init_tls() -> Option<u64> {
@@ -101,6 +102,52 @@ fn init_tls() -> Option<u64> {
 
 //let (tls_set, tls_base, tls_len, tls_align) = crate::rt1::new_thread_tls();
 pub(crate) fn new_thread_tls() -> Option<(usize, *mut u8, usize, usize)> {
+    crate::arch::new_thread_tls()
+}
+
+#[allow(dead_code)]
+pub(crate) fn tls_variant1() -> Option<(usize, *mut u8, usize, usize)> {
+    unsafe {
+        TLS_INFO.as_ref().map(|tls_template| {
+            // TODO: reserved region may be arch specific. aarch64 reserves two
+            // words after the thread pointer (TP), before any TLS blocks
+            let reserved_bytes = core::mem::size_of::<*const u64>() * 2;
+            // the size of the TLS region in memory
+            let tls_size = tls_template.memsz + reserved_bytes;
+
+            // generate a layout where the size is rounded up if not aligned
+            let layout = crate::internal_unwrap(
+                Layout::from_size_align(tls_size, tls_template.align).ok(),
+                "failed to unwrap TLS layout",
+            );            
+            
+            // allocate a region of memory for the thread-local data initialized to zero
+            let tcb_base = crate::alloc::global_alloc(layout);
+            if tcb_base.is_null() {
+                crate::print_err("failed to allocate TLS");
+                crate::abort();
+            }
+            ptr::write_bytes(tcb_base, 0x00, layout.size());
+
+            // Architechtures that use TLS Variant I (e.g. ARM) have the thread pointer 
+            // point to the start of the TCB and thread-local vars are defined 
+            // before this in higher memory addresses. So accessing a thread
+            // local var adds some offset to the thread pointer
+            //
+            // we need a pointer offset of reserved_bytes. add here increments
+            // the pointer offset by sizeof u8 bytes.
+            let tls_base = tcb_base.add(reserved_bytes);
+            // copy from the ELF TLS segment to the allocated region of memory
+            core::ptr::copy_nonoverlapping(tls_template.template_start, tls_base, tls_template.filsz);
+
+            // the TP points to the base of the TCB which exists in lower memory.
+            (tcb_base as usize, tcb_base, layout.size(), layout.align())
+        })
+    }
+}
+
+#[allow(dead_code)]
+pub(crate) fn tls_variant2() -> Option<(usize, *mut u8, usize, usize)> {
     unsafe {
         TLS_INFO.as_ref().map(|info| {
             let mut tls_size = info.memsz;


### PR DESCRIPTION
Similar to #128, we implement TLS Variant I which is used by some architectures other than x86, namely ARM. The right TLS variant is chosen in the `arch` part of the `twizzler-abi` crate. Once we had TLS "working" we found out that the data segment of the init program's ELF executable was partially mapped to a read-only slot. So we ended up setting the offset of where data segment starts for the `aarch64-unknown-twizzler` triple. After this we are able to get the init program to run, and print "Hello, World 42." It gets to the point where it waits for the device manager which we have yet to implement support for on `aarch64`.

**Summary**
* implement TLS variant I in the `twizzler-abi` crate
* make sure that TLS initialization is architecture dependent
* set the user TLS register (`TPIDR_EL0`) in the kernel
* move the data segment onto the next object slot for `aarch64-unknown-twizzler`