### PR TITLE
Add automatic formatting via pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,15 @@
+repos:
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v4.3.0
+  hooks:
+  - id: trailing-whitespace
+  - id: end-of-file-fixer
+  - id: check-added-large-files
+- repo: local
+  hooks:
+    - id: fmt
+      name: fmt
+      entry: bash -c "cargo fmt --all"
+      language: system
+      types: [rust]
+      args: [""]

--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,7 @@
+edition = "2021"
+use_field_init_shorthand = true
+newline_style = "Unix"
+comment_width = 100
+format_code_in_doc_comments = true
+imports_granularity = "Crate"
+wrap_comments = true

--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -5,3 +5,4 @@ comment_width = 100
 format_code_in_doc_comments = true
 imports_granularity = "Crate"
 wrap_comments = true
+group_imports = "StdExternalCrate"


### PR DESCRIPTION
This PR is the first in a set that will add automatic formatting via pre-commit hooks and CI. Formatting is done by rustfmt, and is controlled by .rustfmt.toml.

I plan to apply the formatting changes that rustfmt wants in a separate PR, so as to limit all formatting changes to a single PR. Once the code is reformatted according to the rustfmt config we decide on, I'll update documentation to describe how to setup the pre-commit hook when contributing.

Starting this PR now so any bikeshedding discussion for rustfmt can be contained.