### PR TITLE
Unify ObjID types across API and ABI crates

### DIFF
--- a/src/bin/bootstrap/src/main.rs
+++ b/src/bin/bootstrap/src/main.rs
@@ -34,7 +34,7 @@ fn start_runtime(_runtime_monitor: ObjID, _runtime_library: ObjID) -> ! {
             }
             let id = find_init_name(name)?;
             let obj = twizzler_runtime_api::get_runtime()
-                .map_object(id.as_u128(), MapFlags::READ)
+                .map_object(id, MapFlags::READ)
                 .ok()?;
             Some(Backing::new(obj))
         })

--- a/src/bin/init/src/main.rs
+++ b/src/bin/init/src/main.rs
@@ -356,9 +356,7 @@ fn main() {
     if let Some(id) = find_init_name("test_bins") {
         println!("=== found init test list ===");
         let runtime = __twz_get_runtime();
-        let handle = runtime
-            .map_object(id.as_u128(), Protections::READ.into())
-            .unwrap();
+        let handle = runtime.map_object(id, Protections::READ.into()).unwrap();
 
         let addr = unsafe { handle.start.add(NULLPAGE_SIZE) };
         let bytes = unsafe {
@@ -372,9 +370,7 @@ fn main() {
             if let Some(id) = find_init_name(line) {
                 let tid = exec2(line, id);
                 if let Some(tid) = tid {
-                    let thandle = runtime
-                        .map_object(tid.as_u128(), Protections::READ.into())
-                        .unwrap();
+                    let thandle = runtime.map_object(tid, Protections::READ.into()).unwrap();
 
                     let taddr = unsafe { thandle.start.add(NULLPAGE_SIZE) };
                     let tr = taddr as *const ThreadRepr;

--- a/src/kernel/src/userinit.rs
+++ b/src/kernel/src/userinit.rs
@@ -115,7 +115,7 @@ pub extern "C" fn user_init() {
             )
         }
 
-        aux = append_aux(aux, AuxEntry::ExecId(init_obj.id().as_u128()));
+        aux = append_aux(aux, AuxEntry::ExecId(init_obj.id()));
         append_aux(aux, AuxEntry::Null);
 
         // remove permission mappings from text segment

--- a/src/lib/twizzler-abi/src/object.rs
+++ b/src/lib/twizzler-abi/src/object.rs
@@ -1,74 +1,11 @@
 //! Low-level object APIs, mostly around IDs and basic things like protection definitions and metadata.
 
-use core::fmt::{LowerHex, UpperHex};
-
 /// The maximum size of an object, including null page and meta page(s).
 pub const MAX_SIZE: usize = 1024 * 1024 * 1024;
 /// The size of the null page.
 pub const NULLPAGE_SIZE: usize = 0x1000;
 
-#[repr(transparent)]
-#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
-/// An object ID, represented as a transparent wrapper type. Any value where the upper 64 bits are
-/// zero is invalid.
-pub struct ObjID(twizzler_runtime_api::ObjID);
-
-impl ObjID {
-    /// Create a new ObjID out of a 128 bit value.
-    pub const fn new(id: u128) -> Self {
-        Self(id)
-    }
-
-    /// Split an object ID into upper and lower values, useful for syscalls.
-    pub fn split(&self) -> (u64, u64) {
-        ((self.0 >> 64) as u64, (self.0 & 0xffffffffffffffff) as u64)
-    }
-
-    /// Build a new ObjID out of a high part and a low part.
-    pub fn new_from_parts(hi: u64, lo: u64) -> Self {
-        ObjID::new(((hi as u128) << 64) | (lo as u128))
-    }
-
-    pub fn as_u128(&self) -> u128 {
-        self.0
-    }
-}
-
-impl core::convert::AsRef<ObjID> for ObjID {
-    fn as_ref(&self) -> &ObjID {
-        self
-    }
-}
-
-impl From<u128> for ObjID {
-    fn from(id: u128) -> Self {
-        Self::new(id)
-    }
-}
-
-impl LowerHex for ObjID {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        write!(f, "{:x}", self.0)
-    }
-}
-
-impl UpperHex for ObjID {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        write!(f, "{:X}", self.0)
-    }
-}
-
-impl core::fmt::Display for ObjID {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        write!(f, "ObjID({:x})", self.0)
-    }
-}
-
-impl core::fmt::Debug for ObjID {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        write!(f, "ObjID({:x})", self.0)
-    }
-}
+pub use twizzler_runtime_api::ObjID;
 
 bitflags::bitflags! {
     /// Mapping protections for mapping objects into the address space.

--- a/src/lib/twizzler-abi/src/runtime/core.rs
+++ b/src/lib/twizzler-abi/src/runtime/core.rs
@@ -67,7 +67,7 @@ impl CoreRuntime for MinimalRuntime {
                         process_phdrs(core::slice::from_raw_parts(paddr as *const Phdr, pnum))
                     }
                     AuxEntry::ExecId(id) => {
-                        super::debug::set_execid(ObjID::new(id));
+                        super::debug::set_execid(id);
                     }
                     AuxEntry::Arguments(num, ptr) => {
                         arg_count = num;

--- a/src/lib/twizzler-abi/src/runtime/debug.rs
+++ b/src/lib/twizzler-abi/src/runtime/debug.rs
@@ -25,7 +25,7 @@ impl DebugRuntime for MinimalRuntime {
         id: twizzler_runtime_api::LibraryId,
     ) -> Option<twizzler_runtime_api::Library> {
         let mapping = __twz_get_runtime()
-            .map_object(get_execid().as_u128(), MapFlags::READ)
+            .map_object(get_execid(), MapFlags::READ)
             .ok()?;
         Some(Library {
             range: AddrRange {

--- a/src/lib/twizzler-abi/src/runtime/load_elf.rs
+++ b/src/lib/twizzler-abi/src/runtime/load_elf.rs
@@ -356,7 +356,7 @@ pub fn spawn_new_executable(
     .unwrap();
     let mut idx = 0;
 
-    aux_array[idx] = AuxEntry::ExecId(exe.id().as_u128());
+    aux_array[idx] = AuxEntry::ExecId(exe.id());
     idx += 1;
     aux_array[idx] = AuxEntry::Arguments(args.len(), spawnargs_start as u64);
     idx += 1;

--- a/src/lib/twizzler-abi/src/runtime/object.rs
+++ b/src/lib/twizzler-abi/src/runtime/object.rs
@@ -61,8 +61,7 @@ impl ObjectRuntime for MinimalRuntime {
         flags: twizzler_runtime_api::MapFlags,
     ) -> Result<twizzler_runtime_api::ObjectHandle, twizzler_runtime_api::MapError> {
         let slot = global_allocate().ok_or(MapError::OutOfResources)?;
-        let _ = sys_object_map(None, ObjID::new(id), slot, flags.into(), flags.into())
-            .map_err(|e| e.into())?;
+        let _ = sys_object_map(None, id, slot, flags.into(), flags.into()).map_err(|e| e.into())?;
         Ok(ObjectHandle::new(
             NonNull::new(Box::into_raw(Box::new(InternalHandleRefs::default()))).unwrap(),
             id,

--- a/src/lib/twizzler-abi/src/runtime/object/handle.rs
+++ b/src/lib/twizzler-abi/src/runtime/object/handle.rs
@@ -60,7 +60,7 @@ impl<T> InternalObject<T> {
             slot,
             runtime_handle: ObjectHandle::new(
                 raw,
-                id.as_u128(),
+                id,
                 MapFlags::READ | MapFlags::WRITE,
                 (slot * MAX_SIZE) as *mut u8,
                 (slot * MAX_SIZE + MAX_SIZE - NULLPAGE_SIZE) as *mut u8,
@@ -83,7 +83,7 @@ impl<T> InternalObject<T> {
 
     #[allow(dead_code)]
     pub(crate) fn id(&self) -> ObjID {
-        ObjID::new(self.runtime_handle.id)
+        self.runtime_handle.id
     }
 
     #[allow(dead_code)]
@@ -100,7 +100,7 @@ impl<T> InternalObject<T> {
         Some(Self {
             runtime_handle: ObjectHandle::new(
                 NonNull::new(Box::into_raw(Box::new(InternalHandleRefs::default()))).unwrap(),
-                id.as_u128(),
+                id,
                 prot.into(),
                 (slot * MAX_SIZE) as *mut u8,
                 (slot * MAX_SIZE + MAX_SIZE - NULLPAGE_SIZE) as *mut u8,

--- a/src/lib/twizzler-object/src/slot.rs
+++ b/src/lib/twizzler-object/src/slot.rs
@@ -63,7 +63,7 @@ fn into_protections(flags: twizzler_runtime_api::MapFlags) -> Protections {
 impl Slot {
     fn new(id: ObjID, prot: Protections) -> Result<Self, ObjectInitError> {
         let runtime = twizzler_runtime_api::get_runtime();
-        let rh = runtime.map_object(id.as_u128(), into_map_flags(prot))?;
+        let rh = runtime.map_object(id, into_map_flags(prot))?;
         Ok(Self {
             id,
             prot,
@@ -73,7 +73,7 @@ impl Slot {
 
     pub fn new_from_handle(handle: ObjectHandle) -> Result<Self, ObjectInitError> {
         Ok(Self {
-            id: ObjID::new(handle.id),
+            id: handle.id,
             prot: into_protections(handle.flags),
             runtime_handle: handle,
         })

--- a/src/runtime/dynlink/src/engines/twizzler.rs
+++ b/src/runtime/dynlink/src/engines/twizzler.rs
@@ -107,7 +107,7 @@ impl ContextEngine for Engine {
             }
 
             Ok(ObjectSource::new_copy(
-                twizzler_object::ObjID::new(src.obj.id),
+                src.obj.id,
                 (src_start % MAX_SIZE) as u64,
                 (dest_start % MAX_SIZE) as u64,
                 len,
@@ -136,7 +136,7 @@ impl ContextEngine for Engine {
             .map_two_objects(
                 text_id,
                 MapFlags::READ | MapFlags::EXEC,
-                data_id.as_u128(),
+                data_id,
                 MapFlags::READ | MapFlags::WRITE,
             )
             .map_err(|_| DynlinkErrorKind::NewBackingFail)?;

--- a/src/runtime/monitor/src/compartment.rs
+++ b/src/runtime/monitor/src/compartment.rs
@@ -73,7 +73,7 @@ pub(crate) fn make_new_comp_alloc_object() -> ObjectHandle {
     .unwrap();
 
     twizzler_runtime_api::get_runtime()
-        .map_object(id.as_u128(), MapFlags::READ | MapFlags::WRITE)
+        .map_object(id, MapFlags::READ | MapFlags::WRITE)
         .unwrap()
 }
 

--- a/src/runtime/monitor/src/lib.rs
+++ b/src/runtime/monitor/src/lib.rs
@@ -144,7 +144,7 @@ fn bootstrap_name_res(mut name: &str) -> Option<Backing> {
     }
     let id = find_init_name(name)?;
     let obj = twizzler_runtime_api::get_runtime()
-        .map_object(id.as_u128(), twizzler_runtime_api::MapFlags::READ)
+        .map_object(id, twizzler_runtime_api::MapFlags::READ)
         .ok()?;
     Some(Backing::new(obj))
 }

--- a/src/runtime/monitor/src/object.rs
+++ b/src/runtime/monitor/src/object.rs
@@ -28,7 +28,7 @@ pub fn map_object(_info: &GateCallInfo, id: ObjID, flags: MapFlags) -> Result<us
 
     let Ok(_) = sys_object_map(
         None,
-        twizzler_abi::object::ObjID::new(id),
+        id,
         slot,
         mapflags_into_prot(flags),
         twizzler_abi::syscall::MapFlags::empty(),

--- a/src/runtime/monitor/src/thread.rs
+++ b/src/runtime/monitor/src/thread.rs
@@ -76,7 +76,7 @@ pub fn __monitor_rt_spawn_thread(
     thread_pointer: usize,
     stack_pointer: usize,
 ) -> Result<twizzler_runtime_api::ObjID, SpawnError> {
-    spawn_thread(src_ctx, args, thread_pointer, stack_pointer).map(|o| o.as_u128())
+    spawn_thread(src_ctx, args, thread_pointer, stack_pointer)
 }
 
 // Extern function, linked to by the runtime.

--- a/src/runtime/twz-rt/src/runtime/alloc.rs
+++ b/src/runtime/twz-rt/src/runtime/alloc.rs
@@ -76,7 +76,7 @@ fn create_and_map() -> Option<(usize, ObjID)> {
     )
     .ok()?;
 
-    let slot = monitor_api::monitor_rt_object_map(id.as_u128(), MapFlags::READ | MapFlags::WRITE)
+    let slot = monitor_api::monitor_rt_object_map(id, MapFlags::READ | MapFlags::WRITE)
         .unwrap()
         .ok();
 

--- a/src/runtime/twz-rt/src/runtime/object.rs
+++ b/src/runtime/twz-rt/src/runtime/object.rs
@@ -80,7 +80,7 @@ impl ObjectRuntime for ReferenceRuntime {
 
         sys_object_map(
             None,
-            ObjID::new(in_id_a),
+            in_id_a,
             slot_a,
             prot_a,
             twizzler_abi::syscall::MapFlags::empty(),
@@ -89,7 +89,7 @@ impl ObjectRuntime for ReferenceRuntime {
 
         sys_object_map(
             None,
-            ObjID::new(in_id_b),
+            in_id_b,
             slot_b,
             prot_b,
             twizzler_abi::syscall::MapFlags::empty(),

--- a/src/runtime/twz-rt/src/runtime/thread/mgr.rs
+++ b/src/runtime/twz-rt/src/runtime/thread/mgr.rs
@@ -177,7 +177,7 @@ impl ReferenceRuntime {
         };
 
         let thread_repr_obj = self
-            .map_object(thid.as_u128(), MapFlags::READ | MapFlags::WRITE)
+            .map_object(thid, MapFlags::READ | MapFlags::WRITE)
             .map_err(|_| SpawnError::Other)?;
 
         let thread = InternalThread::new(


### PR DESCRIPTION
This PR moves the definition of ObjID in twizzler-abi into twizzler-runtime-api, so that the low-level object ID type is a) the same across all crates, for ergonomics, and b) is available to even the lowest level runtime code.

The vast majority of changes in this PR are removing no-longer-needed type conversions between the previously different ObjID types.

This will significantly improve the ergonomics of working with object IDs.
