### PR TITLE
Nested interrupt support for aarch64

### DIFF
--- a/src/kernel/src/arch/aarch64/interrupt.rs
+++ b/src/kernel/src/arch/aarch64/interrupt.rs
@@ -197,6 +197,7 @@ pub fn init_interrupts() {
         PhysicalTimer::INTERRUPT_ID,
         cpu.id,
     );
+    INTERRUPT_CONTROLLER.enable_interrupt(PhysicalTimer::INTERRUPT_ID);
 }
 
 pub fn set_interrupt(


### PR DESCRIPTION
This patch adds nested interrupt support for the aarch64 version of the kernel. No changes to the generic part of the kernel were required. We fixed a few things and enable interrupts when handling synchronous exceptions such as system calls and page fault handling.

**Summary**
- make sure new threads start with interrupts enabled
- enable the system timer interrupt
- enable interrupts when handling synchronous exceptions