### PR TITLE
Interrupt driven RX for the PL011 UART driver

### DIFF
--- a/src/kernel/src/arch/aarch64/interrupt.rs
+++ b/src/kernel/src/arch/aarch64/interrupt.rs
@@ -16,6 +16,7 @@ use crate::{
     processor::current_processor,
 };
 use crate::machine::interrupt::INTERRUPT_CONTROLLER;
+use crate::machine::serial::{SERIAL_INT_ID, serial_interrupt_handler};
 
 use super::exception::{
     ExceptionContext, exception_handler, save_stack_pointer, restore_stack_pointer,
@@ -137,6 +138,10 @@ pub(super) fn irq_exception_handler(_ctx: &mut ExceptionContext) {
         PhysicalTimer::INTERRUPT_ID => {
             // call timer interrupt handler
             cntp_interrupt_handler();
+        },
+        _ if irq_number == *SERIAL_INT_ID => {
+            // call the serial interrupt handler
+            serial_interrupt_handler();
         },
         _ => panic!("unknown irq number! {}", irq_number)
     }

--- a/src/kernel/src/arch/aarch64/mod.rs
+++ b/src/kernel/src/arch/aarch64/mod.rs
@@ -8,7 +8,6 @@ use twizzler_abi::syscall::TimeSpan;
 
 use crate::{
     clock::Nanoseconds,
-    interrupt::{Destination, PinPolarity, TriggerMode},
     BootInfo,
     syscall::SyscallContext,
 };
@@ -26,7 +25,7 @@ pub mod thread;
 mod start;
 
 pub use address::{VirtAddr, PhysAddr};
-pub use interrupt::{send_ipi, init_interrupts};
+pub use interrupt::{send_ipi, init_interrupts, set_interrupt};
 pub use start::BootInfoSystemTable;
 
 pub fn init<B: BootInfo>(boot_info: &B) {
@@ -83,16 +82,6 @@ pub fn init_secondary() {
     // TODO: Initialize secondary processors:
     // - set up exception handling
     // - configure the local CPU interrupt controller interface
-}
-
-pub fn set_interrupt(
-    _num: u32,
-    _masked: bool,
-    _trigger: TriggerMode,
-    _polarity: PinPolarity,
-    _destination: Destination,
-) {
-    todo!();
 }
 
 pub fn start_clock(_statclock_hz: u64, _stat_cb: fn(Nanoseconds)) {

--- a/src/kernel/src/machine/arm/common/gicv2/mod.rs
+++ b/src/kernel/src/machine/arm/common/gicv2/mod.rs
@@ -31,15 +31,19 @@ impl GICv2 {
 
     /// Configures the interrupt controller. At the end of this function
     /// the current calling CPU is ready to recieve interrupts.
-    pub fn configure(&self) {
-        // enable the gic distributor
-        self.global.enable();
-
+    pub fn configure_local(&self) {
         // set the interrupt priority mask to accept all interrupts
         self.set_interrupt_mask(GICC::ACCEPT_ALL);
 
         // enable the gic cpu interface
         self.local.enable();
+    }
+
+    /// Configures global state in the interrupt controller. This should only
+    /// really be called once during system intialization by the boostrap core.
+    pub fn configure_global(&self) {
+        // enable the gic distributor
+        self.global.enable();
     }
 
     /// Sets the interrupt priority mask for the current calling CPU.

--- a/src/kernel/src/machine/arm/common/gicv2/mod.rs
+++ b/src/kernel/src/machine/arm/common/gicv2/mod.rs
@@ -51,16 +51,17 @@ impl GICv2 {
     // Enables the interrupt with a given ID to be routed to CPUs.
     pub fn enable_interrupt(&self, int_id: u32) {
         self.global.enable_interrupt(int_id);
-
-        // TODO: set the priority for the corresponding interrupt? see GICD_IPRIORITYRn
-        // TODO: edge triggered or level sensitive??? see GICD_ICFGRn
     }
 
     /// Programs the interrupt controller to be able to route
     /// a given interrupt to a particular core.
-    fn route_interrupt(&self, _int_id: u32, _core: u32) {
-        // TODD: route the interrupt to a corresponding core, see GICD_ITARGETSRn
-        todo!()
+    pub fn route_interrupt(&self, int_id: u32, core: u32) {
+        // route the interrupt to a corresponding core
+        self.global.set_interrupt_target(int_id, core);
+        // TODO: have the priority set to something reasonable
+        // set the priority for the corresponding interrupt
+        self.global.set_interrupt_priority(int_id, GICD::HIGHEST_PRIORITY);
+        // TODO: edge triggered or level sensitive??? see GICD_ICFGRn
     }
 
     /// Returns the pending interrupt ID from the controller, and

--- a/src/kernel/src/machine/arm/common/uart.rs
+++ b/src/kernel/src/machine/arm/common/uart.rs
@@ -19,6 +19,7 @@ enum Registers {
     UARTLCR_H = 0x02C,
     UARTCR = 0x030,
     UARTIMSC = 0x038,
+    UARTICR = 0x044,
     UARTDMACR = 0x048,
 }
 
@@ -173,6 +174,18 @@ impl PL011 {
         {
             let cr = self.read_reg(Registers::UARTCR);
             self.write_reg(Registers::UARTCR, (cr | 0b1) as u32);
+        }
+    }
+
+    pub fn clear_rx_interrupt(&self) {
+        // The UARTICR Register is the interrupt clear register and is write-only. 
+        // On a write of 1, the corresponding interrupt is cleared. 
+        // A write of 0 has no effect. Table 3-17 lists the register bit assignments.
+        //
+        // We must write to Receive interrupt clear (RXIC) which is bit 4. This
+        // Clears the UARTRXINTR interrupt.
+        unsafe {
+            self.write_reg(Registers::UARTICR, (0b1 << 4) as u32);
         }
     }
 

--- a/src/kernel/src/machine/arm/common/uart.rs
+++ b/src/kernel/src/machine/arm/common/uart.rs
@@ -47,18 +47,24 @@ impl PL011 {
         }
     }
 
-    /// Recieve a single byte of data.
-    pub fn rx_byte(&self) -> u8 {
+    /// Recieve a single byte of data if present in a non-blocking way.
+    pub fn rx_byte(&self) -> Option<u8> {
+        // the rx holding register/fifo may be empty
+        // check if RXFF bit in the UARTFR is set
+        let flag_reg = unsafe { self.read_reg(Registers::UARTFR) };
+        let rx_empty = (flag_reg >> 4) & 0b1 == 1;
+        if rx_empty {
+            return None
+        }
+
         // received data byte is read by performing reads from the UARTDR Register 
         // along with the corresponding status information
         let data = unsafe { self.read_reg(Registers::UARTDR) };
 
-        // TODO: rx holding register/fifo may be empty
-
         // TODO: check for rx errors
         // received data character must be read first from UARTDR
         // before reading the error status UARTRSR
-        (data & 0xff) as u8
+        Some((data & 0xff) as u8)
     }
 
     /// Configure the PL011 UART with desired baud, given the clock frequency

--- a/src/kernel/src/machine/arm/virt/mod.rs
+++ b/src/kernel/src/machine/arm/virt/mod.rs
@@ -5,5 +5,6 @@ pub mod processor;
 pub mod serial;
 
 pub fn machine_post_init() {
-    // TODO: initialize uart with interrupts
+    // initialize uart with interrupts
+    serial::SERIAL.late_init();
 }

--- a/src/kernel/src/main.rs
+++ b/src/kernel/src/main.rs
@@ -103,11 +103,10 @@ fn kernel_main<B: BootInfo>(boot_info: &mut B) -> ! {
         panic::init(kernel_image);
     }
 
-    arch::init_interrupts();
-
     logln!("[kernel::cpu] enumerating secondary CPUs");
     let bsp_id = arch::processor::enumerate_cpus();
     processor::init_cpu(image::get_tls(), bsp_id);
+    arch::init_interrupts();
     arch::init_secondary();
     initrd::init(boot_info.get_modules());
     logln!("[kernel::cpu] booting secondary CPUs");


### PR DESCRIPTION
This PR adds driver support for ARM devices needed to read user input from the prompt `init` prints out. The only change to the generic part of the kernel is moving `arch::init_interrupts` after TLS is initialized so we can use `current_processor`. It seems to cause no issues with x86.

**Summary**
* improve RX side in UART driver
* configure UART to enable interrupts for RX
* create interrupt handler for the UART
* parse device tree blob to get interrupt number
* route interrupt nums > 32 in GICv2 driver
* implement set interrupt for aarch64

The result is that now the user can type in stuff to the startup console and the kernel can read input. We can even run the simple hello world [example](https://github.com/twizzler-operating-system/twizzler/blob/main/doc/src/develop.md#writing-your-first-twizzler-program)!