### PR TITLE
Finish implementing TLB shootdown

### DIFF
--- a/src/kernel/src/arch/amd64/interrupt.rs
+++ b/src/kernel/src/arch/amd64/interrupt.rs
@@ -20,6 +20,7 @@ use super::{
 };
 
 pub const GENERIC_IPI_VECTOR: u32 = 200;
+pub const TLB_SHOOTDOWN_VECTOR: u32 = 201;
 pub const TIMER_VECTOR: u32 = 32;
 pub const MIN_VECTOR: usize = 48;
 pub const MAX_VECTOR: usize = 239;
@@ -475,6 +476,9 @@ fn generic_isr_handler(ctx: *mut IsrContext, number: u64, user: bool) {
         0x80 => {}
         GENERIC_IPI_VECTOR => {
             crate::processor::generic_ipi_handler();
+        }
+        TLB_SHOOTDOWN_VECTOR => {
+            super::memory::pagetables::tlb_shootdown_handler();
         }
         n if n >= 240 => {
             super::apic::lapic_interrupt(number as u16);

--- a/src/kernel/src/arch/amd64/memory/pagetables.rs
+++ b/src/kernel/src/arch/amd64/memory/pagetables.rs
@@ -2,6 +2,6 @@ mod consistency;
 mod entry;
 mod table;
 
-pub use consistency::{ArchCacheLineMgr, ArchTlbMgr};
+pub use consistency::{tlb_shootdown_handler, ArchCacheLineMgr, ArchTlbMgr, TlbInvData};
 pub use entry::{Entry, EntryFlags};
 pub use table::Table;

--- a/src/kernel/src/arch/amd64/memory/pagetables.rs
+++ b/src/kernel/src/arch/amd64/memory/pagetables.rs
@@ -2,6 +2,8 @@ mod consistency;
 mod entry;
 mod table;
 
-pub use consistency::{tlb_shootdown_handler, ArchCacheLineMgr, ArchTlbMgr, TlbInvData};
+pub use consistency::{
+    tlb_shootdown_handler, ArchCacheLineMgr, ArchTlbMgr, TlbInvData, TlbShootdownInfo,
+};
 pub use entry::{Entry, EntryFlags};
 pub use table::Table;

--- a/src/kernel/src/arch/amd64/memory/pagetables/consistency.rs
+++ b/src/kernel/src/arch/amd64/memory/pagetables/consistency.rs
@@ -7,7 +7,7 @@ use crate::{
         processor::{TlbShootdownInfo, NUM_TLB_SHOOTDOWN_ENTRIES},
     },
     interrupt::Destination,
-    processor::{current_processor, tls_ready, with_each_active_processor},
+    processor::{current_processor, spin_wait_until, tls_ready, with_each_active_processor},
 };
 
 const MAX_INVALIDATION_INSTRUCTIONS: usize = 16;
@@ -295,11 +295,7 @@ impl ArchTlbMgr {
             // Wait for each processor to report that it is done.
             with_each_active_processor(|p| {
                 if p.id != proc.id {
-                    todo!("introduce the spin-wait concept, which calls into arch code to ensure that deadlock doesn't happen with a spin-wait. the spinlock data structure, this code, and anywhere else that uses spin-wait needs to be audited.");
-                    // It's possible we might wait for more than one invalidation, but it's unlikely
-                    while !p.arch.tlb_shootdown_info.lock().is_finished() {
-                        core::hint::spin_loop();
-                    }
+                    spin_wait_until(|| !p.arch.tlb_shootdown_info.lock().is_finished(), || {});
                 }
             });
         }

--- a/src/kernel/src/arch/amd64/memory/pagetables/consistency.rs
+++ b/src/kernel/src/arch/amd64/memory/pagetables/consistency.rs
@@ -295,6 +295,7 @@ impl ArchTlbMgr {
             // Wait for each processor to report that it is done.
             with_each_active_processor(|p| {
                 if p.id != proc.id {
+                    todo!("introduce the spin-wait concept, which calls into arch code to ensure that deadlock doesn't happen with a spin-wait. the spinlock data structure, this code, and anywhere else that uses spin-wait needs to be audited.");
                     // It's possible we might wait for more than one invalidation, but it's unlikely
                     while !p.arch.tlb_shootdown_info.lock().is_finished() {
                         core::hint::spin_loop();

--- a/src/kernel/src/arch/amd64/processor.rs
+++ b/src/kernel/src/arch/amd64/processor.rs
@@ -7,9 +7,12 @@ use crate::{
     memory::VirtAddr,
     once::Once,
     processor::{current_processor, Processor},
+    spinlock::Spinlock,
 };
 
-use super::{acpi::get_acpi_root, interrupt::InterProcessorInterrupt};
+use super::{
+    acpi::get_acpi_root, interrupt::InterProcessorInterrupt, memory::pagetables::TlbInvData,
+};
 
 #[repr(C)]
 struct GsScratch {
@@ -161,9 +164,33 @@ pub fn get_topology() -> Vec<(usize, bool)> {
     }
 }
 
-#[derive(Default, Debug)]
+pub(super) const NUM_TLB_SHOOTDOWN_ENTRIES: usize = 4;
+pub struct TlbShootdownInfo {
+    pub(super) data: [Option<TlbInvData>; NUM_TLB_SHOOTDOWN_ENTRIES],
+}
+
 pub struct ArchProcessor {
     wait_word: AtomicU64,
+    pub(super) tlb_shootdown_info: Spinlock<TlbShootdownInfo>,
+}
+
+impl core::fmt::Debug for ArchProcessor {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("ArchProcessor")
+            .field("wait_word", &self.wait_word)
+            .finish()
+    }
+}
+
+impl Default for ArchProcessor {
+    fn default() -> Self {
+        Self {
+            wait_word: Default::default(),
+            tlb_shootdown_info: Spinlock::new(TlbShootdownInfo {
+                data: [None, None, None, None],
+            }),
+        }
+    }
 }
 
 #[derive(Default, Debug)]

--- a/src/kernel/src/arch/amd64/processor.rs
+++ b/src/kernel/src/arch/amd64/processor.rs
@@ -11,7 +11,9 @@ use crate::{
 };
 
 use super::{
-    acpi::get_acpi_root, interrupt::InterProcessorInterrupt, memory::pagetables::TlbInvData,
+    acpi::get_acpi_root,
+    interrupt::InterProcessorInterrupt,
+    memory::pagetables::{tlb_shootdown_handler, TlbInvData},
 };
 
 #[repr(C)]
@@ -290,4 +292,8 @@ pub fn get_bsp_id(maybe_processor_info: Option<&acpi::platform::ProcessorInfo>) 
         }
         Some(p) => p.boot_processor.local_apic_id,
     }
+}
+
+pub fn spin_wait_iteration() {
+    tlb_shootdown_handler();
 }

--- a/src/kernel/src/arch/amd64/processor.rs
+++ b/src/kernel/src/arch/amd64/processor.rs
@@ -171,7 +171,7 @@ pub struct TlbShootdownInfo {
 
 pub struct ArchProcessor {
     wait_word: AtomicU64,
-    pub(super) tlb_shootdown_info: Spinlock<TlbShootdownInfo>,
+    pub(super) tlb_shootdown_info: todo!("needs to not be a lock, needs to be wait free"),
 }
 
 impl core::fmt::Debug for ArchProcessor {

--- a/src/kernel/src/mutex.rs
+++ b/src/kernel/src/mutex.rs
@@ -19,6 +19,7 @@ use intrusive_collections::{intrusive_adapter, LinkedList};
 use twizzler_abi::thread::ExecutionState;
 
 use crate::{
+    arch,
     idcounter::StableId,
     sched::{self, schedule_thread},
     spinlock::Spinlock,
@@ -124,6 +125,7 @@ impl<T> Mutex<T> {
                 }
                 reinsert
             };
+            arch::processor::spin_wait_iteration();
             core::hint::spin_loop();
             sched::schedule(reinsert);
             crate::interrupt::set(istate);


### PR DESCRIPTION
The previous TLB shootdown implementation was not fully hooked up and was using the generic IPI mechanism to signal other cores. This is, in general, not safe, nor is it particularly efficient. This PR does the following things:

## Spin-wait
Implements a spin-wait primitive for the kernel to use that allows a general "wait until condition callback returns Some, pause with a different callback" mechanism. The purpose is to allow spin-waiting (e.g. in spinlock implementation) while not blocking certain "critical" work, such as TLB invalidations. Essentially, the design of the interrupt system and TLB invalidation mechanism requires that we always try to handle invalidations even when spin waiting. There's not much getting around something like this, because in principle a shootdown could be triggered by any memory allocation, thus possibly causing a deadlock of the form:

CPU A holds the lock for the allocator
CPU B is waiting on the lock for the allocator
CPU A triggers a TLB shootdown

If the allocator lock is a spinlock, this is deadlock unless CPU B polls for TLB invalidations while waiting for the lock. If the lock is a mutex, there's no problem! But, in general, without a deep audit to ensure that a TLB shootdown will _never_ be triggered by a CPU that holds a spinlock, we have to have a mechanism like this to prevent deadlock. And, honestly, even if we did that audit, I'd still lean towards this as it's cleaner _and_ safer.

## TLB invalidation command distribution
The code now distributes invalidation commands to other CPUs via an arch-specific mechanism. Each CPU maintains a fixed, small array of pending invalidations. When a CPU wants to enqueue an invalidation on another CPU's queue, it tries to place it in the queue using three strategies:

1. Try to put it in an empty slot
2. If no empty slots, try to merge it with an existing command that has the same target root page tables
3. Otherwise, merge it into the first slot (why first? see the code!)

Merge? Yes -- there's a least upper bound merge between any two invalidation commands (see the code). Consider that in the worst case, we can always just promote the existing invalidation to a full, global invalidation.

## TLB invalidation command processing
When a shootdown IPI is received, or we are polling for TLB invalidations, we iterate over the pending commands in our CPU's queue, executing them. For x86, this could mean executing a global, full invalidation, in which case any future invalidations don't matter, so we just flush them. When we are done with a command, the slot in the array is cleared to None, so the sender of the shootdown can know that the command has been handled.

## Waiting for ~Godot~ shootdown ack
We do have to wait for invalidations to complete, while holding the mappings lock. This is somewhat dubious as it could race with other IPIs, but we do poll for other shootdown commands while waiting. We also delay doing local invalidation command processing until after we have submitted the IPIs, as an optimization.

## What about live-lock?
This is for a future PR.