### PR TITLE
Implement first-pass of reference runtime.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1665,6 +1665,8 @@ dependencies = [
 name = "monitor"
 version = "0.1.0"
 dependencies = [
+ "dynlink",
+ "tracing",
  "twizzler-abi",
  "twizzler-runtime-api",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1660,6 +1660,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "monitor"
+version = "0.1.0"
+dependencies = [
+ "twizzler-abi",
+ "twizzler-runtime-api",
+]
+
+[[package]]
 name = "native-tls"
 version = "0.2.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2998,6 +3006,16 @@ dependencies = [
  "bitflags 1.3.2",
  "compiler_builtins",
  "rustc-std-workspace-core",
+]
+
+[[package]]
+name = "twz-rt"
+version = "0.1.0"
+dependencies = [
+ "thiserror",
+ "tracing",
+ "twizzler-abi",
+ "twizzler-runtime-api",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -214,6 +214,7 @@ dependencies = [
  "tracing-subscriber",
  "twizzler-abi",
  "twizzler-object",
+ "twizzler-runtime-api",
 ]
 
 [[package]]
@@ -3012,6 +3013,7 @@ dependencies = [
 name = "twz-rt"
 version = "0.1.0"
 dependencies = [
+ "dynlink",
  "thiserror",
  "tracing",
  "twizzler-abi",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -695,6 +695,7 @@ dependencies = [
  "tracing",
  "twizzler-abi",
  "twizzler-object",
+ "twizzler-runtime-api",
 ]
 
 [[package]]
@@ -3013,7 +3014,9 @@ dependencies = [
 name = "twz-rt"
 version = "0.1.0"
 dependencies = [
+ "bitflags 2.4.0",
  "dynlink",
+ "talc",
  "thiserror",
  "tracing",
  "twizzler-abi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,8 @@ members = [
     "src/lib/twizzler-object",
     "src/lib/twizzler-runtime-api",
     "src/runtime/dynlink",
+    "src/runtime/monitor",
+    "src/runtime/twz-rt",
 ]
 
 exclude = ["toolchain/src/rust"]
@@ -27,11 +29,13 @@ resolver = "2"
 
 [workspace.metadata]
 initrd = [
-    "crate:init",
+    "crate:bootstrap",
     "crate:devmgr",
     "crate:netmgr",
     "crate:nettest",
     "crate:pager",
+    "lib:twz-rt",
+    "lib:monitor",
     #"third-party:hello-world-rs"
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ resolver = "2"
 [workspace.metadata]
 initrd = [
     "crate:bootstrap",
+    "crate:init",
     "crate:devmgr",
     "crate:netmgr",
     "crate:nettest",

--- a/doc/src/ReferenceRuntime.md
+++ b/doc/src/ReferenceRuntime.md
@@ -1,0 +1,9 @@
+# The Twizzler Reference Runtime
+
+The primary runtime environment supported by Twizzler is the _Reference Runtime_. It provides userspace functionality for programs, the ability to load programs and libraries, and the ability to isolate those programs and libraries from each other.
+
+It is a work in progress.
+
+## Stdio
+
+The runtime provides three types of stream-like interfaces for basic IO, which should be familiar to most: stdin (for reading input), stdout (for writing output), and stderr (for reporting errors). Each of these can be handled by either a thread-local path, or a global path. When writing to stdout, for example, the runtime first checks if the thread-local path has a handler. If so, the output gets sent to that handler. If not, the runtime checks if there is a global handler registered for stdout. If so, the output goes there. If not, it gets sent to the fallback handler, which can be configured to either drop the output or send it to the kernel log.

--- a/doc/src/SUMMARY.md
+++ b/doc/src/SUMMARY.md
@@ -14,6 +14,8 @@
 
 - [Permissions](./Permissions.md)
 
+- [Reference Runtime](./ReferenceRuntime.md)
+
 # Primitives
 
 - [Views](./Views.md)

--- a/src/bin/bootstrap/Cargo.toml
+++ b/src/bin/bootstrap/Cargo.toml
@@ -6,6 +6,7 @@ authors = ["Daniel Bittman <danielbittman1@gmail.com>"]
 
 [dependencies]
 twizzler-abi = { path = "../../lib/twizzler-abi", features = ["runtime"] }
+twizzler-runtime-api = { path = "../../lib/twizzler-runtime-api" }
 twizzler-object = { path = "../../lib/twizzler-object" }
 dynlink = { path = "../../runtime/dynlink" }
 tracing = "0.1"

--- a/src/bin/bootstrap/src/main.rs
+++ b/src/bin/bootstrap/src/main.rs
@@ -22,7 +22,7 @@ use twizzler_abi::{
     syscall::{sys_object_create, ObjectSource},
 };
 
-fn start_runtime(_exec_id: ObjID, runtime_monitor: ObjID, runtime_library: ObjID, libstd: ObjID) {
+fn start_runtime(runtime_monitor: ObjID, runtime_library: ObjID, libstd: ObjID) {
     let ctx = dynlink::context::Context::default();
     let monitor_compartment = ctx.add_compartment("monitor").unwrap();
 
@@ -127,13 +127,13 @@ fn main() {
 
     tracing::subscriber::set_global_default(subscriber).expect("setting default subscriber failed");
 
-    let exec_id = find_init_name("libhello_world.so").unwrap();
+    //let exec_id = find_init_name("libhello_world.so").unwrap();
     let runtime_lib = find_init_name("libtwz_rt.so").unwrap();
     let monitor = find_init_name("libmonitor.so").unwrap();
     let libstd = find_init_name("libstd.so").unwrap();
 
     eprintln!("=== BOOTSTRAP RUNTIME ===");
-    start_runtime(exec_id, monitor, runtime_lib, libstd);
+    start_runtime(monitor, runtime_lib, libstd);
 
     let _runtime = twizzler_abi::runtime::__twz_get_runtime();
 }

--- a/src/kernel/src/initrd.rs
+++ b/src/kernel/src/initrd.rs
@@ -61,7 +61,7 @@ pub fn init(modules: &[BootModule]) {
             }
             let obj = Arc::new(obj);
             obj::register_object(obj.clone());
-            if e.filename().as_str() == "init" {
+            if e.filename().as_str() == "bootstrap" {
                 boot_objects.init = Some(obj.clone());
             }
             boot_objects

--- a/src/kernel/src/initrd.rs
+++ b/src/kernel/src/initrd.rs
@@ -61,7 +61,7 @@ pub fn init(modules: &[BootModule]) {
             }
             let obj = Arc::new(obj);
             obj::register_object(obj.clone());
-            if e.filename().as_str() == "bootstrap" {
+            if e.filename().as_str() == "init" {
                 boot_objects.init = Some(obj.clone());
             }
             boot_objects

--- a/src/kernel/src/memory/context/virtmem.rs
+++ b/src/kernel/src/memory/context/virtmem.rs
@@ -634,6 +634,7 @@ pub fn page_fault(addr: VirtAddr, cause: MemoryAccessKind, flags: PageFaultFlags
                         info.obj.id(),
                         ObjectMemoryError::NullPageAccess,
                         cause,
+                        addr.into(),
                     )));
                 return;
             }
@@ -644,6 +645,7 @@ pub fn page_fault(addr: VirtAddr, cause: MemoryAccessKind, flags: PageFaultFlags
                         info.obj.id(),
                         ObjectMemoryError::OutOfBounds(page_number.as_byte_offset()),
                         cause,
+                        addr.into(),
                     )));
                 return;
             }

--- a/src/kernel/src/thread.rs
+++ b/src/kernel/src/thread.rs
@@ -264,6 +264,11 @@ impl Thread {
 
     pub fn send_upcall(&self, info: UpcallInfo) {
         // TODO
+        logln!(
+            "upcall: {:?} {:?}",
+            info,
+            self.arch.entry_registers.borrow()
+        );
         let ctx = current_memory_context().unwrap();
         let upcall = ctx.get_upcall().unwrap();
         self.arch_queue_upcall(upcall, info);

--- a/src/kernel/src/thread.rs
+++ b/src/kernel/src/thread.rs
@@ -264,11 +264,6 @@ impl Thread {
 
     pub fn send_upcall(&self, info: UpcallInfo) {
         // TODO
-        logln!(
-            "upcall: {:?} {:?}",
-            info,
-            self.arch.entry_registers.borrow()
-        );
         let ctx = current_memory_context().unwrap();
         let upcall = ctx.get_upcall().unwrap();
         self.arch_queue_upcall(upcall, info);

--- a/src/lib/twizzler-abi/Cargo.toml
+++ b/src/lib/twizzler-abi/Cargo.toml
@@ -34,7 +34,7 @@ version = "0.2.51"
 
 [features]
 # Activate if you want the minruntime to be compiled.
-runtime = ["volatile", "talc", "bitset-core"]
+runtime = ["volatile", "talc", "bitset-core", "twizzler-runtime-api/rt0"]
 # Activate if compiling for the kernel.
 kernel = ["volatile", "twizzler-runtime-api/kernel"]
 # Activate if compiling for libstd.

--- a/src/lib/twizzler-abi/src/arch/x86_64/upcall.rs
+++ b/src/lib/twizzler-abi/src/arch/x86_64/upcall.rs
@@ -2,6 +2,7 @@
 use crate::upcall::UpcallInfo;
 
 /// Arch-specific frame info for upcall.
+#[derive(Clone, Debug)]
 #[repr(C)]
 pub struct UpcallFrame {
     pub rip: u64,

--- a/src/lib/twizzler-abi/src/runtime/stdio.rs
+++ b/src/lib/twizzler-abi/src/runtime/stdio.rs
@@ -9,7 +9,7 @@ use crate::syscall::KernelConsoleReadError;
 use super::MinimalRuntime;
 
 impl RustStdioRuntime for MinimalRuntime {
-    fn with_panic_output(&self, cb: twizzler_runtime_api::IoWriteDynCallback<'_, ()>) {
+    fn with_panic_output(&self, cb: twizzler_runtime_api::IoWritePanicDynCallback<'_, ()>) {
         let mut wp = WritePoint {};
         cb(&mut wp);
     }
@@ -57,7 +57,7 @@ pub struct WritePoint {}
 pub struct ReadPoint {}
 
 impl IoWrite for WritePoint {
-    fn write(&mut self, buf: &[u8]) -> Result<usize, WriteError> {
+    fn write(&self, buf: &[u8]) -> Result<usize, WriteError> {
         crate::syscall::sys_kernel_console_write(
             buf,
             crate::syscall::KernelConsoleWriteFlags::empty(),
@@ -65,13 +65,13 @@ impl IoWrite for WritePoint {
         Ok(buf.len())
     }
 
-    fn flush(&mut self) -> Result<(), WriteError> {
+    fn flush(&self) -> Result<(), WriteError> {
         Ok(())
     }
 }
 
 impl IoRead for ReadPoint {
-    fn read(&mut self, buf: &mut [u8]) -> Result<usize, ReadError> {
+    fn read(&self, buf: &mut [u8]) -> Result<usize, ReadError> {
         crate::syscall::sys_kernel_console_read(
             buf,
             crate::syscall::KernelConsoleReadFlags::empty(),

--- a/src/lib/twizzler-abi/src/runtime/thread.rs
+++ b/src/lib/twizzler-abi/src/runtime/thread.rs
@@ -155,7 +155,7 @@ impl ThreadRuntime for MinimalRuntime {
         }
     }
 
-    fn tls_get_addr(&self, _tls_index: &twizzler_runtime_api::TlsIndex) -> *const u8 {
+    fn tls_get_addr(&self, _tls_index: &twizzler_runtime_api::TlsIndex) -> Option<*const u8> {
         panic!("minimal runtime only supports LocalExec TLS model");
     }
 }

--- a/src/lib/twizzler-abi/src/upcall.rs
+++ b/src/lib/twizzler-abi/src/upcall.rs
@@ -30,14 +30,22 @@ pub struct ObjectMemoryFaultInfo {
     pub error: ObjectMemoryError,
     /// The kind of memory access that caused the error.
     pub access: MemoryAccessKind,
+    /// The virtual address at which the error occurred.
+    pub addr: usize,
 }
 
 impl ObjectMemoryFaultInfo {
-    pub fn new(object_id: ObjID, error: ObjectMemoryError, access: MemoryAccessKind) -> Self {
+    pub fn new(
+        object_id: ObjID,
+        error: ObjectMemoryError,
+        access: MemoryAccessKind,
+        addr: usize,
+    ) -> Self {
         Self {
             object_id,
             error,
             access,
+            addr,
         }
     }
 }

--- a/src/lib/twizzler-runtime-api/Cargo.toml
+++ b/src/lib/twizzler-runtime-api/Cargo.toml
@@ -30,8 +30,9 @@ rustc-dep-of-std = [
     "bitflags/rustc-dep-of-std",
 ]
 default = ["runtime"]
-# Compiles in rt0 code, and get_runtime.
+# Compiles in get_runtime.
 runtime = []
+# Compiles in rt0 code.
+rt0 = []
 # Activate if compiling for the kernel.
 kernel = []
-

--- a/src/lib/twizzler-runtime-api/src/lib.rs
+++ b/src/lib/twizzler-runtime-api/src/lib.rs
@@ -142,7 +142,8 @@ pub trait ThreadRuntime {
 
     /// Implements the __tls_get_addr functionality. If the runtime feature is enabled, this crate defines the
     /// extern "C" function __tls_get_addr as a wrapper around calling this function after getting the runtime from [get_runtime].
-    fn tls_get_addr(&self, tls_index: &TlsIndex) -> *const u8;
+    /// If the provided index is invalid, return None.
+    fn tls_get_addr(&self, tls_index: &TlsIndex) -> Option<*const u8>;
 }
 
 /// All the object related runtime functions.

--- a/src/lib/twizzler-runtime-api/src/lib.rs
+++ b/src/lib/twizzler-runtime-api/src/lib.rs
@@ -60,6 +60,8 @@ pub enum AuxEntry {
     Arguments(usize, u64),
     /// The object ID of the executable.
     ExecId(ObjID),
+    /// Initial runtime information. The value is runtime-specific.
+    RuntimeInfo(usize),
 }
 
 /// Full runtime trait, composed of smaller traits

--- a/src/lib/twizzler-runtime-api/src/rt0.rs
+++ b/src/lib/twizzler-runtime-api/src/rt0.rs
@@ -42,5 +42,10 @@ extern "C" {
 pub unsafe extern "C" fn __tls_get_addr(arg: usize) -> *const u8 {
     // Just call the runtime.
     let runtime = crate::get_runtime();
-    runtime.tls_get_addr((arg as *const crate::TlsIndex).as_ref().unwrap())
+    let index = (arg as *const crate::TlsIndex)
+        .as_ref()
+        .expect("null pointer passed to __tls_get_addr");
+    runtime
+        .tls_get_addr(index)
+        .expect("index passed to __tls_get_addr is invalid")
 }

--- a/src/lib/twizzler-runtime-api/src/rt0.rs
+++ b/src/lib/twizzler-runtime-api/src/rt0.rs
@@ -1,5 +1,5 @@
 //! rt0 defines a collection of functions that the basic Rust ABI expects to be defined by some part of the C runtime:
-//! 
+//!
 //!   - __tls_get_addr for handling non-local TLS regions.
 //!   - _start, the entry point of an executable (per-arch, as this is assembly code).
 
@@ -21,7 +21,11 @@ unsafe extern "C" fn entry(arg: usize) -> ! {
     rust_entry(arg as *const AuxEntry)
 }
 
-unsafe fn rust_entry(arg: *const AuxEntry) -> ! {
+/// Entry point for Rust code wishing to start from rt0.
+///
+/// # Safety
+/// Do not call this unless you are bootstrapping a runtime.
+pub unsafe fn rust_entry(arg: *const AuxEntry) -> ! {
     // All we need to do is grab the runtime and call its init function. We want to
     // do as little as possible here.
     let runtime = crate::get_runtime();

--- a/src/runtime/dynlink/Cargo.toml
+++ b/src/runtime/dynlink/Cargo.toml
@@ -7,7 +7,8 @@ edition = "2021"
 
 [dependencies]
 elf = "0.7"
-twizzler-abi = { path = "../../lib/twizzler-abi", features = ["runtime"] }
+twizzler-abi = { path = "../../lib/twizzler-abi", default-features = false }
+twizzler-runtime-api = { path = "../../lib/twizzler-runtime-api", default-features = false }
 tracing = "0.1"
 twizzler-object = { path = "../../lib/twizzler-object" }
 thiserror = "1.0"

--- a/src/runtime/dynlink/src/arch/aarch64.rs
+++ b/src/runtime/dynlink/src/arch/aarch64.rs
@@ -1,9 +1,4 @@
 pub(crate) const MINIMUM_TLS_ALIGNMENT: usize = 32;
-/*
-R_X86_64_64, R_X86_64_DTPMOD64,
-        R_X86_64_DTPOFF64, R_X86_64_GLOB_DAT, R_X86_64_JUMP_SLOT, R_X86_64_RELATIVE,
-        R_X86_64_TPOFF64
-         */
 
 pub use elf::abi::R_AARCH64_ABS64 as REL_SYMBOLIC;
 pub use elf::abi::R_AARCH64_COPY as REL_COPY;
@@ -13,3 +8,7 @@ pub use elf::abi::R_AARCH64_RELATIVE as REL_RELATIVE;
 pub use elf::abi::R_AARCH64_TLS_DTPMOD as REL_DTPMOD;
 pub use elf::abi::R_AARCH64_TLS_DTPREL as REL_DTPOFF;
 pub use elf::abi::R_AARCH64_TLS_TPREL as REL_TPOFF;
+
+pub unsafe fn get_thread_control_block<T>() -> *mut Tcb<T> {
+    todo!()
+}

--- a/src/runtime/dynlink/src/arch/mod.rs
+++ b/src/runtime/dynlink/src/arch/mod.rs
@@ -1,9 +1,9 @@
 #[cfg(target_arch = "x86_64")]
 mod x86_64;
 #[cfg(target_arch = "x86_64")]
-pub(crate) use x86_64::*;
+pub use x86_64::*;
 
 #[cfg(target_arch = "aarch64")]
 mod aarch64;
 #[cfg(target_arch = "aarch64")]
-pub(crate) use aarch64::*;
+pub use aarch64::*;

--- a/src/runtime/dynlink/src/arch/x86_64.rs
+++ b/src/runtime/dynlink/src/arch/x86_64.rs
@@ -11,6 +11,10 @@ pub use elf::abi::R_X86_64_JUMP_SLOT as REL_PLT;
 pub use elf::abi::R_X86_64_RELATIVE as REL_RELATIVE;
 pub use elf::abi::R_X86_64_TPOFF64 as REL_TPOFF;
 
+/// Get a pointer to the current thread control block, using the thread pointer.
+///
+/// # Safety
+/// The TCB must actually contain runtime data of type T, and be initialized.
 pub unsafe fn get_thread_control_block<T>() -> *mut Tcb<T> {
     let mut val: usize;
     core::arch::asm!("mov {}, fs:0", out(reg) val);

--- a/src/runtime/dynlink/src/arch/x86_64.rs
+++ b/src/runtime/dynlink/src/arch/x86_64.rs
@@ -1,3 +1,5 @@
+use crate::tls::Tcb;
+
 pub(crate) const MINIMUM_TLS_ALIGNMENT: usize = 32;
 
 pub use elf::abi::R_X86_64_64 as REL_SYMBOLIC;
@@ -8,3 +10,9 @@ pub use elf::abi::R_X86_64_GLOB_DAT as REL_GOT;
 pub use elf::abi::R_X86_64_JUMP_SLOT as REL_PLT;
 pub use elf::abi::R_X86_64_RELATIVE as REL_RELATIVE;
 pub use elf::abi::R_X86_64_TPOFF64 as REL_TPOFF;
+
+pub unsafe fn get_thread_control_block<T>() -> *mut Tcb<T> {
+    let mut val: usize;
+    core::arch::asm!("mov {}, fs:0", out(reg) val);
+    val as *mut _
+}

--- a/src/runtime/dynlink/src/compartment.rs
+++ b/src/runtime/dynlink/src/compartment.rs
@@ -77,6 +77,10 @@ impl CompartmentInner {
             tls_info: Default::default(),
         }
     }
+
+    pub(crate) fn alloc_objects(&self) -> &[Object<u8>] {
+        &self.alloc_objects
+    }
 }
 
 #[allow(dead_code)]

--- a/src/runtime/dynlink/src/compartment.rs
+++ b/src/runtime/dynlink/src/compartment.rs
@@ -67,6 +67,7 @@ impl Debug for Compartment {
 
 pub type CompartmentRef = Arc<Compartment>;
 
+#[allow(dead_code)]
 impl CompartmentInner {
     pub(crate) fn new(name: String, id: u128) -> Self {
         Self {

--- a/src/runtime/dynlink/src/context.rs
+++ b/src/runtime/dynlink/src/context.rs
@@ -7,7 +7,6 @@ use std::{
 
 use petgraph::stable_graph::StableDiGraph;
 use tracing::{debug, trace};
-use twizzler_abi::object::MAX_SIZE;
 
 use crate::{
     compartment::{Compartment, CompartmentRef},
@@ -31,7 +30,6 @@ pub(crate) struct ContextInner {
     pub(crate) library_deps: StableDiGraph<LibraryRef, ()>,
 
     pub(crate) static_ctors: Vec<CtorInfo>,
-    pub(crate) bootstrap_array: Vec<ImportantThing>,
 }
 
 #[allow(dead_code)]
@@ -149,28 +147,6 @@ impl ContextInner {
         Ok(&self.static_ctors)
     }
 
-    fn build_important_array(&mut self) -> Result<&[ImportantThing], DynlinkError> {
-        let mut ia = vec![];
-        for comp in self.compartment_names.values() {
-            comp.with_inner(|inner| {
-                for ao in inner.alloc_objects() {
-                    debug!(
-                        "adding heap object {:x} to bootstrap array",
-                        ao.slot().vaddr_null()
-                    );
-                    let it = ImportantThing::Object(ImportantObject::new(
-                        ImportantObjectKind::Heap,
-                        ao.slot().vaddr_null() / MAX_SIZE,
-                    ));
-                    ia.push(it);
-                }
-            })?;
-        }
-
-        self.bootstrap_array = ia;
-        Ok(&self.bootstrap_array)
-    }
-
     pub(crate) fn build_runtime_info<I>(
         &mut self,
         roots: I,
@@ -183,11 +159,7 @@ impl ContextInner {
             let ctors = self.build_ctors(roots)?;
             (ctors.as_ptr(), ctors.len())
         };
-        let ia = {
-            let ia = self.build_important_array()?;
-            (ia.as_ptr(), ia.len())
-        };
-        Ok(RuntimeInitInfo::new(ctors.0, ctors.1, tls, ia.0, ia.1))
+        Ok(RuntimeInitInfo::new(ctors.0, ctors.1, tls))
     }
 }
 
@@ -283,57 +255,21 @@ pub struct RuntimeInitInfo {
     ctor_info_array_len: usize,
 
     pub tls_region: TlsRegion,
-
-    important_thing_array: *const ImportantThing,
-    important_thing_array_len: usize,
 }
-
-pub enum ImportantObjectKind {
-    Text(u128),
-    Data(u128),
-    Stack,
-    Heap,
-}
-
-pub struct ImportantObject {
-    pub kind: ImportantObjectKind,
-    pub slot: usize,
-}
-
-impl ImportantObject {
-    pub fn new(kind: ImportantObjectKind, slot: usize) -> Self {
-        Self { kind, slot }
-    }
-}
-
-pub enum ImportantThing {
-    Object(ImportantObject),
-}
-
 impl RuntimeInitInfo {
     pub(crate) fn new(
         ctor_info_array: *const CtorInfo,
         ctor_info_array_len: usize,
         tls_region: TlsRegion,
-        important_thing_array: *const ImportantThing,
-        important_thing_array_len: usize,
     ) -> Self {
         Self {
             ctor_info_array,
             ctor_info_array_len,
             tls_region,
-            important_thing_array,
-            important_thing_array_len,
         }
     }
 
     pub fn ctor_infos(&self) -> &[CtorInfo] {
         unsafe { core::slice::from_raw_parts(self.ctor_info_array, self.ctor_info_array_len) }
-    }
-
-    pub fn important_things(&self) -> &[ImportantThing] {
-        unsafe {
-            core::slice::from_raw_parts(self.important_thing_array, self.important_thing_array_len)
-        }
     }
 }

--- a/src/runtime/dynlink/src/library.rs
+++ b/src/runtime/dynlink/src/library.rs
@@ -17,7 +17,7 @@ mod load;
 mod relocate;
 mod tls;
 
-pub(crate) use init::CtorInfo;
+pub use init::CtorInfo;
 pub use load::LibraryLoader;
 
 use petgraph::stable_graph::NodeIndex;
@@ -47,6 +47,8 @@ pub(crate) enum RelocState {
 pub(crate) enum InitState {
     /// No constructors have been called.
     Uninit,
+    /// This library has been loaded as part of the static set, but hasn't been initialized (waiting for runtime entry).
+    StaticUninit,
     /// Constructors have been called, destructors have not been called.
     Constructed,
     /// Destructors have been called.

--- a/src/runtime/dynlink/src/library/init.rs
+++ b/src/runtime/dynlink/src/library/init.rs
@@ -39,18 +39,13 @@ impl Library {
             }
         });
 
-        if dynamic
-            .iter()
-            .find(|d| d.d_tag == DT_PREINIT_ARRAY)
-            .is_some()
-        {
-            if dynamic
+        if dynamic.iter().any(|d| d.d_tag == DT_PREINIT_ARRAY)
+            && dynamic
                 .iter()
                 .find(|d| d.d_tag == DT_PREINIT_ARRAYSZ)
                 .is_some_and(|d| d.d_val() > 0)
-            {
-                warn!("{}: PREINIT_ARRAY is unsupported", self);
-            }
+        {
+            warn!("{}: PREINIT_ARRAY is unsupported", self);
         }
 
         debug!(

--- a/src/runtime/dynlink/src/library/init.rs
+++ b/src/runtime/dynlink/src/library/init.rs
@@ -65,8 +65,7 @@ impl Library {
     }
 }
 
-#[allow(dead_code)]
-pub(crate) struct CtorInfo {
+pub struct CtorInfo {
     pub legacy_init: usize,
     pub init_array: usize,
     pub init_array_len: usize,

--- a/src/runtime/dynlink/src/tls.rs
+++ b/src/runtime/dynlink/src/tls.rs
@@ -3,6 +3,7 @@
 use std::{alloc::Layout, mem::align_of, mem::size_of, ptr::NonNull};
 
 use tracing::{error, trace};
+use twizzler_runtime_api::TlsIndex;
 
 use crate::{arch::MINIMUM_TLS_ALIGNMENT, compartment::CompartmentRef, DynlinkError};
 
@@ -154,11 +155,11 @@ impl TlsInfo {
 }
 
 #[repr(C)]
-pub(crate) struct Tcb<T> {
+pub struct Tcb<T> {
     self_ptr: *const Tcb<T>,
     dtv: *const usize,
     dtv_len: usize,
-    runtime_data: T,
+    pub runtime_data: T,
 }
 
 impl<T> Tcb<T> {
@@ -169,6 +170,13 @@ impl<T> Tcb<T> {
             dtv: tls_region.dtv.as_ptr(),
             dtv_len: tls_region.num_dtv_entries,
             runtime_data: tcb_data,
+        }
+    }
+
+    pub fn get_addr(&self, index: &TlsIndex) -> *const u8 {
+        unsafe {
+            let slice = core::slice::from_raw_parts(self.dtv, self.dtv_len);
+            (slice[index.mod_id] + index.offset) as *const _
         }
     }
 }
@@ -235,3 +243,5 @@ impl TlsRegion {
         }
     }
 }
+
+pub use crate::arch::get_thread_control_block;

--- a/src/runtime/dynlink/src/tls.rs
+++ b/src/runtime/dynlink/src/tls.rs
@@ -206,6 +206,10 @@ impl Drop for TlsRegion {
 }
 
 impl TlsRegion {
+    pub fn get_thread_pointer_value(&self) -> usize {
+        self.thread_pointer.as_ptr() as usize
+    }
+
     pub(crate) fn set_dtv_entry(&self, tm: &TlsModule) {
         let dtv_slice =
             unsafe { core::slice::from_raw_parts_mut(self.dtv.as_ptr(), self.num_dtv_entries) };

--- a/src/runtime/dynlink/src/tls.rs
+++ b/src/runtime/dynlink/src/tls.rs
@@ -173,10 +173,10 @@ impl<T> Tcb<T> {
         }
     }
 
-    pub fn get_addr(&self, index: &TlsIndex) -> *const u8 {
+    pub fn get_addr(&self, index: &TlsIndex) -> Option<*const u8> {
         unsafe {
             let slice = core::slice::from_raw_parts(self.dtv, self.dtv_len);
-            (slice[index.mod_id] + index.offset) as *const _
+            Some((slice.get(index.mod_id)? + index.offset) as *const _)
         }
     }
 }

--- a/src/runtime/monitor/Cargo.toml
+++ b/src/runtime/monitor/Cargo.toml
@@ -10,3 +10,7 @@ crate-type = ["dylib"]
 
 [dependencies]
 twizzler-abi = { path = "../../lib/twizzler-abi", default-features = false }
+twizzler-runtime-api = { path = "../../lib/twizzler-runtime-api", features = [
+    "runtime",
+    "rt0",
+] }

--- a/src/runtime/monitor/Cargo.toml
+++ b/src/runtime/monitor/Cargo.toml
@@ -14,3 +14,5 @@ twizzler-runtime-api = { path = "../../lib/twizzler-runtime-api", features = [
     "runtime",
     "rt0",
 ] }
+dynlink = { path = "../dynlink" }
+tracing = "0.1"

--- a/src/runtime/monitor/src/lib.rs
+++ b/src/runtime/monitor/src/lib.rs
@@ -10,8 +10,6 @@ pub extern "C" fn monitor_entry_from_bootstrap(aux: *const AuxEntry) {
         twizzler_abi::syscall::KernelConsoleWriteFlags::empty(),
     );
     unsafe { twizzler_runtime_api::rt0::rust_entry(aux) }
-    loop {}
-    //println!("Hello, world!");
 }
 
 pub fn my_main() {

--- a/src/runtime/monitor/src/lib.rs
+++ b/src/runtime/monitor/src/lib.rs
@@ -1,12 +1,15 @@
 //#![feature(naked_functions)]
 #![feature(start)]
 
+use twizzler_runtime_api::AuxEntry;
+
 #[no_mangle]
-pub extern "C" fn monitor_entry_from_bootstrap() {
+pub extern "C" fn monitor_entry_from_bootstrap(aux: *const AuxEntry) {
     let _ = twizzler_abi::syscall::sys_kernel_console_write(
         b"hello world from monitor entry\n",
         twizzler_abi::syscall::KernelConsoleWriteFlags::empty(),
     );
+    unsafe { twizzler_runtime_api::rt0::rust_entry(aux) }
     loop {}
     //println!("Hello, world!");
 }
@@ -30,7 +33,7 @@ extern "C" {
 }
 
 #[cfg(not(test))]
-#[start]
+#[no_mangle]
 pub extern "C" fn main(argc: i32, argv: *const *const u8) -> i32 {
     //TODO: sigpipe?
     unsafe { twizzler_call_lang_start(my_main, argc as isize, argv, 0) as i32 }

--- a/src/runtime/monitor/src/lib.rs
+++ b/src/runtime/monitor/src/lib.rs
@@ -1,5 +1,6 @@
 //#![feature(naked_functions)]
 #![feature(start)]
+#![feature(thread_local)]
 
 use twizzler_runtime_api::AuxEntry;
 
@@ -12,11 +13,11 @@ pub extern "C" fn monitor_entry_from_bootstrap(aux: *const AuxEntry) {
     unsafe { twizzler_runtime_api::rt0::rust_entry(aux) }
 }
 
+#[thread_local]
+static FOO: u32 = 3459;
+
 pub fn my_main() {
-    let _ = twizzler_abi::syscall::sys_kernel_console_write(
-        b"hello world from monitor main\n",
-        twizzler_abi::syscall::KernelConsoleWriteFlags::empty(),
-    );
+    println!("hello world from my_main {}", FOO);
     loop {}
 }
 

--- a/src/runtime/twz-rt/Cargo.toml
+++ b/src/runtime/twz-rt/Cargo.toml
@@ -14,3 +14,4 @@ twizzler-runtime-api = { path = "../../lib/twizzler-runtime-api", features = [
 thiserror = "1.0"
 tracing = "0.1"
 twizzler-abi = { path = "../../lib/twizzler-abi", default-features = false }
+dynlink = { path = "../dynlink" }

--- a/src/runtime/twz-rt/Cargo.toml
+++ b/src/runtime/twz-rt/Cargo.toml
@@ -17,3 +17,4 @@ twizzler-abi = { path = "../../lib/twizzler-abi", default-features = false }
 dynlink = { path = "../dynlink" }
 bitflags = "2.4"
 talc = { version = "3.1", default-features = false }
+#tracing-subscriber = { version = "0.3", default-features = false }

--- a/src/runtime/twz-rt/Cargo.toml
+++ b/src/runtime/twz-rt/Cargo.toml
@@ -11,3 +11,6 @@ crate-type = ["dylib"]
 twizzler-runtime-api = { path = "../../lib/twizzler-runtime-api", features = [
     "runtime",
 ] }
+thiserror = "1.0"
+tracing = "0.1"
+twizzler-abi = { path = "../../lib/twizzler-abi", default-features = false }

--- a/src/runtime/twz-rt/Cargo.toml
+++ b/src/runtime/twz-rt/Cargo.toml
@@ -18,3 +18,7 @@ dynlink = { path = "../dynlink" }
 bitflags = "2.4"
 talc = { version = "3.1", default-features = false }
 #tracing-subscriber = { version = "0.3", default-features = false }
+
+[features]
+runtime = []
+default = ["runtime"]

--- a/src/runtime/twz-rt/Cargo.toml
+++ b/src/runtime/twz-rt/Cargo.toml
@@ -15,3 +15,5 @@ thiserror = "1.0"
 tracing = "0.1"
 twizzler-abi = { path = "../../lib/twizzler-abi", default-features = false }
 dynlink = { path = "../dynlink" }
+bitflags = "2.4"
+talc = { version = "3.1", default-features = false }

--- a/src/runtime/twz-rt/Cargo.toml
+++ b/src/runtime/twz-rt/Cargo.toml
@@ -5,7 +5,6 @@ edition = "2021"
 
 [lib]
 crate-type = ["dylib"]
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
 twizzler-runtime-api = { path = "../../lib/twizzler-runtime-api", features = [
@@ -17,7 +16,6 @@ twizzler-abi = { path = "../../lib/twizzler-abi", default-features = false }
 dynlink = { path = "../dynlink" }
 bitflags = "2.4"
 talc = { version = "3.1", default-features = false }
-#tracing-subscriber = { version = "0.3", default-features = false }
 
 [features]
 runtime = []

--- a/src/runtime/twz-rt/src/arch.rs
+++ b/src/runtime/twz-rt/src/arch.rs
@@ -1,0 +1,5 @@
+#[cfg(target_arch = "x86_64")]
+mod x86_64;
+
+#[cfg(target_arch = "x86_64")]
+pub use x86_64::*;

--- a/src/runtime/twz-rt/src/arch.rs
+++ b/src/runtime/twz-rt/src/arch.rs
@@ -4,3 +4,10 @@ mod x86_64;
 #[allow(unused_imports)]
 #[cfg(target_arch = "x86_64")]
 pub use x86_64::*;
+
+#[cfg(target_arch = "aarch64")]
+mod aarch64;
+
+#[allow(unused_imports)]
+#[cfg(target_arch = "aarch64")]
+pub use aarch64::*;

--- a/src/runtime/twz-rt/src/arch.rs
+++ b/src/runtime/twz-rt/src/arch.rs
@@ -1,5 +1,6 @@
 #[cfg(target_arch = "x86_64")]
 mod x86_64;
 
+#[allow(unused_imports)]
 #[cfg(target_arch = "x86_64")]
 pub use x86_64::*;

--- a/src/runtime/twz-rt/src/arch/x86_64.rs
+++ b/src/runtime/twz-rt/src/arch/x86_64.rs
@@ -1,0 +1,44 @@
+use twizzler_abi::upcall::{UpcallFrame, UpcallInfo};
+
+use crate::preinit_println;
+
+#[no_mangle]
+pub(crate) unsafe extern "C" fn rr_upcall_entry(
+    rdi: *const UpcallFrame,
+    rsi: *const UpcallInfo,
+) -> ! {
+    core::arch::asm!(
+        ".cfi_signal_frame",
+        "mov rbp, rdx",
+        "push rax",
+        "push rbp",
+        "push rax",
+        ".cfi_def_cfa rsp, 0",
+        ".cfi_offset rbp, 8",
+        ".cfi_offset rip, 0",
+        ".cfi_return_column rip",
+        "jmp rr_upcall_entry2",
+        in("rax") (&*rdi).rip,
+        in("rdx") (&*rdi).rbp,
+        in("rdi") rdi,
+        in("rsi") rsi,
+        options(noreturn)
+    );
+}
+
+#[no_mangle]
+pub(crate) unsafe extern "C" fn rr_upcall_entry2(
+    rdi: *const UpcallFrame,
+    rsi: *const UpcallInfo,
+) -> ! {
+    use crate::runtime::__twz_get_runtime;
+
+    preinit_println!(
+        "got upcall: {:?}, {:?}",
+        rdi.as_ref().unwrap(),
+        rsi.as_ref().unwrap()
+    );
+    //crate::runtime::upcall::upcall_rust_entry(&*rdi, &*rsi);
+    let runtime = __twz_get_runtime();
+    runtime.abort()
+}

--- a/src/runtime/twz-rt/src/arch/x86_64.rs
+++ b/src/runtime/twz-rt/src/arch/x86_64.rs
@@ -2,6 +2,7 @@ use twizzler_abi::upcall::{UpcallFrame, UpcallInfo};
 
 use crate::preinit_println;
 
+#[cfg(feature = "runtime")]
 #[no_mangle]
 pub(crate) unsafe extern "C" fn rr_upcall_entry(
     rdi: *const UpcallFrame,
@@ -26,12 +27,13 @@ pub(crate) unsafe extern "C" fn rr_upcall_entry(
     );
 }
 
+#[cfg(feature = "runtime")]
 #[no_mangle]
 pub(crate) unsafe extern "C" fn rr_upcall_entry2(
     rdi: *const UpcallFrame,
     rsi: *const UpcallInfo,
 ) -> ! {
-    use crate::runtime::__twz_get_runtime;
+    use crate::runtime::do_impl::__twz_get_runtime;
 
     preinit_println!(
         "got upcall: {:?}, {:?}",

--- a/src/runtime/twz-rt/src/arch/x86_64.rs
+++ b/src/runtime/twz-rt/src/arch/x86_64.rs
@@ -19,8 +19,8 @@ pub(crate) unsafe extern "C" fn rr_upcall_entry(
         ".cfi_offset rip, 0",
         ".cfi_return_column rip",
         "jmp rr_upcall_entry2",
-        in("rax") (&*rdi).rip,
-        in("rdx") (&*rdi).rbp,
+        in("rax") (*rdi).rip,
+        in("rdx") (*rdi).rbp,
         in("rdi") rdi,
         in("rsi") rsi,
         options(noreturn)

--- a/src/runtime/twz-rt/src/error.rs
+++ b/src/runtime/twz-rt/src/error.rs
@@ -1,0 +1,18 @@
+use std::sync::PoisonError;
+
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum RuntimeError {
+    #[error("unknown")]
+    Unknown,
+    #[error("lock poison error")]
+    PoisonError,
+}
+
+impl<T> From<PoisonError<T>> for RuntimeError {
+    fn from(_value: PoisonError<T>) -> Self {
+        // TODO
+        Self::PoisonError
+    }
+}

--- a/src/runtime/twz-rt/src/lib.rs
+++ b/src/runtime/twz-rt/src/lib.rs
@@ -1,6 +1,10 @@
+#![feature(core_intrinsics)]
+
 pub(crate) mod arch;
 
 mod runtime;
 
 mod error;
 pub use error::*;
+
+pub(crate) mod preinit;

--- a/src/runtime/twz-rt/src/lib.rs
+++ b/src/runtime/twz-rt/src/lib.rs
@@ -1,5 +1,6 @@
 #![feature(core_intrinsics)]
 #![feature(thread_local)]
+#![feature(array_windows)]
 
 pub(crate) mod arch;
 

--- a/src/runtime/twz-rt/src/lib.rs
+++ b/src/runtime/twz-rt/src/lib.rs
@@ -1,4 +1,5 @@
 #![feature(core_intrinsics)]
+#![feature(thread_local)]
 
 pub(crate) mod arch;
 

--- a/src/runtime/twz-rt/src/lib.rs
+++ b/src/runtime/twz-rt/src/lib.rs
@@ -1,3 +1,9 @@
+//! # The Twizzler Reference Runtime
+//! The Reference Runtime implements the Runtime trait from twizzler-runtime-abi, and is designed to be the primary, fully supported
+//! programming environment on Twizzler.
+//!
+//! This is a work in progress.
+
 #![feature(core_intrinsics)]
 #![feature(thread_local)]
 #![feature(array_windows)]

--- a/src/runtime/twz-rt/src/lib.rs
+++ b/src/runtime/twz-rt/src/lib.rs
@@ -1,17 +1,6 @@
-#![feature(linkage)]
+pub(crate) mod arch;
 
-use twizzler_runtime_api::Runtime;
+mod runtime;
 
-#[inline]
-#[no_mangle]
-// Returns a reference to the currently-linked Runtime implementation.
-pub fn __twz_get_runtime() -> &'static (dyn Runtime + Sync) {
-    todo!()
-    //&OUR_RUNTIME
-}
-
-//static OUR_RUNTIME: MinimalRuntime = MinimalRuntime {};
-
-// Ensure the compiler doesn't optimize us away.
-#[used]
-static USE_MARKER: fn() -> &'static (dyn Runtime + Sync) = __twz_get_runtime;
+mod error;
+pub use error::*;

--- a/src/runtime/twz-rt/src/preinit.rs
+++ b/src/runtime/twz-rt/src/preinit.rs
@@ -16,8 +16,7 @@ impl core::fmt::Write for PreinitLogger {
 
 impl PreinitLogger {
     pub fn write(&self, data: &[u8]) {
-        // we did our best
-        let _ = sys_kernel_console_write(data, KernelConsoleWriteFlags::empty());
+        sys_kernel_console_write(data, KernelConsoleWriteFlags::empty());
     }
 }
 

--- a/src/runtime/twz-rt/src/preinit.rs
+++ b/src/runtime/twz-rt/src/preinit.rs
@@ -1,0 +1,78 @@
+use core::fmt::Write;
+
+use twizzler_abi::syscall::{sys_kernel_console_write, KernelConsoleWriteFlags};
+
+#[derive(Clone, Copy)]
+pub struct PreinitLogger {}
+
+impl core::fmt::Write for PreinitLogger {
+    fn write_str(&mut self, s: &str) -> core::fmt::Result {
+        self.write(s.as_bytes());
+        Ok(())
+    }
+}
+
+impl PreinitLogger {
+    pub fn write(&self, data: &[u8]) {
+        // we did our best
+        let _ = sys_kernel_console_write(data, KernelConsoleWriteFlags::empty());
+    }
+}
+
+static mut PREINIT_OUTPUT: PreinitLogger = PreinitLogger {};
+
+#[doc(hidden)]
+pub fn _print_normal(args: ::core::fmt::Arguments) {
+    let _ = unsafe { PREINIT_OUTPUT }.write_fmt(args);
+}
+
+#[macro_export]
+macro_rules! preinit_print {
+    ($($arg:tt)*) => {
+        $crate::preinit::_print_normal(format_args!($($arg)*))
+    };
+}
+
+#[macro_export]
+macro_rules! preinit_println {
+    () => {
+        $crate::preinit_print!("\n")
+    };
+    ($fmt:expr) => {
+        $crate::preinit_print!(concat!($fmt, "\n"))
+    };
+    ($fmt:expr, $($arg:tt)*) => {
+        $crate::preinit_print!(concat!($fmt, "\n"), $($arg)*)
+    };
+}
+
+pub fn preinit_abort() -> ! {
+    core::intrinsics::abort()
+}
+
+pub fn preinit_unwrap<T>(op: Option<T>) -> T {
+    match op {
+        Some(item) => item,
+        None => {
+            preinit_println!(
+                "failed to unwrap option: {}",
+                core::panic::Location::caller()
+            );
+            preinit_abort();
+        }
+    }
+}
+
+pub fn preinit_unwrap_result<T, E: core::fmt::Display>(op: Result<T, E>) -> T {
+    match op {
+        Ok(item) => item,
+        Err(e) => {
+            preinit_println!(
+                "failed to unwrap result: {} at {}",
+                e,
+                core::panic::Location::caller()
+            );
+            preinit_abort();
+        }
+    }
+}

--- a/src/runtime/twz-rt/src/preinit.rs
+++ b/src/runtime/twz-rt/src/preinit.rs
@@ -1,3 +1,5 @@
+//! Utilities that enable formatted printing for early runtime init.
+
 use core::fmt::Write;
 
 use twizzler_abi::syscall::{sys_kernel_console_write, KernelConsoleWriteFlags};

--- a/src/runtime/twz-rt/src/preinit.rs
+++ b/src/runtime/twz-rt/src/preinit.rs
@@ -63,6 +63,7 @@ pub fn preinit_unwrap<T>(op: Option<T>) -> T {
     }
 }
 
+#[allow(dead_code)]
 pub fn preinit_unwrap_result<T, E: core::fmt::Display>(op: Result<T, E>) -> T {
     match op {
         Ok(item) => item,

--- a/src/runtime/twz-rt/src/runtime.rs
+++ b/src/runtime/twz-rt/src/runtime.rs
@@ -1,15 +1,38 @@
+use std::sync::atomic::{AtomicU32, Ordering};
+
 use twizzler_runtime_api::Runtime;
 
+mod alloc;
 mod core;
 mod debug;
 mod file;
 mod object;
 mod process;
+mod slot;
 mod stdio;
 mod thread;
 mod time;
 
-pub struct ReferenceRuntime {}
+pub struct ReferenceRuntime {
+    pub(crate) state: AtomicU32,
+}
+
+bitflags::bitflags! {
+    pub struct RuntimeState : u32 {
+        const READY = 1;
+    }
+}
+
+impl ReferenceRuntime {
+    fn state(&self) -> RuntimeState {
+        RuntimeState::from_bits_truncate(self.state.load(Ordering::SeqCst))
+    }
+
+    fn set_runtime_ready(&self) {
+        self.state
+            .fetch_or(RuntimeState::READY.bits(), Ordering::SeqCst);
+    }
+}
 
 impl Runtime for ReferenceRuntime {}
 
@@ -20,7 +43,9 @@ pub fn __twz_get_runtime() -> &'static (dyn Runtime + Sync) {
     &OUR_RUNTIME
 }
 
-static OUR_RUNTIME: ReferenceRuntime = ReferenceRuntime {};
+static OUR_RUNTIME: ReferenceRuntime = ReferenceRuntime {
+    state: AtomicU32::new(0),
+};
 
 // Ensure the compiler doesn't optimize us away.
 #[used]

--- a/src/runtime/twz-rt/src/runtime.rs
+++ b/src/runtime/twz-rt/src/runtime.rs
@@ -1,0 +1,27 @@
+use twizzler_runtime_api::Runtime;
+
+mod core;
+mod debug;
+mod file;
+mod object;
+mod process;
+mod stdio;
+mod thread;
+mod time;
+
+pub struct ReferenceRuntime {}
+
+impl Runtime for ReferenceRuntime {}
+
+#[inline]
+#[no_mangle]
+// Returns a reference to the currently-linked Runtime implementation.
+pub fn __twz_get_runtime() -> &'static (dyn Runtime + Sync) {
+    &OUR_RUNTIME
+}
+
+static OUR_RUNTIME: ReferenceRuntime = ReferenceRuntime {};
+
+// Ensure the compiler doesn't optimize us away.
+#[used]
+static USE_MARKER: fn() -> &'static (dyn Runtime + Sync) = __twz_get_runtime;

--- a/src/runtime/twz-rt/src/runtime.rs
+++ b/src/runtime/twz-rt/src/runtime.rs
@@ -1,3 +1,5 @@
+//! Top level runtime module, managing the basic presentation of the runtime.
+
 use std::sync::atomic::{AtomicU32, Ordering};
 
 mod alloc;
@@ -11,11 +13,13 @@ mod stdio;
 mod thread;
 mod time;
 
+/// The runtime trait implementer itself.
 pub struct ReferenceRuntime {
     pub(crate) state: AtomicU32,
 }
 
 bitflags::bitflags! {
+    /// Various state flags for the runtime.
     pub struct RuntimeState : u32 {
         const READY = 1;
     }

--- a/src/runtime/twz-rt/src/runtime/alloc.rs
+++ b/src/runtime/twz-rt/src/runtime/alloc.rs
@@ -1,3 +1,7 @@
+//! Primary allocator, for compartment-local allocation. One tricky aspect to this is that we need to support allocation before the
+//! runtime is fully ready, so to avoid calling into std, we implement a manual spinlock around the allocator until the better Mutex
+//! is available. Once it is, we move the allocator into the mutex, and use that.
+
 use core::{
     alloc::{GlobalAlloc, Layout},
     cell::UnsafeCell,
@@ -37,6 +41,7 @@ impl ReferenceRuntime {
 
 pub struct LocalAllocator {
     runtime: &'static ReferenceRuntime,
+    // early allocation need a lock, but mutex isn't usable yet.
     early_lock: AtomicBool,
     early_alloc: UnsafeCell<Option<LocalAllocatorInner>>,
     inner: Mutex<Option<LocalAllocatorInner>>,

--- a/src/runtime/twz-rt/src/runtime/alloc.rs
+++ b/src/runtime/twz-rt/src/runtime/alloc.rs
@@ -1,0 +1,175 @@
+use core::{
+    alloc::{GlobalAlloc, Layout},
+    cell::UnsafeCell,
+    ptr::NonNull,
+    sync::atomic::{AtomicBool, Ordering},
+};
+
+use std::sync::Mutex;
+
+use talc::{OomHandler, Span, Talc};
+use twizzler_abi::{
+    object::{Protections, MAX_SIZE, NULLPAGE_SIZE},
+    syscall::{
+        sys_object_create, sys_object_map, BackingType, LifetimeType, MapFlags, ObjectCreate,
+        ObjectCreateFlags,
+    },
+};
+
+use crate::{
+    preinit_println,
+    runtime::{slot::early_slot_alloc, RuntimeState},
+};
+
+use super::{ReferenceRuntime, OUR_RUNTIME};
+
+static LOCAL_ALLOCATOR: LocalAllocator = LocalAllocator {
+    runtime: &OUR_RUNTIME,
+    early_lock: AtomicBool::new(false),
+    early_alloc: UnsafeCell::new(Some(LocalAllocatorInner::new())),
+    inner: Mutex::new(None),
+};
+
+unsafe impl Sync for LocalAllocator {}
+
+impl ReferenceRuntime {
+    pub fn get_alloc(&self) -> &'static LocalAllocator {
+        &LOCAL_ALLOCATOR
+    }
+}
+
+pub struct LocalAllocator {
+    runtime: &'static ReferenceRuntime,
+    early_lock: AtomicBool,
+    early_alloc: UnsafeCell<Option<LocalAllocatorInner>>,
+    inner: Mutex<Option<LocalAllocatorInner>>,
+}
+
+struct LocalAllocatorInner {
+    talc: Talc<RuntimeOom>,
+    //_objects: Vec<(usize, ObjID)>,
+}
+
+struct RuntimeOom {}
+
+impl OomHandler for RuntimeOom {
+    fn handle_oom(talc: &mut Talc<Self>, _layout: Layout) -> Result<(), ()> {
+        preinit_println!("got OOM");
+        let id = sys_object_create(
+            ObjectCreate::new(
+                BackingType::Normal,
+                LifetimeType::Volatile,
+                None,
+                ObjectCreateFlags::empty(),
+            ),
+            &[],
+            &[],
+        )
+        .map_err(|_| ())?;
+
+        let slot = early_slot_alloc().ok_or(())?;
+
+        sys_object_map(
+            None,
+            id,
+            slot,
+            Protections::READ | Protections::WRITE,
+            MapFlags::empty(),
+        )
+        .map_err(|_| ())?;
+
+        let base = slot * MAX_SIZE + NULLPAGE_SIZE * 2;
+        let top = (slot + 1) * MAX_SIZE - NULLPAGE_SIZE * 4;
+
+        unsafe {
+            talc.claim(Span::new(base as *mut _, top as *mut _))?;
+        }
+
+        // TODO: track the objects
+
+        Ok(())
+    }
+}
+
+unsafe impl GlobalAlloc for LocalAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        if self.runtime.state().contains(RuntimeState::READY) {
+            // Runtime is ready, we can use normal locking
+            let mut inner = self.inner.lock().unwrap();
+            if inner.is_none() {
+                // First ones in after bootstrap. Lock, and then grab the early_alloc, using it for ourselves.
+                while !self.early_lock.swap(true, Ordering::SeqCst) {
+                    core::hint::spin_loop()
+                }
+                assert!((*self.early_alloc.get()).is_some());
+                *inner = (*self.early_alloc.get()).take();
+                self.early_lock.store(false, Ordering::SeqCst);
+            }
+            inner.as_mut().unwrap().do_alloc(layout)
+        } else {
+            // Runtime is NOT ready. Use a basic spinlock to prevent calls to std.
+            while !self.early_lock.swap(true, Ordering::SeqCst) {
+                core::hint::spin_loop()
+            }
+            assert!((*self.early_alloc.get()).is_some());
+            let ret = self
+                .early_alloc
+                .get()
+                .as_mut()
+                .unwrap()
+                .as_mut()
+                .unwrap()
+                .do_alloc(layout);
+            self.early_lock.store(false, Ordering::SeqCst);
+            ret
+        }
+    }
+
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        if self.runtime.state().contains(RuntimeState::READY) {
+            // Runtime is ready, we can use normal locking
+            let mut inner = self.inner.lock().unwrap();
+            if inner.is_none() {
+                // First ones in after bootstrap. Lock, and then grab the early_alloc, using it for ourselves.
+                while !self.early_lock.swap(true, Ordering::SeqCst) {
+                    core::hint::spin_loop()
+                }
+                assert!((*self.early_alloc.get()).is_some());
+                *inner = (*self.early_alloc.get()).take();
+                self.early_lock.store(false, Ordering::SeqCst);
+            }
+            inner.as_mut().unwrap().do_dealloc(ptr, layout);
+        } else {
+            // Runtime is NOT ready. Use a basic spinlock to prevent calls to std.
+            while !self.early_lock.swap(true, Ordering::SeqCst) {
+                core::hint::spin_loop()
+            }
+            assert!((*self.early_alloc.get()).is_some());
+            self.early_alloc
+                .get()
+                .as_mut()
+                .unwrap()
+                .as_mut()
+                .unwrap()
+                .do_dealloc(ptr, layout);
+            self.early_lock.store(false, Ordering::SeqCst);
+        }
+    }
+}
+
+impl LocalAllocatorInner {
+    const fn new() -> Self {
+        Self {
+            talc: Talc::new(RuntimeOom {}),
+            // objects: vec![],
+        }
+    }
+
+    unsafe fn do_alloc(&mut self, layout: Layout) -> *mut u8 {
+        self.talc.malloc(layout).unwrap().as_ptr()
+    }
+
+    unsafe fn do_dealloc(&mut self, ptr: *mut u8, layout: Layout) {
+        self.talc.free(NonNull::new(ptr).unwrap(), layout);
+    }
+}

--- a/src/runtime/twz-rt/src/runtime/alloc.rs
+++ b/src/runtime/twz-rt/src/runtime/alloc.rs
@@ -16,7 +16,7 @@ use twizzler_abi::{
     },
 };
 
-use crate::runtime::{slot::early_slot_alloc, RuntimeState};
+use crate::runtime::RuntimeState;
 
 use super::{ReferenceRuntime, OUR_RUNTIME};
 
@@ -63,7 +63,7 @@ impl OomHandler for RuntimeOom {
         )
         .map_err(|_| ())?;
 
-        let slot = early_slot_alloc().ok_or(())?;
+        let slot = OUR_RUNTIME.allocate_slot().ok_or(())?;
 
         sys_object_map(
             None,

--- a/src/runtime/twz-rt/src/runtime/alloc.rs
+++ b/src/runtime/twz-rt/src/runtime/alloc.rs
@@ -16,10 +16,7 @@ use twizzler_abi::{
     },
 };
 
-use crate::{
-    preinit_println,
-    runtime::{slot::early_slot_alloc, RuntimeState},
-};
+use crate::runtime::{slot::early_slot_alloc, RuntimeState};
 
 use super::{ReferenceRuntime, OUR_RUNTIME};
 
@@ -54,7 +51,6 @@ struct RuntimeOom {}
 
 impl OomHandler for RuntimeOom {
     fn handle_oom(talc: &mut Talc<Self>, _layout: Layout) -> Result<(), ()> {
-        preinit_println!("got OOM");
         let id = sys_object_create(
             ObjectCreate::new(
                 BackingType::Normal,

--- a/src/runtime/twz-rt/src/runtime/alloc.rs
+++ b/src/runtime/twz-rt/src/runtime/alloc.rs
@@ -79,8 +79,12 @@ impl OomHandler for RuntimeOom {
         )
         .map_err(|_| ())?;
 
-        let base = slot * MAX_SIZE + NULLPAGE_SIZE * 2;
-        let top = (slot + 1) * MAX_SIZE - NULLPAGE_SIZE * 4;
+        // reserve an additional page size at the base of the object for future use. This behavior may change as the runtime is fleshed out.
+        const HEAP_OFFSET: usize = NULLPAGE_SIZE * 2;
+        // offset from the endpoint of the object to where the endpoint of the heap is. Reserve a page for the metadata + a few pages for any future FOT entries.
+        const TOP_OFFSET: usize = NULLPAGE_SIZE * 4;
+        let base = slot * MAX_SIZE + HEAP_OFFSET;
+        let top = (slot + 1) * MAX_SIZE - TOP_OFFSET;
 
         unsafe {
             talc.claim(Span::new(base as *mut _, top as *mut _))?;

--- a/src/runtime/twz-rt/src/runtime/core.rs
+++ b/src/runtime/twz-rt/src/runtime/core.rs
@@ -1,0 +1,32 @@
+use twizzler_runtime_api::CoreRuntime;
+
+use super::ReferenceRuntime;
+
+impl CoreRuntime for ReferenceRuntime {
+    fn default_allocator(&self) -> &'static dyn std::alloc::GlobalAlloc {
+        todo!()
+    }
+
+    fn exit(&self, code: i32) -> ! {
+        todo!()
+    }
+
+    fn abort(&self) -> ! {
+        todo!()
+    }
+
+    fn runtime_entry(
+        &self,
+        arg: *const twizzler_runtime_api::AuxEntry,
+        std_entry: unsafe extern "C" fn(
+            twizzler_runtime_api::BasicAux,
+        ) -> twizzler_runtime_api::BasicReturn,
+    ) -> ! {
+        twizzler_abi::syscall::sys_kernel_console_write(
+            b"hello from refruntime entry\n",
+            twizzler_abi::syscall::KernelConsoleWriteFlags::empty(),
+        );
+        loop {}
+        todo!()
+    }
+}

--- a/src/runtime/twz-rt/src/runtime/core.rs
+++ b/src/runtime/twz-rt/src/runtime/core.rs
@@ -1,5 +1,7 @@
 use twizzler_runtime_api::CoreRuntime;
 
+use crate::preinit_println;
+
 use super::ReferenceRuntime;
 
 impl CoreRuntime for ReferenceRuntime {
@@ -22,9 +24,9 @@ impl CoreRuntime for ReferenceRuntime {
             twizzler_runtime_api::BasicAux,
         ) -> twizzler_runtime_api::BasicReturn,
     ) -> ! {
-        twizzler_abi::syscall::sys_kernel_console_write(
-            b"hello from refruntime entry\n",
-            twizzler_abi::syscall::KernelConsoleWriteFlags::empty(),
+        preinit_println!(
+            "hello world from refruntime entry, with println {:p} !",
+            arg
         );
         loop {}
         todo!()

--- a/src/runtime/twz-rt/src/runtime/core.rs
+++ b/src/runtime/twz-rt/src/runtime/core.rs
@@ -1,3 +1,5 @@
+//! Implements the core runtime functions.
+
 use dynlink::{context::RuntimeInitInfo, library::CtorInfo};
 use twizzler_runtime_api::{AuxEntry, BasicAux, CoreRuntime};
 
@@ -40,6 +42,7 @@ impl CoreRuntime for ReferenceRuntime {
 
     fn exit(&self, code: i32) -> ! {
         if self.state().contains(RuntimeState::READY) {
+            // TODO: hook into debugging?
             todo!()
         } else {
             preinit_println!("runtime exit before runtime ready: {}", code);
@@ -64,7 +67,7 @@ impl CoreRuntime for ReferenceRuntime {
             twizzler_runtime_api::BasicAux,
         ) -> twizzler_runtime_api::BasicReturn,
     ) -> ! {
-        // Step 1: build the aux slice
+        // Step 1: build the aux slice (count until we see a null entry)
         let aux_len = unsafe {
             let mut count = 0;
             let mut tmp = aux;
@@ -133,7 +136,7 @@ impl ReferenceRuntime {
     }
 
     fn init_allocator(&self, _info: &RuntimeInitInfo) {
-        // TODO: hack
+        // TODO: fix this hack
         for slot in 0..100 {
             mark_slot_reserved(slot)
         }

--- a/src/runtime/twz-rt/src/runtime/core.rs
+++ b/src/runtime/twz-rt/src/runtime/core.rs
@@ -99,7 +99,6 @@ impl CoreRuntime for ReferenceRuntime {
     }
 
     fn pre_main_hook(&self) {
-        preinit_println!("HERE: premain");
         self.set_runtime_ready();
     }
 
@@ -111,9 +110,7 @@ impl ReferenceRuntime {
         for ctor in ctor_array {
             unsafe {
                 if ctor.legacy_init != 0 {
-                    preinit_println!("calling legacy init {:x}", ctor.legacy_init);
                     (core::mem::transmute::<_, extern "C" fn()>(ctor.legacy_init))();
-                    preinit_println!("back!");
                 }
                 if ctor.init_array > 0 && ctor.init_array_len > 0 {
                     let init_slice: &[usize] = core::slice::from_raw_parts(
@@ -121,7 +118,6 @@ impl ReferenceRuntime {
                         ctor.init_array_len,
                     );
                     for call in init_slice.iter().cloned() {
-                        preinit_println!("calling init array {:x}", call);
                         (core::mem::transmute::<_, extern "C" fn()>(call))();
                     }
                 }

--- a/src/runtime/twz-rt/src/runtime/core.rs
+++ b/src/runtime/twz-rt/src/runtime/core.rs
@@ -72,9 +72,8 @@ impl CoreRuntime for ReferenceRuntime {
             let mut count = 0;
             let mut tmp = aux;
             while !tmp.is_null() {
-                match preinit_unwrap(tmp.as_ref()) {
-                    AuxEntry::Null => break,
-                    _ => {}
+                if preinit_unwrap(tmp.as_ref()) == &AuxEntry::Null {
+                    break;
                 }
                 tmp = tmp.add(1);
                 count += 1;

--- a/src/runtime/twz-rt/src/runtime/debug.rs
+++ b/src/runtime/twz-rt/src/runtime/debug.rs
@@ -7,11 +7,11 @@ impl DebugRuntime for ReferenceRuntime {
         &self,
         _id: twizzler_runtime_api::LibraryId,
     ) -> Option<twizzler_runtime_api::Library> {
-        todo!()
+        None
     }
 
     fn get_exeid(&self) -> Option<twizzler_runtime_api::LibraryId> {
-        todo!()
+        None
     }
 
     fn get_library_segment(
@@ -19,13 +19,13 @@ impl DebugRuntime for ReferenceRuntime {
         _lib: &twizzler_runtime_api::Library,
         _seg: usize,
     ) -> Option<twizzler_runtime_api::AddrRange> {
-        todo!()
+        None
     }
 
     fn get_full_mapping(
         &self,
         _lib: &twizzler_runtime_api::Library,
     ) -> Option<twizzler_runtime_api::ObjectHandle> {
-        todo!()
+        None
     }
 }

--- a/src/runtime/twz-rt/src/runtime/debug.rs
+++ b/src/runtime/twz-rt/src/runtime/debug.rs
@@ -1,0 +1,31 @@
+use twizzler_runtime_api::DebugRuntime;
+
+use super::ReferenceRuntime;
+
+impl DebugRuntime for ReferenceRuntime {
+    fn get_library(
+        &self,
+        id: twizzler_runtime_api::LibraryId,
+    ) -> Option<twizzler_runtime_api::Library> {
+        todo!()
+    }
+
+    fn get_exeid(&self) -> Option<twizzler_runtime_api::LibraryId> {
+        todo!()
+    }
+
+    fn get_library_segment(
+        &self,
+        lib: &twizzler_runtime_api::Library,
+        seg: usize,
+    ) -> Option<twizzler_runtime_api::AddrRange> {
+        todo!()
+    }
+
+    fn get_full_mapping(
+        &self,
+        lib: &twizzler_runtime_api::Library,
+    ) -> Option<twizzler_runtime_api::ObjectHandle> {
+        todo!()
+    }
+}

--- a/src/runtime/twz-rt/src/runtime/debug.rs
+++ b/src/runtime/twz-rt/src/runtime/debug.rs
@@ -2,6 +2,8 @@ use twizzler_runtime_api::DebugRuntime;
 
 use super::ReferenceRuntime;
 
+// TODO: hook into dynlink for this stuff
+
 impl DebugRuntime for ReferenceRuntime {
     fn get_library(
         &self,

--- a/src/runtime/twz-rt/src/runtime/debug.rs
+++ b/src/runtime/twz-rt/src/runtime/debug.rs
@@ -5,7 +5,7 @@ use super::ReferenceRuntime;
 impl DebugRuntime for ReferenceRuntime {
     fn get_library(
         &self,
-        id: twizzler_runtime_api::LibraryId,
+        _id: twizzler_runtime_api::LibraryId,
     ) -> Option<twizzler_runtime_api::Library> {
         todo!()
     }
@@ -16,15 +16,15 @@ impl DebugRuntime for ReferenceRuntime {
 
     fn get_library_segment(
         &self,
-        lib: &twizzler_runtime_api::Library,
-        seg: usize,
+        _lib: &twizzler_runtime_api::Library,
+        _seg: usize,
     ) -> Option<twizzler_runtime_api::AddrRange> {
         todo!()
     }
 
     fn get_full_mapping(
         &self,
-        lib: &twizzler_runtime_api::Library,
+        _lib: &twizzler_runtime_api::Library,
     ) -> Option<twizzler_runtime_api::ObjectHandle> {
         todo!()
     }

--- a/src/runtime/twz-rt/src/runtime/file.rs
+++ b/src/runtime/twz-rt/src/runtime/file.rs
@@ -1,0 +1,5 @@
+use twizzler_runtime_api::RustFsRuntime;
+
+use super::ReferenceRuntime;
+
+impl RustFsRuntime for ReferenceRuntime {}

--- a/src/runtime/twz-rt/src/runtime/object.rs
+++ b/src/runtime/twz-rt/src/runtime/object.rs
@@ -5,17 +5,17 @@ use super::ReferenceRuntime;
 impl ObjectRuntime for ReferenceRuntime {
     fn map_object(
         &self,
-        id: twizzler_runtime_api::ObjID,
-        flags: twizzler_runtime_api::MapFlags,
+        _id: twizzler_runtime_api::ObjID,
+        _flags: twizzler_runtime_api::MapFlags,
     ) -> Result<twizzler_runtime_api::ObjectHandle, twizzler_runtime_api::MapError> {
         todo!()
     }
 
-    fn unmap_object(&self, handle: &twizzler_runtime_api::ObjectHandle) {
+    fn unmap_object(&self, _handle: &twizzler_runtime_api::ObjectHandle) {
         todo!()
     }
 
-    fn release_handle(&self, handle: &mut twizzler_runtime_api::ObjectHandle) {
+    fn release_handle(&self, _handle: &mut twizzler_runtime_api::ObjectHandle) {
         todo!()
     }
 }

--- a/src/runtime/twz-rt/src/runtime/object.rs
+++ b/src/runtime/twz-rt/src/runtime/object.rs
@@ -1,0 +1,21 @@
+use twizzler_runtime_api::ObjectRuntime;
+
+use super::ReferenceRuntime;
+
+impl ObjectRuntime for ReferenceRuntime {
+    fn map_object(
+        &self,
+        id: twizzler_runtime_api::ObjID,
+        flags: twizzler_runtime_api::MapFlags,
+    ) -> Result<twizzler_runtime_api::ObjectHandle, twizzler_runtime_api::MapError> {
+        todo!()
+    }
+
+    fn unmap_object(&self, handle: &twizzler_runtime_api::ObjectHandle) {
+        todo!()
+    }
+
+    fn release_handle(&self, handle: &mut twizzler_runtime_api::ObjectHandle) {
+        todo!()
+    }
+}

--- a/src/runtime/twz-rt/src/runtime/object.rs
+++ b/src/runtime/twz-rt/src/runtime/object.rs
@@ -6,6 +6,8 @@ use twizzler_runtime_api::{MapError, MapFlags, ObjectHandle, ObjectRuntime};
 
 use super::ReferenceRuntime;
 
+// TODO: implement an object cache
+
 impl ObjectRuntime for ReferenceRuntime {
     fn map_object(
         &self,
@@ -44,6 +46,8 @@ impl ObjectRuntime for ReferenceRuntime {
     fn release_handle(&self, handle: &mut twizzler_runtime_api::ObjectHandle) {
         let slot = (handle.start as usize) / MAX_SIZE;
 
-        if sys_object_unmap(None, slot, UnmapFlags::empty()).is_ok() {}
+        if sys_object_unmap(None, slot, UnmapFlags::empty()).is_ok() {
+            self.release_slot(slot);
+        }
     }
 }

--- a/src/runtime/twz-rt/src/runtime/object.rs
+++ b/src/runtime/twz-rt/src/runtime/object.rs
@@ -1,21 +1,45 @@
-use twizzler_runtime_api::ObjectRuntime;
+use twizzler_abi::{
+    object::{ObjID, Protections, MAX_SIZE, NULLPAGE_SIZE},
+    syscall::sys_object_map,
+};
+use twizzler_runtime_api::{MapError, MapFlags, ObjectHandle, ObjectRuntime};
 
-use super::ReferenceRuntime;
+use super::{slot::early_slot_alloc, ReferenceRuntime};
 
 impl ObjectRuntime for ReferenceRuntime {
     fn map_object(
         &self,
-        _id: twizzler_runtime_api::ObjID,
-        _flags: twizzler_runtime_api::MapFlags,
+        id: twizzler_runtime_api::ObjID,
+        flags: twizzler_runtime_api::MapFlags,
     ) -> Result<twizzler_runtime_api::ObjectHandle, twizzler_runtime_api::MapError> {
-        todo!()
+        let mut prot = Protections::empty();
+        if flags.contains(MapFlags::READ) {
+            prot.insert(Protections::READ);
+        }
+        if flags.contains(MapFlags::WRITE) {
+            prot.insert(Protections::WRITE);
+        }
+        if flags.contains(MapFlags::EXEC) {
+            prot.insert(Protections::EXEC);
+        }
+        let slot = early_slot_alloc().ok_or(MapError::OutOfResources)?;
+        let _ = sys_object_map(
+            None,
+            ObjID::new(id),
+            slot,
+            prot,
+            twizzler_abi::syscall::MapFlags::empty(),
+        )
+        .map_err(|_| MapError::InternalError)?;
+        Ok(ObjectHandle {
+            id,
+            flags,
+            start: (slot * MAX_SIZE) as *mut u8,
+            meta: (slot * MAX_SIZE + MAX_SIZE - NULLPAGE_SIZE) as *mut u8,
+        })
     }
 
-    fn unmap_object(&self, _handle: &twizzler_runtime_api::ObjectHandle) {
-        todo!()
-    }
+    fn unmap_object(&self, _handle: &twizzler_runtime_api::ObjectHandle) {}
 
-    fn release_handle(&self, _handle: &mut twizzler_runtime_api::ObjectHandle) {
-        todo!()
-    }
+    fn release_handle(&self, _handle: &mut twizzler_runtime_api::ObjectHandle) {}
 }

--- a/src/runtime/twz-rt/src/runtime/process.rs
+++ b/src/runtime/twz-rt/src/runtime/process.rs
@@ -1,0 +1,5 @@
+use twizzler_runtime_api::RustProcessRuntime;
+
+use super::ReferenceRuntime;
+
+impl RustProcessRuntime for ReferenceRuntime {}

--- a/src/runtime/twz-rt/src/runtime/slot.rs
+++ b/src/runtime/twz-rt/src/runtime/slot.rs
@@ -32,7 +32,7 @@ impl EarlySlotAllocatorInner {
         self.slots[slot / 8] |= 1 << (slot % 8)
     }
 
-    fn release(&mut self, slot: usize) {
+    fn _release(&mut self, slot: usize) {
         self.slots[slot / 8] &= !(1 << (slot % 8));
     }
 

--- a/src/runtime/twz-rt/src/runtime/slot.rs
+++ b/src/runtime/twz-rt/src/runtime/slot.rs
@@ -1,0 +1,71 @@
+use std::{
+    cell::UnsafeCell,
+    sync::atomic::{AtomicBool, Ordering},
+};
+
+use twizzler_abi::arch::SLOTS;
+
+pub fn early_slot_alloc() -> Option<usize> {
+    EARLY_SLOT_ALLOC.with_inner_mut(|inner| inner.get_new())
+}
+
+pub fn mark_slot_reserved(slot: usize) {
+    EARLY_SLOT_ALLOC.with_inner_mut(|inner| inner.set(slot))
+}
+
+struct EarlySlotAllocatorInner {
+    slots: [u8; SLOTS / 8],
+}
+
+impl EarlySlotAllocatorInner {
+    const fn new() -> Self {
+        Self {
+            slots: [0u8; SLOTS / 8],
+        }
+    }
+
+    fn test(&self, slot: usize) -> bool {
+        self.slots[slot / 8] & (1 << (slot % 8)) != 0
+    }
+
+    fn set(&mut self, slot: usize) {
+        self.slots[slot / 8] |= 1 << (slot % 8)
+    }
+
+    fn release(&mut self, slot: usize) {
+        self.slots[slot / 8] &= !(1 << (slot % 8));
+    }
+
+    fn get_new(&mut self) -> Option<usize> {
+        for s in 0..SLOTS {
+            if !self.test(s) {
+                self.set(s);
+                return Some(s);
+            }
+        }
+        None
+    }
+}
+
+struct EarlySlotAllocator {
+    lock: AtomicBool,
+    inner: UnsafeCell<EarlySlotAllocatorInner>,
+}
+
+impl EarlySlotAllocator {
+    fn with_inner_mut<R>(&self, f: impl FnOnce(&mut EarlySlotAllocatorInner) -> R) -> R {
+        while self.lock.swap(true, Ordering::SeqCst) {
+            core::hint::spin_loop()
+        }
+        let r = f(unsafe { self.inner.get().as_mut().unwrap() });
+        self.lock.store(false, Ordering::SeqCst);
+        r
+    }
+}
+
+static EARLY_SLOT_ALLOC: EarlySlotAllocator = EarlySlotAllocator {
+    lock: AtomicBool::new(false),
+    inner: UnsafeCell::new(EarlySlotAllocatorInner::new()),
+};
+
+unsafe impl Sync for EarlySlotAllocator {}

--- a/src/runtime/twz-rt/src/runtime/slot.rs
+++ b/src/runtime/twz-rt/src/runtime/slot.rs
@@ -1,71 +1,215 @@
-use std::{
-    cell::UnsafeCell,
-    sync::atomic::{AtomicBool, Ordering},
+//! Slot allocator. This proceeds in two phases. During the initialization phase, before the runtime is
+//! marked ready, we use early slot allocation. After the runtime is ready, we use normal slot allocation.
+//! Right before switching, the runtime must call in and initialize the proper slot allocator.
+//!
+//! Slots are organized into pairs, (0,1), (2,3), (4,5), ..., (n-2,n-1). This is because the dynamic linker
+//! needs to be able to load an ELF into adjacent objects in virtual memory, and is not fundamental to Twizzler.
+//! To allocate single slots, we allocate a pair and split it, recording one of the slots as available for single
+//! allocation, and returning the other. When a single slot is released, it also gets marked as available for
+//! single allocation. However, eventually we'll need to consolidate the single slots back into pairs, or we will
+//! run out. When the number of single slots allocated from pairs grows past a high watermark, we do a GC run on
+//! the slot list, which sorts the list and then finds and removes pairs, freeing those pairs back up for future allocation.
+//!
+//! One thing that makes this tricky is that we cannot allocate memory within the slot allocator, as we hold a lock on it,
+//! and the allocator might call us if it needs another object for allocating memory. Thus we must be careful during operation
+//! to not allocate memory. We manage this by being a bit wasteful: the slot allocator reserves two vectors ahead of time,
+//! each of capacity SLOTS (which is the max number of slots we can have). The first is a stack of single allocated slots, and
+//! the second is used during the GC pass described above.
+
+use std::sync::{
+    atomic::{AtomicUsize, Ordering},
+    Mutex,
 };
 
+use tracing::trace;
 use twizzler_abi::arch::SLOTS;
 
-pub fn early_slot_alloc() -> Option<usize> {
-    EARLY_SLOT_ALLOC.with_inner_mut(|inner| inner.get_new())
+use crate::{preinit::preinit_abort, preinit_println};
+
+use super::{ReferenceRuntime, RuntimeState};
+
+fn early_slot_alloc() -> Option<usize> {
+    Some(EARLY_SLOT_ALLOC.next.fetch_add(1, Ordering::SeqCst))
 }
 
-pub fn mark_slot_reserved(slot: usize) {
-    EARLY_SLOT_ALLOC.with_inner_mut(|inner| inner.set(slot))
+pub fn mark_slot_reserved(_slot: usize) {
+    // TODO: actually reserve bootstrap slots
 }
 
-struct EarlySlotAllocatorInner {
-    slots: [u8; SLOTS / 8],
+// Simple incremental allocator.
+struct EarlySlotAllocator {
+    next: AtomicUsize,
 }
 
-impl EarlySlotAllocatorInner {
+impl EarlySlotAllocator {}
+
+static EARLY_SLOT_ALLOC: EarlySlotAllocator = EarlySlotAllocator {
+    // TODO: actually reserve bootstrap slots
+    next: AtomicUsize::new(100),
+};
+
+struct SlotAllocatorInner {
+    pairs: [u8; (SLOTS / 2) / 8],
+    singles: Vec<usize>,
+    singles_aux: Vec<usize>,
+}
+
+impl SlotAllocatorInner {
     const fn new() -> Self {
         Self {
-            slots: [0u8; SLOTS / 8],
+            pairs: [0; SLOTS / 2 / 8],
+            singles: Vec::new(),
+            singles_aux: Vec::new(),
         }
     }
 
-    fn test(&self, slot: usize) -> bool {
-        self.slots[slot / 8] & (1 << (slot % 8)) != 0
+    fn test(&self, pair: usize) -> bool {
+        self.pairs[pair / 8] & (1 << (pair % 8)) != 0
     }
 
-    fn set(&mut self, slot: usize) {
-        self.slots[slot / 8] |= 1 << (slot % 8)
+    fn set(&mut self, pair: usize) {
+        self.pairs[pair / 8] |= 1 << (pair % 8)
     }
 
-    fn _release(&mut self, slot: usize) {
-        self.slots[slot / 8] &= !(1 << (slot % 8));
+    fn release_pair(&mut self, first_slot: usize) {
+        assert!(first_slot % 2 == 0);
+        let pair = first_slot / 2;
+        self.pairs[pair / 8] &= !(1 << (pair % 8));
     }
 
-    fn get_new(&mut self) -> Option<usize> {
-        for s in 0..SLOTS {
-            if !self.test(s) {
-                self.set(s);
-                return Some(s);
+    fn alloc_pair(&mut self) -> Option<(usize, usize)> {
+        for p in 0..(SLOTS / 2) {
+            if !self.test(p) {
+                self.set(p);
+                return Some((p * 2, p * 2 + 1));
             }
         }
         None
     }
-}
 
-struct EarlySlotAllocator {
-    lock: AtomicBool,
-    inner: UnsafeCell<EarlySlotAllocatorInner>,
-}
-
-impl EarlySlotAllocator {
-    fn with_inner_mut<R>(&self, f: impl FnOnce(&mut EarlySlotAllocatorInner) -> R) -> R {
-        while self.lock.swap(true, Ordering::SeqCst) {
-            core::hint::spin_loop()
+    fn alloc_single(&mut self) -> Option<usize> {
+        if let Some(idx) = self.singles.pop() {
+            return Some(idx);
         }
-        let r = f(unsafe { self.inner.get().as_mut().unwrap() });
-        self.lock.store(false, Ordering::SeqCst);
-        r
+
+        let pair = self.alloc_pair()?;
+        trace!("slot allocator: splitting pair ({}, {})", pair.0, pair.1);
+        self.singles.push(pair.0);
+        Some(pair.1)
+    }
+
+    fn release_single(&mut self, slot: usize) {
+        self.singles.push(slot);
+        self.maybe_gc_singles();
+    }
+
+    // TODO: tune this!
+    const HIGH_WATERMARK: usize = SLOTS / 4;
+    const SINGLES_CAPACITY: usize = SLOTS;
+
+    fn maybe_gc_singles(&mut self) {
+        if self.singles.len() < Self::HIGH_WATERMARK {
+            return;
+        }
+        trace!(
+            "slot allocator: GC single slots (len = {})",
+            self.singles.len()
+        );
+        // Step 1: setup the aux vector and sort the singles. Use unstable sort because it doesn't allocate memory.
+        self.singles_aux.truncate(0);
+        self.singles.sort_unstable();
+
+        // Step 2: collect a list of valid pairs by iterating over all windows of size 2 and checking if a window contains a pair.
+        // Note that this is exactly correct and not an overcount because we know that each slot in here is unique, so imagine:
+        // [2,3,4,5]. This will produce pairs (2,3) and (4,5), even though it considers and sees (3,4) as a pair of consecutive
+        // indices. But (3,4) is not a valid pair because it does not start with an even number, and all valid pairs do.
+        // [1,2,3,4] => (2,3), [2,4,5] => (4,5)
+        let pair_firsts = self.singles.array_windows::<2>().filter_map(|maybe_pair| {
+            if (maybe_pair[0] % 2 == 0) && maybe_pair[1] == maybe_pair[0] + 1 {
+                Some(maybe_pair[0])
+            } else {
+                None
+            }
+        });
+        // Use the preallocated aux vector to collect the pair list.
+        self.singles_aux.extend(pair_firsts);
+
+        // Step 3: remove all pairs from the single list, and free them.
+        for pf in &self.singles_aux {
+            let index = self.singles.binary_search(pf).unwrap();
+            let old_a = self.singles.remove(index);
+            let old_b = self.singles.remove(index + 1);
+            assert_eq!(old_a + 1, old_b);
+            assert_eq!(old_a, *pf);
+            assert_eq!(old_a % 2, 0);
+            let pair = *pf / 2;
+            self.pairs[pair / 8] &= !(1 << (pair % 8));
+        }
+
+        trace!(
+            "slot allocator: GC single slots recovered {} pairs (single slots len = {})",
+            self.singles_aux.len(),
+            self.singles.len()
+        );
     }
 }
 
-static EARLY_SLOT_ALLOC: EarlySlotAllocator = EarlySlotAllocator {
-    lock: AtomicBool::new(false),
-    inner: UnsafeCell::new(EarlySlotAllocatorInner::new()),
+struct SlotAllocator {
+    inner: Mutex<SlotAllocatorInner>,
+}
+
+static SLOT_ALLOCATOR: SlotAllocator = SlotAllocator {
+    inner: Mutex::new(SlotAllocatorInner::new()),
 };
 
-unsafe impl Sync for EarlySlotAllocator {}
+#[allow(dead_code)]
+impl ReferenceRuntime {
+    pub(crate) fn init_slots(&self) {
+        // pre-allocate the slot vectors
+        let singles = Vec::with_capacity(SlotAllocatorInner::SINGLES_CAPACITY);
+        let singles_aux = Vec::with_capacity(SlotAllocatorInner::SINGLES_CAPACITY);
+        let mut inner = SLOT_ALLOCATOR.inner.lock().unwrap();
+        inner.singles = singles;
+        inner.singles_aux = singles_aux;
+        // TODO: proper pre-reservation
+        for i in 0..(EARLY_SLOT_ALLOC.next.load(Ordering::SeqCst) / 2 + 1) {
+            inner.set(i);
+        }
+    }
+
+    /// Allocate a slot, returning it's number if one is available.
+    pub fn allocate_slot(&self) -> Option<usize> {
+        if self.state().contains(RuntimeState::READY) {
+            SLOT_ALLOCATOR.inner.lock().unwrap().alloc_single()
+        } else {
+            early_slot_alloc()
+        }
+    }
+
+    /// Release a slot.
+    pub fn release_slot(&self, slot: usize) {
+        if self.state().contains(RuntimeState::READY) {
+            SLOT_ALLOCATOR.inner.lock().unwrap().release_single(slot)
+        }
+        // early alloc has no ability to release slots
+    }
+
+    /// Allocate a pair of adjacent slots, returning their numbers if a pair is available. The returned tuple will always be of form (x, x+1).
+    pub fn allocate_pair(&self) -> Option<(usize, usize)> {
+        if self.state().contains(RuntimeState::READY) {
+            SLOT_ALLOCATOR.inner.lock().unwrap().alloc_pair()
+        } else {
+            preinit_println!("cannot allocate slot pairs during runtime init");
+            preinit_abort();
+        }
+    }
+
+    /// Release a pair. Must be of form (x, x+1).
+    pub fn release_pair(&self, pair: (usize, usize)) {
+        if self.state().contains(RuntimeState::READY) {
+            assert_eq!(pair.0 + 1, pair.1);
+            SLOT_ALLOCATOR.inner.lock().unwrap().release_pair(pair.0)
+        }
+        // early alloc has no ability to release slots
+    }
+}

--- a/src/runtime/twz-rt/src/runtime/stdio.rs
+++ b/src/runtime/twz-rt/src/runtime/stdio.rs
@@ -1,3 +1,7 @@
+//! Implements stdio streams. For each one (stdin, stdout, and stderr), we have two possible sinks: a thread-local, and a "local"
+//! destination (here, local to this particular linking to this runtime). We try the thread-local first, if available, and if not, try
+//! the runtime local option. If that isn't present, we fallback to the Fallback writer and reader.
+
 use std::{
     panic::RefUnwindSafe,
     sync::{Arc, RwLock},

--- a/src/runtime/twz-rt/src/runtime/stdio.rs
+++ b/src/runtime/twz-rt/src/runtime/stdio.rs
@@ -1,39 +1,66 @@
-use twizzler_runtime_api::RustStdioRuntime;
+use twizzler_abi::syscall::{
+    sys_kernel_console_read, sys_kernel_console_write, KernelConsoleReadFlags,
+    KernelConsoleWriteFlags,
+};
+use twizzler_runtime_api::{IoRead, IoWrite, ReadError, RustStdioRuntime};
 
 use super::ReferenceRuntime;
 
 impl RustStdioRuntime for ReferenceRuntime {
-    fn with_panic_output(&self, _cb: twizzler_runtime_api::IoWriteDynCallback<'_, ()>) {
-        todo!()
+    fn with_panic_output(&self, cb: twizzler_runtime_api::IoWriteDynCallback<'_, ()>) {
+        cb(&mut IoWritePoint {})
     }
 
     fn with_stdin(
         &self,
-        _cb: twizzler_runtime_api::IoReadDynCallback<
+        cb: twizzler_runtime_api::IoReadDynCallback<
             '_,
             Result<usize, twizzler_runtime_api::ReadError>,
         >,
     ) -> Result<usize, twizzler_runtime_api::ReadError> {
-        todo!()
+        cb(&mut IoReadPoint {})
     }
 
     fn with_stdout(
         &self,
-        _cb: twizzler_runtime_api::IoWriteDynCallback<
+        cb: twizzler_runtime_api::IoWriteDynCallback<
             '_,
             Result<usize, twizzler_runtime_api::WriteError>,
         >,
     ) -> Result<usize, twizzler_runtime_api::WriteError> {
-        todo!()
+        cb(&mut IoWritePoint {})
     }
 
     fn with_stderr(
         &self,
-        _cb: twizzler_runtime_api::IoWriteDynCallback<
+        cb: twizzler_runtime_api::IoWriteDynCallback<
             '_,
             Result<usize, twizzler_runtime_api::WriteError>,
         >,
     ) -> Result<usize, twizzler_runtime_api::WriteError> {
-        todo!()
+        cb(&mut IoWritePoint {})
+    }
+}
+
+struct IoWritePoint {}
+
+impl IoWrite for IoWritePoint {
+    fn write(&mut self, buf: &[u8]) -> Result<usize, twizzler_runtime_api::WriteError> {
+        sys_kernel_console_write(buf, KernelConsoleWriteFlags::empty());
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> Result<(), twizzler_runtime_api::WriteError> {
+        Ok(())
+    }
+}
+
+struct IoReadPoint {}
+
+impl IoRead for IoReadPoint {
+    fn read(&mut self, buf: &mut [u8]) -> Result<usize, twizzler_runtime_api::ReadError> {
+        let len = sys_kernel_console_read(buf, KernelConsoleReadFlags::empty())
+            .map_err(|_| ReadError::IoError)?;
+        Ok(len)
     }
 }

--- a/src/runtime/twz-rt/src/runtime/stdio.rs
+++ b/src/runtime/twz-rt/src/runtime/stdio.rs
@@ -3,13 +3,13 @@ use twizzler_runtime_api::RustStdioRuntime;
 use super::ReferenceRuntime;
 
 impl RustStdioRuntime for ReferenceRuntime {
-    fn with_panic_output(&self, cb: twizzler_runtime_api::IoWriteDynCallback<'_, ()>) {
+    fn with_panic_output(&self, _cb: twizzler_runtime_api::IoWriteDynCallback<'_, ()>) {
         todo!()
     }
 
     fn with_stdin(
         &self,
-        cb: twizzler_runtime_api::IoReadDynCallback<
+        _cb: twizzler_runtime_api::IoReadDynCallback<
             '_,
             Result<usize, twizzler_runtime_api::ReadError>,
         >,
@@ -19,7 +19,7 @@ impl RustStdioRuntime for ReferenceRuntime {
 
     fn with_stdout(
         &self,
-        cb: twizzler_runtime_api::IoWriteDynCallback<
+        _cb: twizzler_runtime_api::IoWriteDynCallback<
             '_,
             Result<usize, twizzler_runtime_api::WriteError>,
         >,
@@ -29,7 +29,7 @@ impl RustStdioRuntime for ReferenceRuntime {
 
     fn with_stderr(
         &self,
-        cb: twizzler_runtime_api::IoWriteDynCallback<
+        _cb: twizzler_runtime_api::IoWriteDynCallback<
             '_,
             Result<usize, twizzler_runtime_api::WriteError>,
         >,

--- a/src/runtime/twz-rt/src/runtime/stdio.rs
+++ b/src/runtime/twz-rt/src/runtime/stdio.rs
@@ -1,3 +1,8 @@
+use std::{
+    panic::RefUnwindSafe,
+    sync::{Arc, RwLock},
+};
+
 use twizzler_abi::syscall::{
     sys_kernel_console_read, sys_kernel_console_write, KernelConsoleReadFlags,
     KernelConsoleWriteFlags,
@@ -6,9 +11,42 @@ use twizzler_runtime_api::{IoRead, IoWrite, ReadError, RustStdioRuntime};
 
 use super::ReferenceRuntime;
 
+#[thread_local]
+static THREAD_STDIN: RwLock<Option<Arc<dyn IoRead>>> = RwLock::new(None);
+#[thread_local]
+static THREAD_STDOUT: RwLock<Option<Arc<dyn IoWrite>>> = RwLock::new(None);
+#[thread_local]
+static THREAD_STDERR: RwLock<Option<Arc<dyn IoWrite + RefUnwindSafe>>> = RwLock::new(None);
+
+static LOCAL_STDIN: RwLock<Option<Arc<dyn IoRead + Sync + Send>>> = RwLock::new(None);
+static LOCAL_STDOUT: RwLock<Option<Arc<dyn IoWrite + Sync + Send>>> = RwLock::new(None);
+static LOCAL_STDERR: RwLock<Option<Arc<dyn IoWrite + Sync + Send + RefUnwindSafe>>> =
+    RwLock::new(None);
+
 impl RustStdioRuntime for ReferenceRuntime {
-    fn with_panic_output(&self, cb: twizzler_runtime_api::IoWriteDynCallback<'_, ()>) {
-        cb(&mut IoWritePoint {})
+    fn with_panic_output(&self, cb: twizzler_runtime_api::IoWritePanicDynCallback<'_, ()>) {
+        // For panic output, try to never wait on any locks. Also, catch unwinds and treat
+        // the output option as None if the callback panics, to try to ensure the output goes somewhere.
+
+        // Unwrap-Ok: we ensure that no one can panic when holding the read lock.
+        if let Ok(ref out) = THREAD_STDERR.try_read() {
+            if let Some(ref out) = **out {
+                if std::panic::catch_unwind(|| cb(&**out)).is_ok() {
+                    return;
+                }
+            }
+        }
+
+        if let Ok(ref out) = LOCAL_STDERR.try_read() {
+            if let Some(ref out) = **out {
+                if std::panic::catch_unwind(|| cb(&**out)).is_ok() {
+                    return;
+                }
+            }
+        }
+
+        // We've done all we can do.
+        let _ = std::panic::catch_unwind(|| cb(&mut FallbackWritePoint {}));
     }
 
     fn with_stdin(
@@ -18,7 +56,19 @@ impl RustStdioRuntime for ReferenceRuntime {
             Result<usize, twizzler_runtime_api::ReadError>,
         >,
     ) -> Result<usize, twizzler_runtime_api::ReadError> {
-        cb(&mut IoReadPoint {})
+        // Unwrap-Ok: we ensure that no one can panic when holding the read lock.
+        if let Some(ref out) = &*THREAD_STDIN.read().unwrap() {
+            // TODO: do we need to catch unwinds here?
+            return cb(&**out);
+        }
+
+        if let Some(ref out) = &*LOCAL_STDIN.read().unwrap() {
+            // TODO: do we need to catch unwinds here?
+            return cb(&**out);
+        }
+
+        // TODO: do we need to catch unwinds here?
+        cb(&mut FallbackReadPoint {})
     }
 
     fn with_stdout(
@@ -28,7 +78,19 @@ impl RustStdioRuntime for ReferenceRuntime {
             Result<usize, twizzler_runtime_api::WriteError>,
         >,
     ) -> Result<usize, twizzler_runtime_api::WriteError> {
-        cb(&mut IoWritePoint {})
+        // Unwrap-Ok: we ensure that no one can panic when holding the read lock.
+        if let Some(ref out) = &*THREAD_STDOUT.read().unwrap() {
+            // TODO: do we need to catch unwinds here?
+            return cb(&**out);
+        }
+
+        if let Some(ref out) = &*LOCAL_STDOUT.read().unwrap() {
+            // TODO: do we need to catch unwinds here?
+            return cb(&**out);
+        }
+
+        // TODO: do we need to catch unwinds here?
+        cb(&mut FallbackWritePoint {})
     }
 
     fn with_stderr(
@@ -38,27 +100,39 @@ impl RustStdioRuntime for ReferenceRuntime {
             Result<usize, twizzler_runtime_api::WriteError>,
         >,
     ) -> Result<usize, twizzler_runtime_api::WriteError> {
-        cb(&mut IoWritePoint {})
+        // Unwrap-Ok: we ensure that no one can panic when holding the read lock.
+        if let Some(ref out) = &*THREAD_STDERR.read().unwrap() {
+            // TODO: do we need to catch unwinds here?
+            return cb(&**out);
+        }
+
+        if let Some(ref out) = &*LOCAL_STDERR.read().unwrap() {
+            // TODO: do we need to catch unwinds here?
+            return cb(&**out);
+        }
+
+        // TODO: do we need to catch unwinds here?
+        cb(&mut FallbackWritePoint {})
     }
 }
 
-struct IoWritePoint {}
+struct FallbackWritePoint {}
 
-impl IoWrite for IoWritePoint {
-    fn write(&mut self, buf: &[u8]) -> Result<usize, twizzler_runtime_api::WriteError> {
+impl IoWrite for FallbackWritePoint {
+    fn write(&self, buf: &[u8]) -> Result<usize, twizzler_runtime_api::WriteError> {
         sys_kernel_console_write(buf, KernelConsoleWriteFlags::empty());
         Ok(buf.len())
     }
 
-    fn flush(&mut self) -> Result<(), twizzler_runtime_api::WriteError> {
+    fn flush(&self) -> Result<(), twizzler_runtime_api::WriteError> {
         Ok(())
     }
 }
 
-struct IoReadPoint {}
+struct FallbackReadPoint {}
 
-impl IoRead for IoReadPoint {
-    fn read(&mut self, buf: &mut [u8]) -> Result<usize, twizzler_runtime_api::ReadError> {
+impl IoRead for FallbackReadPoint {
+    fn read(&self, buf: &mut [u8]) -> Result<usize, twizzler_runtime_api::ReadError> {
         let len = sys_kernel_console_read(buf, KernelConsoleReadFlags::empty())
             .map_err(|_| ReadError::IoError)?;
         Ok(len)

--- a/src/runtime/twz-rt/src/runtime/stdio.rs
+++ b/src/runtime/twz-rt/src/runtime/stdio.rs
@@ -1,0 +1,39 @@
+use twizzler_runtime_api::RustStdioRuntime;
+
+use super::ReferenceRuntime;
+
+impl RustStdioRuntime for ReferenceRuntime {
+    fn with_panic_output(&self, cb: twizzler_runtime_api::IoWriteDynCallback<'_, ()>) {
+        todo!()
+    }
+
+    fn with_stdin(
+        &self,
+        cb: twizzler_runtime_api::IoReadDynCallback<
+            '_,
+            Result<usize, twizzler_runtime_api::ReadError>,
+        >,
+    ) -> Result<usize, twizzler_runtime_api::ReadError> {
+        todo!()
+    }
+
+    fn with_stdout(
+        &self,
+        cb: twizzler_runtime_api::IoWriteDynCallback<
+            '_,
+            Result<usize, twizzler_runtime_api::WriteError>,
+        >,
+    ) -> Result<usize, twizzler_runtime_api::WriteError> {
+        todo!()
+    }
+
+    fn with_stderr(
+        &self,
+        cb: twizzler_runtime_api::IoWriteDynCallback<
+            '_,
+            Result<usize, twizzler_runtime_api::WriteError>,
+        >,
+    ) -> Result<usize, twizzler_runtime_api::WriteError> {
+        todo!()
+    }
+}

--- a/src/runtime/twz-rt/src/runtime/thread.rs
+++ b/src/runtime/twz-rt/src/runtime/thread.rs
@@ -1,27 +1,62 @@
+use dynlink::tls::Tcb;
+use twizzler_abi::syscall::{
+    sys_thread_sync, ThreadSync, ThreadSyncError, ThreadSyncFlags, ThreadSyncOp,
+    ThreadSyncReference, ThreadSyncSleep, ThreadSyncWake,
+};
 use twizzler_runtime_api::ThreadRuntime;
+
+use crate::preinit_println;
 
 use super::ReferenceRuntime;
 
 impl ThreadRuntime for ReferenceRuntime {
-    fn available_parallelism(&self) -> std::num::NonZeroUsize {
-        todo!()
+    fn available_parallelism(&self) -> core::num::NonZeroUsize {
+        twizzler_abi::syscall::sys_info().cpu_count()
     }
 
     fn futex_wait(
         &self,
-        _futex: &std::sync::atomic::AtomicU32,
-        _expected: u32,
-        _timeout: Option<std::time::Duration>,
+        futex: &core::sync::atomic::AtomicU32,
+        expected: u32,
+        timeout: Option<core::time::Duration>,
     ) -> bool {
-        todo!()
+        // No need to wait if the value already changed.
+        if futex.load(core::sync::atomic::Ordering::Relaxed) != expected {
+            return true;
+        }
+
+        let r = sys_thread_sync(
+            &mut [ThreadSync::new_sleep(ThreadSyncSleep::new(
+                ThreadSyncReference::Virtual32(futex),
+                expected as u64,
+                ThreadSyncOp::Equal,
+                ThreadSyncFlags::empty(),
+            ))],
+            timeout,
+        );
+
+        match r {
+            Err(ThreadSyncError::Timeout) => return false,
+            _ => return true,
+        }
     }
 
-    fn futex_wake(&self, _futex: &std::sync::atomic::AtomicU32) -> bool {
-        todo!()
+    fn futex_wake(&self, futex: &core::sync::atomic::AtomicU32) -> bool {
+        let wake = ThreadSync::new_wake(ThreadSyncWake::new(
+            ThreadSyncReference::Virtual32(futex),
+            1,
+        ));
+        let _ = sys_thread_sync(&mut [wake], None);
+        // TODO
+        false
     }
 
-    fn futex_wake_all(&self, _futex: &std::sync::atomic::AtomicU32) {
-        todo!()
+    fn futex_wake_all(&self, futex: &core::sync::atomic::AtomicU32) {
+        let wake = ThreadSync::new_wake(ThreadSyncWake::new(
+            ThreadSyncReference::Virtual32(futex),
+            usize::MAX,
+        ));
+        let _ = sys_thread_sync(&mut [wake], None);
     }
 
     fn spawn(
@@ -31,27 +66,23 @@ impl ThreadRuntime for ReferenceRuntime {
         todo!()
     }
 
-    fn yield_now(&self) {
-        todo!()
-    }
+    fn yield_now(&self) {}
 
-    fn set_name(&self, _name: &std::ffi::CStr) {
-        todo!()
-    }
+    fn set_name(&self, _name: &std::ffi::CStr) {}
 
-    fn sleep(&self, _duration: std::time::Duration) {
-        todo!()
-    }
+    fn sleep(&self, _duration: std::time::Duration) {}
 
     fn join(
         &self,
         _id: u32,
         _timeout: Option<std::time::Duration>,
     ) -> Result<(), twizzler_runtime_api::JoinError> {
+        preinit_println!("HERE: join");
         todo!()
     }
 
-    fn tls_get_addr(&self, _tls_index: &twizzler_runtime_api::TlsIndex) -> *const u8 {
-        todo!()
+    fn tls_get_addr(&self, index: &twizzler_runtime_api::TlsIndex) -> *const u8 {
+        let tp: &Tcb<()> = unsafe { dynlink::tls::get_thread_control_block().as_ref().unwrap() };
+        tp.get_addr(index)
     }
 }

--- a/src/runtime/twz-rt/src/runtime/thread.rs
+++ b/src/runtime/twz-rt/src/runtime/thread.rs
@@ -1,3 +1,5 @@
+//! Implements thread management routines. Largely unimplemented still.
+
 use dynlink::tls::Tcb;
 use twizzler_abi::syscall::{
     sys_thread_sync, sys_thread_yield, ThreadSync, ThreadSyncError, ThreadSyncFlags, ThreadSyncOp,

--- a/src/runtime/twz-rt/src/runtime/thread.rs
+++ b/src/runtime/twz-rt/src/runtime/thread.rs
@@ -44,10 +44,7 @@ impl ThreadRuntime for ReferenceRuntime {
             timeout,
         );
 
-        match r {
-            Err(ThreadSyncError::Timeout) => return false,
-            _ => return true,
-        }
+        !matches!(r, Err(ThreadSyncError::Timeout))
     }
 
     fn futex_wake(&self, futex: &core::sync::atomic::AtomicU32) -> bool {

--- a/src/runtime/twz-rt/src/runtime/thread.rs
+++ b/src/runtime/twz-rt/src/runtime/thread.rs
@@ -28,7 +28,6 @@ impl ThreadRuntime for ReferenceRuntime {
         expected: u32,
         timeout: Option<core::time::Duration>,
     ) -> bool {
-        preinit_println!("AAAAA");
         // No need to wait if the value already changed.
         if futex.load(core::sync::atomic::Ordering::Relaxed) != expected {
             return true;

--- a/src/runtime/twz-rt/src/runtime/thread.rs
+++ b/src/runtime/twz-rt/src/runtime/thread.rs
@@ -9,24 +9,24 @@ impl ThreadRuntime for ReferenceRuntime {
 
     fn futex_wait(
         &self,
-        futex: &std::sync::atomic::AtomicU32,
-        expected: u32,
-        timeout: Option<std::time::Duration>,
+        _futex: &std::sync::atomic::AtomicU32,
+        _expected: u32,
+        _timeout: Option<std::time::Duration>,
     ) -> bool {
         todo!()
     }
 
-    fn futex_wake(&self, futex: &std::sync::atomic::AtomicU32) -> bool {
+    fn futex_wake(&self, _futex: &std::sync::atomic::AtomicU32) -> bool {
         todo!()
     }
 
-    fn futex_wake_all(&self, futex: &std::sync::atomic::AtomicU32) {
+    fn futex_wake_all(&self, _futex: &std::sync::atomic::AtomicU32) {
         todo!()
     }
 
     fn spawn(
         &self,
-        args: twizzler_runtime_api::ThreadSpawnArgs,
+        _args: twizzler_runtime_api::ThreadSpawnArgs,
     ) -> Result<u32, twizzler_runtime_api::SpawnError> {
         todo!()
     }
@@ -35,23 +35,23 @@ impl ThreadRuntime for ReferenceRuntime {
         todo!()
     }
 
-    fn set_name(&self, name: &std::ffi::CStr) {
+    fn set_name(&self, _name: &std::ffi::CStr) {
         todo!()
     }
 
-    fn sleep(&self, duration: std::time::Duration) {
+    fn sleep(&self, _duration: std::time::Duration) {
         todo!()
     }
 
     fn join(
         &self,
-        id: u32,
-        timeout: Option<std::time::Duration>,
+        _id: u32,
+        _timeout: Option<std::time::Duration>,
     ) -> Result<(), twizzler_runtime_api::JoinError> {
         todo!()
     }
 
-    fn tls_get_addr(&self, tls_index: &twizzler_runtime_api::TlsIndex) -> *const u8 {
+    fn tls_get_addr(&self, _tls_index: &twizzler_runtime_api::TlsIndex) -> *const u8 {
         todo!()
     }
 }

--- a/src/runtime/twz-rt/src/runtime/thread.rs
+++ b/src/runtime/twz-rt/src/runtime/thread.rs
@@ -1,0 +1,57 @@
+use twizzler_runtime_api::ThreadRuntime;
+
+use super::ReferenceRuntime;
+
+impl ThreadRuntime for ReferenceRuntime {
+    fn available_parallelism(&self) -> std::num::NonZeroUsize {
+        todo!()
+    }
+
+    fn futex_wait(
+        &self,
+        futex: &std::sync::atomic::AtomicU32,
+        expected: u32,
+        timeout: Option<std::time::Duration>,
+    ) -> bool {
+        todo!()
+    }
+
+    fn futex_wake(&self, futex: &std::sync::atomic::AtomicU32) -> bool {
+        todo!()
+    }
+
+    fn futex_wake_all(&self, futex: &std::sync::atomic::AtomicU32) {
+        todo!()
+    }
+
+    fn spawn(
+        &self,
+        args: twizzler_runtime_api::ThreadSpawnArgs,
+    ) -> Result<u32, twizzler_runtime_api::SpawnError> {
+        todo!()
+    }
+
+    fn yield_now(&self) {
+        todo!()
+    }
+
+    fn set_name(&self, name: &std::ffi::CStr) {
+        todo!()
+    }
+
+    fn sleep(&self, duration: std::time::Duration) {
+        todo!()
+    }
+
+    fn join(
+        &self,
+        id: u32,
+        timeout: Option<std::time::Duration>,
+    ) -> Result<(), twizzler_runtime_api::JoinError> {
+        todo!()
+    }
+
+    fn tls_get_addr(&self, tls_index: &twizzler_runtime_api::TlsIndex) -> *const u8 {
+        todo!()
+    }
+}

--- a/src/runtime/twz-rt/src/runtime/thread.rs
+++ b/src/runtime/twz-rt/src/runtime/thread.rs
@@ -94,8 +94,12 @@ impl ThreadRuntime for ReferenceRuntime {
         todo!()
     }
 
-    fn tls_get_addr(&self, index: &twizzler_runtime_api::TlsIndex) -> *const u8 {
-        let tp: &Tcb<()> = unsafe { dynlink::tls::get_thread_control_block().as_ref().unwrap() };
+    fn tls_get_addr(&self, index: &twizzler_runtime_api::TlsIndex) -> Option<*const u8> {
+        let tp: &Tcb<()> = unsafe {
+            dynlink::tls::get_thread_control_block()
+                .as_ref()
+                .expect("failed to find thread control block")
+        };
         tp.get_addr(index)
     }
 }

--- a/src/runtime/twz-rt/src/runtime/time.rs
+++ b/src/runtime/twz-rt/src/runtime/time.rs
@@ -1,3 +1,5 @@
+//! Implements time routines.
+
 use std::time::Duration;
 
 use twizzler_abi::syscall::{sys_read_clock_info, ClockSource, ReadClockFlags};

--- a/src/runtime/twz-rt/src/runtime/time.rs
+++ b/src/runtime/twz-rt/src/runtime/time.rs
@@ -1,0 +1,26 @@
+use std::time::Duration;
+
+use twizzler_abi::syscall::{sys_read_clock_info, ClockSource, ReadClockFlags};
+use twizzler_runtime_api::{Monotonicity, RustTimeRuntime};
+
+use super::ReferenceRuntime;
+
+// TODO: determine actual monotonicity properties
+
+impl RustTimeRuntime for ReferenceRuntime {
+    fn get_monotonic(&self) -> Duration {
+        let clock_info = sys_read_clock_info(ClockSource::BestMonotonic, ReadClockFlags::empty())
+            .expect("failed to get monotonic time from kernel");
+        Duration::from(clock_info.current_value())
+    }
+
+    fn actual_monotonicity(&self) -> Monotonicity {
+        Monotonicity::NonMonotonic
+    }
+
+    fn get_system_time(&self) -> Duration {
+        let clock_info = sys_read_clock_info(ClockSource::BestRealTime, ReadClockFlags::empty())
+            .expect("failed to get monotonic time from kernel");
+        Duration::from(clock_info.current_value())
+    }
+}

--- a/tools/xtask/src/build.rs
+++ b/tools/xtask/src/build.rs
@@ -274,13 +274,12 @@ fn maybe_build_tests<'a>(
     options.spec = Packages::Packages(
         packages
             .iter()
-            .filter_map(|p| {
-                match p.name().as_str() {
-                    "twizzler-kernel-macros" => None,
-                    "twizzler-runtime-api" => None,
-                    "nvme" => None,
-                    _ => Some(p.name().to_string())
-                }
+            .filter_map(|p| match p.name().as_str() {
+                "twizzler-kernel-macros" => None,
+                "twizzler-runtime-api" => None,
+                "nvme" => None,
+                "twz-rt" => None,
+                _ => Some(p.name().to_string()),
             })
             .collect(),
     );


### PR DESCRIPTION
This PR continues this fun chain by implementing a lot of the stubs needed for the reference runtime to be able to compile and link, along with just enough functionality for it to start up and manage to call a main function. This PR does not yet hook it up to anything real, however.

* Implement stubs for reference runtime impl Runtime
* Implement runtime init for rr, getting to main.
* Support preinit output (early runtime setup formatted output)
* Implement a basic slot allocator
* Implement basic framework for stdio.