### PR TITLE
Fix handling of aarch64 system state when switching threads

### DIFF
--- a/src/bin/pager/src/main.rs
+++ b/src/bin/pager/src/main.rs
@@ -73,12 +73,12 @@ fn main() {
         }
     })
     .detach();
-    let nvme_ctrl = twizzler_async::block_on(nvme::init_nvme());
-    let len = twizzler_async::block_on(nvme_ctrl.flash_len());
+    // let nvme_ctrl = twizzler_async::block_on(nvme::init_nvme());
+    // let len = twizzler_async::block_on(nvme_ctrl.flash_len());
 
-    let storage = Storage::new(nvme_ctrl);
-    let mut read_buffer = [0; BLOCK_SIZE];
-    let _kv = KeyValueStore::new(storage, &mut read_buffer, len).unwrap();
+    // let storage = Storage::new(nvme_ctrl);
+    // let mut read_buffer = [0; BLOCK_SIZE];
+    // let _kv = KeyValueStore::new(storage, &mut read_buffer, len).unwrap();
 
     twizzler_async::Task::spawn(async move {
         loop {

--- a/src/bin/pager/src/main.rs
+++ b/src/bin/pager/src/main.rs
@@ -10,7 +10,7 @@ use std::collections::BTreeMap;
 
 use tickv::{success_codes::SuccessCode, ErrorCode};
 
-use crate::store::{Key, KeyValueStore, Storage, BLOCK_SIZE};
+use crate::store::{Key, KeyValueStore};
 
 mod nvme;
 mod store;
@@ -73,12 +73,6 @@ fn main() {
         }
     })
     .detach();
-    // let nvme_ctrl = twizzler_async::block_on(nvme::init_nvme());
-    // let len = twizzler_async::block_on(nvme_ctrl.flash_len());
-
-    // let storage = Storage::new(nvme_ctrl);
-    // let mut read_buffer = [0; BLOCK_SIZE];
-    // let _kv = KeyValueStore::new(storage, &mut read_buffer, len).unwrap();
 
     twizzler_async::Task::spawn(async move {
         loop {

--- a/src/kernel/src/arch/aarch64/cntp.rs
+++ b/src/kernel/src/arch/aarch64/cntp.rs
@@ -78,7 +78,7 @@ impl ClockHardware for PhysicalTimer {
 /// for now this does not do anything interesting. It merely
 /// prints to the debug console and clears the interrupt.
 pub fn cntp_interrupt_handler() {
-    emerglogln!("[arch:cntp] Hello from Timer!!");
+    // emerglogln!("[arch:cntp] Hello from Timer!!");
     // handle the timer interrupt by advancing the scheduler ticks
     crate::clock::oneshot_clock_hardtick();
 

--- a/src/kernel/src/arch/aarch64/cntp.rs
+++ b/src/kernel/src/arch/aarch64/cntp.rs
@@ -78,7 +78,6 @@ impl ClockHardware for PhysicalTimer {
 /// for now this does not do anything interesting. It merely
 /// prints to the debug console and clears the interrupt.
 pub fn cntp_interrupt_handler() {
-    // emerglogln!("[arch:cntp] Hello from Timer!!");
     // handle the timer interrupt by advancing the scheduler ticks
     crate::clock::oneshot_clock_hardtick();
 

--- a/src/kernel/src/arch/aarch64/exception.rs
+++ b/src/kernel/src/arch/aarch64/exception.rs
@@ -119,10 +119,10 @@ pub struct ExceptionContext {
     pub x28: u64,
     pub x29: u64,
     pub x30: u64,
-    /// The stack pointer, depending onf the context where the exception
-    /// occured, this is either sp_el0 or sp_el1
+    /// The stack pointer, depending on the context where the exception
+    /// occurred, this is either sp_el0 or sp_el1
     pub sp: u64,
-    /// The program counter. The address where the exception occured.
+    /// The program counter. The address where the exception occurred.
     pub elr: u64,
     /// The state of the processor (SPSR_EL1). Determines execution environment (e.g., interrupts)
     pub spsr: u64,

--- a/src/kernel/src/arch/aarch64/exception.rs
+++ b/src/kernel/src/arch/aarch64/exception.rs
@@ -8,7 +8,7 @@
 
 use core::fmt::{Display, Formatter, Result};
 
-use arm64::registers::{VBAR_EL1, ESR_EL1, SPSR_EL1, ELR_EL1};
+use arm64::registers::{VBAR_EL1, ESR_EL1};
 use registers::{
     registers::InMemoryRegister,
     interfaces::{Readable, Writeable},
@@ -119,7 +119,17 @@ pub struct ExceptionContext {
     pub x28: u64,
     pub x29: u64,
     pub x30: u64,
+    /// The stack pointer, depending onf the context where the exception
+    /// occured, this is either sp_el0 or sp_el1
     pub sp: u64,
+    /// The program counter. The address where the exception occured.
+    pub elr: u64,
+    /// The state of the processor (SPSR_EL1). Determines execution environment (e.g., interrupts)
+    pub spsr: u64,
+    /// The cause of a synchronous exception (ESR_EL1).
+    pub esr: u64,
+    /// The address where a the fault occured (FAR_EL1).
+    pub far: u64,
 }
 
 impl Display for ExceptionContext {
@@ -132,7 +142,8 @@ impl Display for ExceptionContext {
         writeln!(f, "\tx16: {:#018x} x17: {:#018x} x18: {:#018x} x19: {:#018x}", self.x16, self.x17, self.x18, self.x19)?;
         writeln!(f, "\tx20: {:#018x} x21: {:#018x} x22: {:#018x} x23: {:#018x}", self.x20, self.x21, self.x22, self.x23)?;
         writeln!(f, "\tx24: {:#018x} x25: {:#018x} x26: {:#018x} x27: {:#018x}", self.x24, self.x25, self.x26, self.x27)?;
-        writeln!(f, "\tx28: {:#018x} x29: {:#018x} x30: {:#018x} sp: {:#018x}", self.x28, self.x29, self.x30, self.sp)
+        writeln!(f, "\tx28: {:#018x} x29: {:#018x} x30: {:#018x}  sp: {:#018x}", self.x28, self.x29, self.x30, self.sp)?;
+        writeln!(f, "\telr: {:#018x} spsr: {:#018x} esr: {:#018x} far: {:#018x}", self.elr, self.spsr, self.esr, self.far)
     }
 }
 
@@ -153,7 +164,7 @@ impl From<ExceptionContext> for UpcallFrame {
 }
 
 // TODO: reentrant/nested interrupt support
-// - save spsr_el1 and elr_el1 before calling handler
+// x save spsr_el1 and elr_el1 before calling handler
 // - enable interrupts while servicing exceptions
 
 /// macro creates a high level exception handler
@@ -189,12 +200,32 @@ macro_rules! exception_handler {
                 // link register (i.e. x30)
                 save_stack_pointer!($is_kernel),
                 "stp x30, x10, [sp, #16 * 15]",
+                // the program counter
+                "mrs x11, elr_el1",
+                // the processor state
+                "mrs x12, spsr_el1",
+                // the exception syndrome register
+                "mrs x13, esr_el1",
+                // the fault address register
+                "mrs x14, far_el1",
+                "stp x11, x12, [sp, #16 * 16]",
+                "stp x13, x14, [sp, #16 * 17]", 
                 // move stack pointer of last frame as an argument
                 "mov x0, sp",
                 // go to exception handler (overwrites x30)
                 "bl {handler}",
-                // restore all general purpose registers (x0-x30)
                 // pop registers off of the stack
+                "ldp x13, x14, [sp, #16 * 17]", 
+                "ldp x11, x12, [sp, #16 * 16]",
+                // the program counter
+                "msr elr_el1, x11",
+                // the processor state
+                "msr spsr_el1, x12",
+                // the exception syndrome register
+                "msr esr_el1, x13",
+                // the fault address register
+                "msr far_el1, x14",
+                // restore all general purpose registers (x0-x30)
                 "ldp x30, x10, [sp, #16 * 15]",
                 restore_stack_pointer!($is_kernel),
                 "ldp x28, x29, [sp, #16 * 14]",
@@ -267,7 +298,7 @@ exception_handler!(default_exception_handler, debug_handler, true);
 /// useful system register state. Then it panics.
 fn debug_handler(ctx: &mut ExceptionContext) {
     // read of raw value for ESR
-    let esr = ESR_EL1.get();
+    let esr = ctx.esr;
     // print reason for exception (syndrome register)
     emerglogln!("[kernel::exception] Exception Syndrome Register (ESR) value: {:#x}", esr);
     // print decoding information
@@ -314,7 +345,7 @@ fn debug_handler(ctx: &mut ExceptionContext) {
         if far_valid {
             emerglogln!("\t\tFault Address Register is valid"); 
             // print faulting address (ELR/FAR)
-            emerglogln!("\t\tFAR value = {:#018x}", arm64::registers::FAR_EL1.get());
+            emerglogln!("\t\tFAR value = {:#018x}", ctx.far);
         }
 
         // was fault caused by a write to memory or a read?
@@ -340,8 +371,8 @@ fn debug_handler(ctx: &mut ExceptionContext) {
     }
 
     // print other system registers: PSTATE/SPSR
-    emerglogln!("[kernel::exception] SPSR_EL1: {:#018x}", SPSR_EL1.get());
-
+    emerglogln!("[kernel::exception] SPSR_EL1: {:#018x}", ctx.spsr);
+    
     // print registers
     emerglog!("[kernel::exception] dumping register state: {}", ctx);
 
@@ -358,7 +389,7 @@ exception_handler!(sync_exception_handler_el0, sync_handler, false);
 /// such as Data Aborts (i.e. page faults)
 fn sync_handler(ctx: &mut ExceptionContext) {
     // read of raw value for ESR
-    let esr = ESR_EL1.get();
+    let esr = ctx.esr;
     let esr_reg: InMemoryRegister<u64, ESR_EL1::Register> = InMemoryRegister::new(esr);
     match esr_reg.read_as_enum(ESR_EL1::EC) {
         // TODO: reorganize data abort handling between user and kernel
@@ -368,7 +399,7 @@ fn sync_handler(ctx: &mut ExceptionContext) {
             // is the fault address register valid?
             let far_valid = iss & (1 << 10) == 0;
             // print faulting address (ELR/FAR)
-            let far = arm64::registers::FAR_EL1.get();
+            let far = ctx.far;
             if !far_valid {
                 panic!("FAR is not valid!!");
             }
@@ -402,7 +433,7 @@ fn sync_handler(ctx: &mut ExceptionContext) {
             }
             crate::thread::enter_kernel();
             // crate::interrupt::set(true);
-            let elr = ELR_EL1.get();
+            let elr = ctx.elr;
             if let Ok(elr_va) = VirtAddr::new(elr) {
                 crate::memory::context::virtmem::page_fault(
                     far_va,
@@ -434,7 +465,7 @@ fn sync_handler(ctx: &mut ExceptionContext) {
     }
 }
 
-fn handle_inst_abort(_ctx: &mut ExceptionContext, esr_reg: &InMemoryRegister<u64, ESR_EL1::Register>) {
+fn handle_inst_abort(ctx: &mut ExceptionContext, esr_reg: &InMemoryRegister<u64, ESR_EL1::Register>) {
     // decoding ISS for instruction fault.
     // iss: syndrome
     let iss = esr_reg.read(ESR_EL1::ISS);
@@ -443,7 +474,7 @@ fn handle_inst_abort(_ctx: &mut ExceptionContext, esr_reg: &InMemoryRegister<u64
     if !far_valid {
         panic!("FAR is not valid!!");
     }
-    let far = arm64::registers::FAR_EL1.get();
+    let far = ctx.far;
 
     // The cause is from an instruction fetch
     let cause = MemoryAccessKind::InstructionFetch;
@@ -473,7 +504,7 @@ fn handle_inst_abort(_ctx: &mut ExceptionContext, esr_reg: &InMemoryRegister<u64
 
     crate::thread::enter_kernel();
     // crate::interrupt::set(true);
-    let elr = ELR_EL1.get();
+    let elr = ctx.elr;
     if let Ok(elr_va) = VirtAddr::new(elr) {
         // logln!("fault {:?} from {:?}", far_va, elr_va);
         crate::memory::context::virtmem::page_fault(

--- a/src/kernel/src/arch/aarch64/interrupt.rs
+++ b/src/kernel/src/arch/aarch64/interrupt.rs
@@ -129,7 +129,7 @@ pub(super) fn irq_exception_handler(_ctx: &mut ExceptionContext) {
     // Get pending IRQ number from GIC CPU Interface.
     // Doing so acknowledges the pending interrupt.
     let irq_number = INTERRUPT_CONTROLLER.pending_interrupt();
-    emerglogln!("[arch::irq] interrupt: {}", irq_number);
+    // emerglogln!("[arch::irq] interrupt: {}", irq_number);
     
     match irq_number {
         PhysicalTimer::INTERRUPT_ID => {

--- a/src/kernel/src/arch/aarch64/interrupt.rs
+++ b/src/kernel/src/arch/aarch64/interrupt.rs
@@ -129,7 +129,6 @@ pub(super) fn irq_exception_handler(_ctx: &mut ExceptionContext) {
     // Get pending IRQ number from GIC CPU Interface.
     // Doing so acknowledges the pending interrupt.
     let irq_number = INTERRUPT_CONTROLLER.pending_interrupt();
-    // emerglogln!("[arch::irq] interrupt: {}", irq_number);
     
     match irq_number {
         PhysicalTimer::INTERRUPT_ID => {

--- a/src/kernel/src/arch/aarch64/mod.rs
+++ b/src/kernel/src/arch/aarch64/mod.rs
@@ -100,7 +100,6 @@ pub fn start_clock(_statclock_hz: u64, _stat_cb: fn(Nanoseconds)) {
 }
 
 pub fn schedule_oneshot_tick(time: Nanoseconds) {
-    // emerglogln!("[arch::tick] setting the timer to fire off after {} ns", time);
     let old = interrupt::disable();
     // set timer to fire off after a certian amount of time has passed
     let phys_timer = cntp::PhysicalTimer::new();

--- a/src/kernel/src/arch/aarch64/mod.rs
+++ b/src/kernel/src/arch/aarch64/mod.rs
@@ -100,7 +100,7 @@ pub fn start_clock(_statclock_hz: u64, _stat_cb: fn(Nanoseconds)) {
 }
 
 pub fn schedule_oneshot_tick(time: Nanoseconds) {
-    emerglogln!("[arch::tick] setting the timer to fire off after {} ns", time);
+    // emerglogln!("[arch::tick] setting the timer to fire off after {} ns", time);
     let old = interrupt::disable();
     // set timer to fire off after a certian amount of time has passed
     let phys_timer = cntp::PhysicalTimer::new();

--- a/src/kernel/src/arch/aarch64/syscall.rs
+++ b/src/kernel/src/arch/aarch64/syscall.rs
@@ -108,7 +108,7 @@ pub unsafe fn return_to_user(context: &Armv8SyscallContext) -> ! {
     // crate::interrupt::set(true);
 
     // configure the execution state for EL0:
-    // - interrupts umasked
+    // - interrupts unmasked
     // - el0 exception level
     // - use sp_el0 stack pointer
     // - aarch64 execution state

--- a/src/kernel/src/arch/aarch64/syscall.rs
+++ b/src/kernel/src/arch/aarch64/syscall.rs
@@ -7,7 +7,7 @@
 ///     https://github.com/ARM-software/abi-aa/releases/download/2023Q1/aapcs64.pdf
 
 use arm64::registers::{ELR_EL1, SP_EL0, SPSR_EL1};
-use registers::interfaces::{Readable, Writeable};
+use registers::interfaces::Writeable;
 
 use twizzler_abi::upcall::UpcallFrame;
 
@@ -84,8 +84,7 @@ impl SyscallContext for Armv8SyscallContext {
         T::from(self.x5)
     }
     fn pc(&self) -> VirtAddr {
-        // TODO: save and pass in elr register
-        todo!("get pc")
+        VirtAddr::new(self.elr).unwrap()
     }
 
     fn set_return_values<R1, R2>(&mut self, ret0: R1, ret1: R2)
@@ -106,14 +105,15 @@ pub unsafe fn return_to_user(context: &Armv8SyscallContext) -> ! {
     SP_EL0.set(context.sp);
 
     // TODO: enable interrupts when we can support nested exception handling
+    // crate::interrupt::set(true);
 
     // configure the execution state for EL0:
-    // - interrupts masked
+    // - interrupts umasked
     // - el0 exception level
     // - use sp_el0 stack pointer
     // - aarch64 execution state
     SPSR_EL1.write(
-        SPSR_EL1::D::Masked + SPSR_EL1::A::Masked + SPSR_EL1::I::Masked
+        SPSR_EL1::D::Masked + SPSR_EL1::A::Masked + SPSR_EL1::I::Unmasked
         + SPSR_EL1::F::Masked + SPSR_EL1::M::EL0t
     );
 
@@ -131,7 +131,7 @@ pub unsafe fn return_to_user(context: &Armv8SyscallContext) -> ! {
 /// Service a system call according to the ABI defined in [`twizzler_abi`]
 pub fn handle_syscall(ctx: &mut ExceptionContext) {
     crate::thread::enter_kernel();
-    // crate::interrupt::set(true);
+    crate::interrupt::set(true);
 
     let mut context: Armv8SyscallContext = Default::default();
     context.x0 = ctx.x0;
@@ -143,9 +143,7 @@ pub fn handle_syscall(ctx: &mut ExceptionContext) {
     context.x6 = ctx.x6;
     context.x7 = ctx.x7;
     context.sp = ctx.sp;
-
-    // TODO: save this in the incoming exception?
-    context.elr = ELR_EL1.get();
+    context.elr = ctx.elr;
 
     crate::syscall::syscall_entry(&mut context);
     // crate::interrupt::set(false);


### PR DESCRIPTION
Two small issues were addressed here that prevented user threads from being switched back and forth. One was that certain system registers were not being saved (e.g. the user thread local storage register). We save system registers upon thread entry to handle an exception, and during a context switch between threads. We take inspiration from FreeBSD for the latter, and save the user thread local storage variables there.

Another was the context switch code for aarch64 assumed that it was called as a subroutine which assumed the return address of the caller was saved in the link register. At the end of the routine, the code would call `ret`. The issue was that the compiler would inline this function, making our assumptions incorrect and causing an infinite loop. We fixed this by not inlining the context switch code with the `inline(never)` macro.

The only other change was to comment out the enumeration of NVMe from within the Pager since unlike the Device Manager, it crashes if no NVMe controller is found. The current virt device (aarch64) emulated supports NVMe, but the option is not enabled. It seems unnecessary for the Pager to require this functionality so I opted to comment it out.

With these changes, the ARM port now reaches the user prompt printed by the init program waiting for user input. The actual user input processing requires an interrupt driven serial device to place bytes in the console among other things which is future work.

**Summary**
- save system registers for handling exceptions (`ELR_EL1`, `SPSR_EL1`, etc.)
- enable interrupts while running in user space
- save user TLS registers (`TPIDR_EL0/TPIDRRO_EL0`) during a context switch
- remove miscellaneous logging messages in interrupt handling code
- remove NVMe enumeration from the Pager