### PR TITLE
Enhanced object copy primitive (part 1)

### DIFF
--- a/src/kernel/src/memory/context.rs
+++ b/src/kernel/src/memory/context.rs
@@ -9,7 +9,6 @@ use core::ops::Range;
 use core::ptr::NonNull;
 
 use alloc::sync::Arc;
-use twizzler_abi::marker::BaseType;
 use twizzler_abi::object::ObjID;
 use twizzler_abi::{device::CacheType, object::Protections};
 
@@ -104,7 +103,7 @@ pub enum InsertError {
 
 /// A trait for kernel-related memory context actions.
 pub trait KernelMemoryContext {
-    type Handle<T: BaseType>: KernelObjectHandle<T>;
+    type Handle<T>: KernelObjectHandle<T>;
     /// Called once during initialization, after which calls to the other function in this trait may be called.
     fn init_allocator(&self);
     /// Allocate a contiguous chunk of memory. This is not expected to be good for small allocations, this should be
@@ -122,7 +121,7 @@ pub trait KernelMemoryContext {
     fn prep_smp(&self);
     /// Insert object into kernel space. The context need only support a small number of kernel-memory-mapped objects.
     /// The mapping is released when the returned handle is dropped.
-    fn insert_kernel_object<T: BaseType>(&self, info: ObjectContextInfo) -> Self::Handle<T>;
+    fn insert_kernel_object<T>(&self, info: ObjectContextInfo) -> Self::Handle<T>;
 }
 
 pub trait KernelObjectHandle<T> {

--- a/src/kernel/src/memory/context/virtmem.rs
+++ b/src/kernel/src/memory/context/virtmem.rs
@@ -5,7 +5,6 @@ use core::{intrinsics::size_of, marker::PhantomData, ptr::NonNull};
 use alloc::{collections::BTreeMap, sync::Arc, vec::Vec};
 use twizzler_abi::{
     device::CacheType,
-    marker::BaseType,
     object::{ObjID, Protections, MAX_SIZE, NULLPAGE_SIZE},
     upcall::{
         MemoryAccessKind, MemoryContextViolationInfo, ObjectMemoryError, ObjectMemoryFaultInfo,
@@ -439,9 +438,9 @@ impl KernelMemoryContext for VirtContext {
         ));
     }
 
-    type Handle<T: BaseType> = KernelObjectVirtHandle<T>;
+    type Handle<T> = KernelObjectVirtHandle<T>;
 
-    fn insert_kernel_object<T: BaseType>(&self, info: ObjectContextInfo) -> Self::Handle<T> {
+    fn insert_kernel_object<T>(&self, info: ObjectContextInfo) -> Self::Handle<T> {
         let mut slots = self.slots.lock();
         let mut kernel_slots_counter = KERNEL_SLOT_COUNTER.lock();
         let slot = kernel_slots_counter
@@ -484,7 +483,7 @@ pub struct KernelObjectVirtHandle<T> {
 }
 
 impl<T> KernelObjectVirtHandle<T> {
-    fn start_addr(&self) -> VirtAddr {
+    pub fn start_addr(&self) -> VirtAddr {
         VirtAddr::new(0)
             .unwrap()
             .offset(self.slot.raw() * MAX_SIZE)
@@ -507,7 +506,7 @@ impl<T> Drop for KernelObjectVirtHandle<T> {
     }
 }
 
-impl<T: BaseType> KernelObjectHandle<T> for KernelObjectVirtHandle<T> {
+impl<T> KernelObjectHandle<T> for KernelObjectVirtHandle<T> {
     fn base(&self) -> &T {
         unsafe {
             self.start_addr()

--- a/src/kernel/src/obj/copy.rs
+++ b/src/kernel/src/obj/copy.rs
@@ -36,13 +36,16 @@ fn copy_range_to_object_tree(
     let new_range_key = new_range.start..new_range.start.offset(new_range.length);
     let kicked = dest_tree.insert_replace(new_range_key.clone(), new_range);
     for k in kicked {
+        logln!("kicked: {:?}", k.0);
         let (r1, r2) = split_range(k.1, new_range_key.clone());
         if let Some(r1) = r1 {
+            logln!("reins: {:?} {}", r1.range(), r1.start);
             r1.gc_pagevec();
             let res = dest_tree.insert_replace(r1.start..r1.start.offset(r1.length), r1);
             assert!(res.is_empty());
         }
         if let Some(r2) = r2 {
+            logln!("reins: {:?} {}", r2.range(), r2.start);
             r2.gc_pagevec();
             let res = dest_tree.insert_replace(r2.start..r2.start.offset(r2.length), r2);
             assert!(res.is_empty());
@@ -50,60 +53,216 @@ fn copy_range_to_object_tree(
     }
 }
 
+fn copy_single(
+    dest_tree: &mut LockGuard<PageRangeTree>,
+    src_tree: &mut LockGuard<PageRangeTree>,
+    dest_point: PageNumber,
+    src_point: PageNumber,
+    offset: usize,
+    max: usize,
+) {
+    let src_page = src_tree.get_page(src_point, false);
+    if dest_tree.get_page(dest_point, true).is_none() {
+        // TODO
+        dest_tree.add_page(dest_point, super::pages::Page::new());
+    }
+    let (dest_page, _) = dest_tree
+        .get_page(dest_point, true)
+        .expect("failed to get destination page"); //TODO fix this
+    if let Some((src_page, _)) = src_page {
+        dest_page.as_mut_slice()[offset..max].copy_from_slice(&src_page.as_slice()[offset..max]);
+    } else {
+        // TODO: could skip this on freshly created page, if we can detect that
+        dest_page.as_mut_slice()[offset..max].fill(0);
+    }
+}
+
 pub fn copy_ranges(
     src: &ObjectRef,
-    src_start: PageNumber,
+    src_off: usize,
     dest: &ObjectRef,
-    dest_start: PageNumber,
-    length: usize,
+    dest_off: usize,
+    byte_length: usize,
 ) {
-    let (src_tree, mut dest_tree) = crate::utils::lock_two(&src.range_tree, &dest.range_tree);
-
-    let mut dest_point = dest_start;
-    let mut src_point = src_start;
-    let mut rem = length;
-    let ranges = src_tree.range(src_start..src_start.offset(length));
-    for range in ranges {
-        if src_point < *range.0 {
-            /* TODO: we'll need to ensure all backing pages are present if we get here */
-            let diff = *range.0 - src_point;
-            dest_point = dest_point.offset(diff);
-            rem -= diff;
-        }
-        let offset = src_point.num().saturating_sub(range.0.num());
-        let len = core::cmp::min(range.1.value().length - offset, rem);
-        copy_range_to_object_tree(&mut dest_tree, dest_point, range.1.value(), offset, len);
-        dest_point = dest_point.offset(len);
-        rem -= len;
-        src_point = src_point.offset(len);
+    if src_off % PageNumber::PAGE_SIZE != dest_off % PageNumber::PAGE_SIZE {
+        todo!("support copy_ranges that aren't aligned")
     }
 
+    let src_start = PageNumber::from_offset(src_off);
+    let dest_start = PageNumber::from_offset(dest_off);
+    let start_offset = src_off % PageNumber::PAGE_SIZE;
+    let end_offset = (src_off + byte_length) % PageNumber::PAGE_SIZE;
+    let nr_pages: usize = byte_length.saturating_sub(start_offset + end_offset)
+        / PageNumber::PAGE_SIZE
+        + match (start_offset, end_offset) {
+            (0, 0) => 0,
+            (0, _) | (_, 0) => 1,
+            (_, _) => 2,
+        };
+    logln!(
+        "==> {:x} {:x} {:x} {:x} {:x} {} {}",
+        src_off,
+        dest_off,
+        byte_length,
+        start_offset,
+        end_offset,
+        byte_length / PageNumber::PAGE_SIZE,
+        nr_pages
+    );
+    // Step 1: lock the page trees for the objects, in a canonical order.
+    let (mut src_tree, mut dest_tree) = crate::utils::lock_two(&src.range_tree, &dest.range_tree);
+
+    // Step 2: Invalidate the page ranges. In the destination, we fully unmap the object for that range. In the source,
+    // we only need to ensure that no one modifies pages, so we just write-protect it.
     src.invalidate(
-        src_start..src_start.offset(length),
+        src_start..src_start.offset(nr_pages),
         InvalidateMode::WriteProtect,
     );
-    dest.invalidate(dest_start..dest_start.offset(length), InvalidateMode::Full);
-}
+    dest.invalidate(
+        dest_start..dest_start.offset(nr_pages),
+        InvalidateMode::Full,
+    );
 
-pub struct CopySpec {
-    pub src: ObjectRef,
-    pub src_start: PageNumber,
-    pub dest_start: PageNumber,
-    pub length: usize,
-}
+    // Step 3a: Copy any non-full-page at the start
+    let mut dest_point = dest_start;
+    let mut src_point = src_start;
+    let mut remaining_pages = nr_pages;
+    if start_offset != 0 {
+        copy_single(
+            &mut dest_tree,
+            &mut src_tree,
+            dest_point,
+            src_point,
+            start_offset,
+            PageNumber::PAGE_SIZE,
+        );
+        dest_point = dest_point.offset(1);
+        src_point = src_point.offset(1);
+        remaining_pages -= 1;
+    }
 
-impl CopySpec {
-    pub fn new(
-        src: ObjectRef,
-        src_start: PageNumber,
-        dest_start: PageNumber,
-        length: usize,
-    ) -> Self {
-        Self {
-            src,
-            src_start,
-            dest_start,
-            length,
+    let vec_pages = remaining_pages - if end_offset > 0 { 1 } else { 0 };
+    let mut remaining_vec_pages = vec_pages;
+    if vec_pages > 0 {
+        let ranges = src_tree.range(src_point..src_point.offset(vec_pages));
+        for range in ranges {
+            if src_point < *range.0 {
+                /* TODO: we'll need to ensure all backing pages are present if we get here */
+                let diff = *range.0 - src_point;
+                dest_point = dest_point.offset(diff);
+                remaining_vec_pages -= diff;
+            }
+            let offset = src_point.num().saturating_sub(range.0.num());
+            let len = core::cmp::min(range.1.value().length - offset, remaining_vec_pages);
+            copy_range_to_object_tree(&mut dest_tree, dest_point, range.1.value(), offset, len);
+            dest_point = dest_point.offset(len);
+            remaining_vec_pages -= len;
+            src_point = src_point.offset(len);
         }
+    }
+
+    remaining_pages -= vec_pages;
+    assert_eq!(remaining_pages == 1, end_offset > 0);
+    assert!(remaining_pages == 1 || remaining_pages == 0);
+    assert_eq!(remaining_vec_pages, 0);
+
+    if end_offset > 0 {
+        copy_single(
+            &mut dest_tree,
+            &mut src_tree,
+            dest_point,
+            src_point,
+            0,
+            end_offset,
+        );
+    }
+
+    dest.invalidate(
+        dest_start..dest_start.offset(nr_pages),
+        InvalidateMode::Full,
+    );
+}
+
+#[cfg(test)]
+mod test {
+    use twizzler_abi::{device::CacheType, object::Protections};
+
+    use crate::{
+        memory::context::{kernel_context, KernelMemoryContext, ObjectContextInfo},
+        obj::{pages::Page, ObjectRef, PageNumber},
+        userinit::create_blank_object,
+    };
+
+    use super::copy_ranges;
+
+    fn copy_ranges_and_check(
+        src: &ObjectRef,
+        src_off: usize,
+        dest: &ObjectRef,
+        dest_off: usize,
+        byte_length: usize,
+    ) {
+        copy_ranges(src, src_off, dest, dest_off, byte_length);
+
+        let dko = kernel_context().insert_kernel_object::<u8>(ObjectContextInfo::new(
+            dest.clone(),
+            Protections::READ,
+            CacheType::WriteBack,
+        ));
+        let dptr = dko.start_addr();
+
+        let sko = kernel_context().insert_kernel_object::<u8>(ObjectContextInfo::new(
+            src.clone(),
+            Protections::READ,
+            CacheType::WriteBack,
+        ));
+        let sptr = sko.start_addr();
+
+        let src_slice = unsafe {
+            core::slice::from_raw_parts(sptr.as_mut_ptr::<u8>().add(src_off), byte_length)
+        };
+        let dest_slice = unsafe {
+            core::slice::from_raw_parts(dptr.as_mut_ptr::<u8>().add(dest_off), byte_length)
+        };
+
+        dest.invalidate(
+            PageNumber::base_page()..PageNumber::base_page().offset(1000),
+            crate::obj::InvalidateMode::Full,
+        );
+        //dest.print_page_tree();
+        assert_eq!(src_slice.len(), dest_slice.len());
+        //logln!("==> {:?}", src_slice);
+        //logln!("==> {:?}", dest_slice);
+        assert!(src_slice == dest_slice);
+    }
+
+    #[twizzler_kernel_macros::kernel_test]
+    fn test_object_copy() {
+        let src = create_blank_object();
+        let dest = create_blank_object();
+
+        for p in 0..254 {
+            let mut tree: crate::mutex::LockGuard<'_, crate::obj::range::PageRangeTree> =
+                src.lock_page_tree();
+            tree.add_page(PageNumber::base_page().offset(p), Page::new());
+            let (sp, _) = tree
+                .get_page(PageNumber::base_page().offset(p), true)
+                .unwrap();
+            sp.as_mut_slice().fill((p + 1) as u8);
+        }
+
+        //src.print_page_tree();
+        copy_ranges_and_check(&src, 0x1000, &dest, 0x1000, 0x1000);
+        copy_ranges_and_check(&src, 0x3000, &dest, 0x2000, 0x1000);
+
+        // overwrite
+        //copy_ranges_and_check(&src, 0x2000, &dest, 0x1000, 0x1000);
+
+        copy_ranges_and_check(&src, 0x3100, &dest, 0x4100, 0x1000);
+        copy_ranges_and_check(&src, 0x5100, &dest, 0x5100, 0x100);
+        copy_ranges_and_check(&src, 0x6100, &dest, 0x6100, 0x1300);
+        copy_ranges_and_check(&src, 0x7800, &dest, 0x7800, 0x800);
+        copy_ranges_and_check(&src, 0x8000, &dest, 0x8000, 0x800);
+        copy_ranges_and_check(&src, 0x9000, &dest, 0x9000, 0x2100);
     }
 }

--- a/src/kernel/src/obj/mod.rs
+++ b/src/kernel/src/obj/mod.rs
@@ -111,6 +111,10 @@ impl PageNumber {
         PageNumber((addr.raw() as usize % MAX_SIZE) / Self::PAGE_SIZE)
     }
 
+    pub fn from_offset(off: usize) -> Self {
+        PageNumber(off / Self::PAGE_SIZE)
+    }
+
     pub fn next(&self) -> Self {
         Self(self.0 + 1)
     }

--- a/src/kernel/src/obj/pages.rs
+++ b/src/kernel/src/obj/pages.rs
@@ -5,7 +5,7 @@ use twizzler_abi::device::{CacheType, MMIO_OFFSET};
 
 use crate::{
     arch::memory::{frame::FRAME_SIZE, phys_to_virt},
-    memory::frame::{self, FrameRef, PhysicalFrameFlags},
+    memory::frame::{self, free_frame, FrameRef, PhysicalFrameFlags},
     memory::{PhysAddr, VirtAddr},
 };
 
@@ -30,6 +30,17 @@ pub type PageRef = Arc<Page>;
 impl Default for Page {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+impl Drop for Page {
+    fn drop(&mut self) {
+        match self.frame {
+            FrameOrWired::Frame(f) => {
+                free_frame(f);
+            }
+            FrameOrWired::Wired(_) => todo!(),
+        }
     }
 }
 

--- a/src/kernel/src/obj/pagevec.rs
+++ b/src/kernel/src/obj/pagevec.rs
@@ -86,7 +86,7 @@ impl PageVec {
             self.pages.reserve((offset + 1) * 2);
             self.pages.resize(offset + 1, None)
         }
-        assert!(self.pages[offset].is_none()); //TODO
+        //assert!(self.pages[offset].is_none()); //TODO
         self.pages[offset] = Some(Arc::new(page));
     }
 }

--- a/src/kernel/src/obj/pagevec.rs
+++ b/src/kernel/src/obj/pagevec.rs
@@ -100,7 +100,6 @@ impl PageVec {
             self.pages.reserve((offset + 1) * 2);
             self.pages.resize(offset + 1, None)
         }
-        //assert!(self.pages[offset].is_none()); //TODO
         self.pages[offset] = Some(Arc::new(page));
     }
 }

--- a/src/kernel/src/obj/pagevec.rs
+++ b/src/kernel/src/obj/pagevec.rs
@@ -20,6 +20,20 @@ impl PageVec {
         }
     }
 
+    pub fn len(&self) -> usize {
+        self.pages.len()
+    }
+
+    /// Remove the first elements up to offset, and then truncate the vector to the given length.
+    pub fn truncate_and_drain(&mut self, offset: usize, len: usize) {
+        logln!("t&d {} : {} {}", self.pages.len(), offset, len);
+        self.pages.drain(0..offset);
+        self.pages.truncate(len);
+        if self.pages.capacity() > 2 * len {
+            self.pages.shrink_to_fit();
+        }
+    }
+
     pub fn show_part(&self, range: &PageRange) -> String {
         let mut str = String::new();
         str += &format!("PV {:p} ", self);

--- a/src/kernel/src/obj/pagevec.rs
+++ b/src/kernel/src/obj/pagevec.rs
@@ -26,7 +26,6 @@ impl PageVec {
 
     /// Remove the first elements up to offset, and then truncate the vector to the given length.
     pub fn truncate_and_drain(&mut self, offset: usize, len: usize) {
-        logln!("t&d {} : {} {}", self.pages.len(), offset, len);
         self.pages.drain(0..offset);
         self.pages.truncate(len);
         if self.pages.capacity() > 2 * len {

--- a/src/kernel/src/obj/range.rs
+++ b/src/kernel/src/obj/range.rs
@@ -58,11 +58,18 @@ impl PageRange {
         self.pv_ref_count() > 1
     }
 
-    pub fn gc_pagevec(&self) {
-        // TODO
+    pub fn gc_pagevec(&mut self) {
+        if self.is_shared() {
+            // TODO: maybe we can do something smarter here, but it may be dangerous. In particular, we should
+            // study what pagevecs actually look like in a long-running system and decide what to do based on that.
+            // Of course, if we want to be able to do anything here, we'll either need to promote pagevecs to non-shared
+            // or we will need to track more page info.
+            return;
+        }
 
-        //logln!("TODO: gc page vec");
-        //       todo!()
+        let mut pv = self.pv.lock();
+        pv.truncate_and_drain(self.offset, self.length);
+        self.offset = 0;
     }
 
     pub fn split_at(&self, pn: PageNumber) -> (Option<PageRange>, PageRange, Option<PageRange>) {

--- a/src/kernel/src/obj/range.rs
+++ b/src/kernel/src/obj/range.rs
@@ -143,6 +143,10 @@ impl PageRangeTree {
         self.tree.get_mut(&pn)
     }
 
+    pub fn remove(&mut self, pn: &PageNumber) -> Option<PageRange> {
+        self.tree.remove(pn)
+    }
+
     fn split_into_three(&mut self, pn: PageNumber, discard: bool) {
         let Some(range) = self.tree.remove(&pn) else {
             return;

--- a/src/kernel/src/obj/range.rs
+++ b/src/kernel/src/obj/range.rs
@@ -211,8 +211,9 @@ impl PageRangeTree {
             range.add_page(pn, page);
         } else {
             if let Some(prev) = pn.prev() {
-                let range = self.tree.remove(&prev);
-                if let Some(mut range) = range {
+                let range = self.tree.get(&prev);
+                if range.is_some_and(|range| !range.is_shared()) {
+                    let mut range = self.tree.remove(&prev).unwrap();
                     range.length += 1;
                     range.add_page(pn, page);
                     self.tree.insert_replace(range.range(), range);

--- a/src/kernel/src/obj/range.rs
+++ b/src/kernel/src/obj/range.rs
@@ -190,6 +190,19 @@ impl PageRangeTree {
         Some((page, false))
     }
 
+    pub fn get_or_add_page(
+        &mut self,
+        pn: PageNumber,
+        is_write: bool,
+        if_not_present: impl Fn(PageNumber, bool) -> Page,
+    ) -> (PageRef, bool) {
+        if let Some(out) = self.get_page(pn, is_write) {
+            return out;
+        }
+        self.add_page(pn, if_not_present(pn, is_write));
+        self.get_page(pn, is_write).unwrap()
+    }
+
     pub fn insert_replace(
         &mut self,
         k: core::ops::Range<PageNumber>,

--- a/src/kernel/src/obj/range.rs
+++ b/src/kernel/src/obj/range.rs
@@ -215,6 +215,7 @@ impl PageRangeTree {
     pub fn add_page(&mut self, pn: PageNumber, page: Page) {
         let range = self.tree.get(&pn);
         if let Some(range) = range {
+            // TODO: If this is shared, we need to split.
             range.add_page(pn, page);
         } else {
             if let Some(prev) = pn.prev() {
@@ -227,10 +228,13 @@ impl PageRangeTree {
                     return;
                 }
             }
+            // TODO: we could be a little smarter, and search a few pages back, or something. Find the previous
+            // range and see if it can be extended. We also need to make a page tree merging GC function.
             let mut range = PageRange::new(pn);
             range.length = 1;
             range.add_page(pn, page);
-            self.tree.insert_replace(pn..pn.next(), range);
+            let kicked = self.tree.insert_replace(pn..pn.next(), range);
+            assert_eq!(kicked.len(), 0);
         }
     }
 

--- a/src/kernel/src/processor.rs
+++ b/src/kernel/src/processor.rs
@@ -420,6 +420,9 @@ fn enqueue_ipi_task_many(incl_self: bool, task: &Arc<IpiTask>) {
 
 /// Run a closure on some set of CPUs, waiting for all invocations to complete.
 pub fn ipi_exec(target: Destination, f: Box<dyn Fn() + Send + Sync>) {
+    if current_thread_ref().is_none() {
+        return;
+    }
     let task = Arc::new(IpiTask {
         outstanding: AtomicU64::new(0),
         func: f,

--- a/src/kernel/src/syscall/object.rs
+++ b/src/kernel/src/syscall/object.rs
@@ -11,9 +11,9 @@ use twizzler_abi::{
 };
 
 use crate::{
-    memory::{context::ContextRef, VirtAddr},
+    memory::context::ContextRef,
     mutex::Mutex,
-    obj::{copy::CopySpec, LookupFlags, Object, ObjectRef, PageNumber},
+    obj::{LookupFlags, Object, ObjectRef},
     once::Once,
     thread::current_memory_context,
 };
@@ -37,13 +37,13 @@ pub fn sys_object_create(
                 src.len
             );
         }
-        let cs = CopySpec::new(
-            so,
-            PageNumber::from_address(VirtAddr::new(src.src_start).unwrap()),
-            PageNumber::from_address(VirtAddr::new(src.dest_start).unwrap()),
+        crate::obj::copy::copy_ranges(
+            &so,
+            src.src_start as usize,
+            &obj,
+            src.dest_start as usize,
             src.len,
-        );
-        crate::obj::copy::copy_ranges(&cs.src, cs.src_start, &obj, cs.dest_start, cs.length)
+        )
     }
     crate::obj::register_object(obj.clone());
     Ok(obj.id())

--- a/src/kernel/src/syscall/object.rs
+++ b/src/kernel/src/syscall/object.rs
@@ -30,16 +30,6 @@ pub fn sys_object_create(
         } else {
             let so = crate::obj::lookup_object(src.id, LookupFlags::empty())
                 .ok_or(ObjectCreateError::ObjectNotFound)?;
-            if false {
-                logln!(
-                    "object copy ranges: {} => {} :: {:x} => {:x} {:x}",
-                    src.id,
-                    obj.id(),
-                    src.src_start,
-                    src.dest_start,
-                    src.len
-                );
-            }
             crate::obj::copy::copy_ranges(
                 &so,
                 src.src_start as usize,
@@ -73,15 +63,6 @@ pub fn sys_object_map(
     };
     // TODO
     let _res = crate::operations::map_object_into_context(slot, obj, vm, prot.into());
-    if false {
-        logln!(
-            "mapping obj {} to {} with {:?} in {:?}",
-            id,
-            slot,
-            prot,
-            handle
-        );
-    }
     Ok(slot)
 }
 

--- a/src/kernel/src/syscall/object.rs
+++ b/src/kernel/src/syscall/object.rs
@@ -25,25 +25,29 @@ pub fn sys_object_create(
 ) -> Result<ObjID, ObjectCreateError> {
     let obj = Arc::new(Object::new());
     for src in srcs {
-        let so = crate::obj::lookup_object(src.id, LookupFlags::empty())
-            .ok_or(ObjectCreateError::ObjectNotFound)?;
-        if false {
-            logln!(
-                "object copy ranges: {} => {} :: {:x} => {:x} {:x}",
-                src.id,
-                obj.id(),
-                src.src_start,
-                src.dest_start,
-                src.len
-            );
+        if src.id.as_u128() == 0 {
+            crate::obj::copy::zero_ranges(&obj, src.dest_start as usize, src.len)
+        } else {
+            let so = crate::obj::lookup_object(src.id, LookupFlags::empty())
+                .ok_or(ObjectCreateError::ObjectNotFound)?;
+            if false {
+                logln!(
+                    "object copy ranges: {} => {} :: {:x} => {:x} {:x}",
+                    src.id,
+                    obj.id(),
+                    src.src_start,
+                    src.dest_start,
+                    src.len
+                );
+            }
+            crate::obj::copy::copy_ranges(
+                &so,
+                src.src_start as usize,
+                &obj,
+                src.dest_start as usize,
+                src.len,
+            )
         }
-        crate::obj::copy::copy_ranges(
-            &so,
-            src.src_start as usize,
-            &obj,
-            src.dest_start as usize,
-            src.len,
-        )
     }
     crate::obj::register_object(obj.clone());
     Ok(obj.id())

--- a/src/lib/twizzler-abi/src/runtime/load_elf.rs
+++ b/src/lib/twizzler-abi/src/runtime/load_elf.rs
@@ -223,7 +223,7 @@ pub fn spawn_new_executable(
         let prot = phdr.prot();
 
         if prot.contains(Protections::WRITE) {
-            let copy = ObjectSource::new(
+            let copy = ObjectSource::new_copy(
                 exe.id(),
                 src_start,
                 dest_start & (MAX_SIZE as u64 - 1),
@@ -236,7 +236,7 @@ pub fn spawn_new_executable(
             let dest_zero_start = brk & (MAX_SIZE as u64 - 1);
             data_copy.push(copy);
             if pgend > pgbrk {
-                data_copy.push(ObjectSource::new(
+                data_copy.push(ObjectSource::new_copy(
                     ObjID::new(0),
                     0,
                     dest_start,
@@ -245,7 +245,7 @@ pub fn spawn_new_executable(
             }
             data_zero.push((dest_zero_start, pgbrk - brk));
         } else {
-            let copy = ObjectSource::new(exe.id(), src_start, dest_start, aligned_len);
+            let copy = ObjectSource::new_copy(exe.id(), src_start, dest_start, aligned_len);
             text_copy.push(copy);
         }
     }

--- a/src/lib/twizzler-abi/src/syscall/create.rs
+++ b/src/lib/twizzler-abi/src/syscall/create.rs
@@ -1,9 +1,9 @@
 use core::fmt;
 
-use crate::{object::ObjID, arch::syscall::raw_syscall};
+use crate::{arch::syscall::raw_syscall, object::ObjID};
 use bitflags::bitflags;
 
-use super::{Syscall, convert_codes_to_result};
+use super::{convert_codes_to_result, Syscall};
 
 #[derive(Debug, Copy, Clone, PartialEq, PartialOrd, Ord, Eq)]
 #[repr(C)]
@@ -11,22 +11,32 @@ use super::{Syscall, convert_codes_to_result};
 /// source:[src_start, src_start + len) copied to <some unspecified destination object>:[dest_start,
 /// dest_start + len). Each range must start within an object, and end within the object.
 pub struct ObjectSource {
-    /// The ID of the source object.
+    /// The ID of the source object, or zero for filling destination with zero.
     pub id: ObjID,
-    /// The offset into the source object to start the copy.
+    /// The offset into the source object to start the copy. If id is zero, this field is reserved for future use.
     pub src_start: u64,
-    /// The offset into the dest object to start the copy to.
+    /// The offset into the dest object to start the copy or zero.
     pub dest_start: u64,
-    /// The length of the copy.
+    /// The length of the copy or zero.
     pub len: usize,
 }
 
 impl ObjectSource {
     /// Construct a new ObjectSource.
-    pub fn new(id: ObjID, src_start: u64, dest_start: u64, len: usize) -> Self {
+    pub fn new_copy(id: ObjID, src_start: u64, dest_start: u64, len: usize) -> Self {
         Self {
             id,
             src_start,
+            dest_start,
+            len,
+        }
+    }
+
+    /// Construct a new ObjectSource.
+    pub fn new_zero(dest_start: u64, len: usize) -> Self {
+        Self {
+            id: 0.into(),
+            src_start: 0,
             dest_start,
             len,
         }
@@ -61,7 +71,7 @@ pub enum LifetimeType {
 
 bitflags! {
     /// Flags to pass to the object create system call.
-    #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)] 
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
     pub struct ObjectCreateFlags: u32 {
     }
 }

--- a/src/runtime/dynlink/src/library/load.rs
+++ b/src/runtime/dynlink/src/library/load.rs
@@ -68,7 +68,7 @@ impl Library {
                 let len = (vaddr - dest_start) + filesz;
                 Ok((
                     targets_data,
-                    twizzler_abi::syscall::ObjectSource::new(
+                    twizzler_abi::syscall::ObjectSource::new_copy(
                         self.full_obj.id(),
                         src_start as u64,
                         dest_start as u64,


### PR DESCRIPTION
This PR enhances they object copy primitive in the kernel. This primitive is invoked on object creation, and is used to map regions of memory as required by executable loaders. However, the primitive is generalized: a destination object may be given a list of copy-from directives, which acts like a gather operation on object data from source objects copied into the destination. If possible, the kernel prefers to share pages between objects using copy on write.

This PR improves in the following ways:

- Reorders some internal operations
- Implements some basic GC work that page vectors need
- Adds tests for object copy
- Allows non-aligned copy, though the kernel may have to fallback to manual copy depending on parameters.
- Allows specifying the source object to be zero, in which case the copy turns into a zeroing of the destination region.

Still planning to add, before ready for review:

- [x] Allow a source of "fill with byte" (memset)
- [x] Cleanup