### PR TITLE
Add a build step to the CI for aarch64

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -29,12 +29,16 @@ jobs:
           toolchain: stable
     - name: Bootstrap Toolchain
       run: cargo bootstrap
-    - name: Build
+    # x86_64 is the default, builds in debug mode
+    - name: Build x86_64
       run: cargo build-all
-    - name: Test
+    - name: Test x86_64 Debug
       run: cargo start-qemu --tests --qemu-options=--nographic
-    - name: Test Release
+    - name: Test x86_64 Release
       run: cargo start-qemu --profile release --tests --qemu-options=--nographic
+    # aarch64 is compiled for QEMU virt, builds in debug mode
+    - name: Build aarch64
+      run: cargo build-all -a aarch64 -m virt
     - name: Install mdbook
       run: |
         mkdir mdbook

--- a/src/kernel/src/arch/aarch64/thread.rs
+++ b/src/kernel/src/arch/aarch64/thread.rs
@@ -11,7 +11,7 @@
 use arm64::registers::TPIDR_EL0;
 use registers::interfaces::Writeable;
 
-use twizzler_abi::upcall::{UpcallFrame, UpcallInfo};
+use twizzler_abi::upcall::{UpcallFrame, UpcallInfo, UpcallTarget};
 
 use crate::thread::Thread;
 use crate::memory::VirtAddr;
@@ -103,7 +103,11 @@ pub fn new_stack_top(stack_base: usize, stack_size: usize) -> VirtAddr {
 }
 
 impl Thread {
-    pub fn arch_queue_upcall(&self, _target: super::address::VirtAddr, _info: UpcallInfo) {
+    pub fn restore_upcall_frame(&self, _frame: &UpcallFrame) {
+        todo!()
+    }
+
+    pub fn arch_queue_upcall(&self, _target: UpcallTarget, _info: UpcallInfo, _sup: bool) {
         todo!()
     }
 

--- a/src/lib/twizzler-abi/src/arch/aarch64/upcall.rs
+++ b/src/lib/twizzler-abi/src/arch/aarch64/upcall.rs
@@ -1,5 +1,5 @@
 #[allow(unused_imports)]
-use crate::upcall::UpcallInfo;
+use crate::upcall::{UpcallData, UpcallInfo};
 
 /// Arch-specific frame info for upcall.
 #[derive(Clone, Debug)]
@@ -26,7 +26,7 @@ impl UpcallFrame {
 #[no_mangle]
 #[cfg(feature = "runtime")]
 pub(crate) unsafe extern "C" fn upcall_entry2(
-    _frame: *const UpcallFrame,
+    _frame: *mut UpcallFrame,
     _info: *const UpcallInfo,
 ) -> ! {
     todo!()
@@ -34,9 +34,9 @@ pub(crate) unsafe extern "C" fn upcall_entry2(
 
 #[cfg(feature = "runtime")]
 #[no_mangle]
-pub(crate) unsafe extern "C" fn upcall_entry(
-    _frame: *const UpcallFrame,
-    _info: *const UpcallInfo,
+pub(crate) unsafe extern "C-unwind" fn upcall_entry(
+    _frame: *mut UpcallFrame,
+    _info: *const UpcallData,
 ) -> ! {
     todo!()
 }

--- a/src/runtime/twz-rt/src/arch/aarch64.rs
+++ b/src/runtime/twz-rt/src/arch/aarch64.rs
@@ -1,21 +1,21 @@
-use twizzler_abi::upcall::{UpcallFrame, UpcallInfo};
+use twizzler_abi::upcall::{UpcallData, UpcallFrame};
 
 use crate::preinit_println;
 
 #[cfg(feature = "runtime")]
 #[no_mangle]
-pub(crate) unsafe extern "C" fn rr_upcall_entry(
-    _frame: *const UpcallFrame,
-    _info: *const UpcallInfo,
+pub(crate) unsafe extern "C-unwind" fn rr_upcall_entry(
+    _frame: *mut UpcallFrame,
+    _info: *const UpcallData,
 ) -> ! {
     todo!()
 }
 
 #[cfg(feature = "runtime")]
 #[no_mangle]
-pub(crate) unsafe extern "C" fn rr_upcall_entry2(
-    frame: *const UpcallFrame,
-    info: *const UpcallInfo,
+pub(crate) unsafe extern "C-unwind" fn rr_upcall_entry2(
+    frame: *mut UpcallFrame,
+    info: *const UpcallData,
 ) -> ! {
     use crate::runtime::do_impl::__twz_get_runtime;
 


### PR DESCRIPTION
We modify the CI to add a step to check if Twizzler builds both userspace and the kernel for aarch64. This helps aarch64 code to stay in sync with changes to generic interfaces implemented in subsequent PR's. In those cases, we could add stubs.

The CI first builds x86_64 code and tests it, then builds code for aarch64. Tests for aarch64 is future work.

**Summary**
- add build step for aarch64 code to CI
- add missing stubs for upcalls