### PR TITLE
Develop doc hello world correction + made submodules work when developing from a personal fork of the repo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,8 +1,8 @@
 [submodule "toolchain/src/rust"]
 	path = toolchain/src/rust
-	url = ../rust.git
+	url = https://github.com/twizzler/rust.git
 	branch = twizzler-dynlink
 [submodule "src/lib/nvme-rs"]
 	path = src/lib/nvme-rs
-	url = ../nvme-rs.git
+	url = https://twizzler/nvme-rs.git
 	branch = twizzler-dynlink

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,8 +1,8 @@
 [submodule "toolchain/src/rust"]
 	path = toolchain/src/rust
-	url = ../../twizzler/rust.git
+	url = ../../twizzler-operating-system/rust.git
 	branch = twizzler-dynlink
 [submodule "src/lib/nvme-rs"]
 	path = src/lib/nvme-rs
-	url = ../../twizzler/nvme-rs.git
+	url = ../../twizzler-operating-system/nvme-rs.git
 	branch = twizzler-dynlink

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,8 +1,8 @@
 [submodule "toolchain/src/rust"]
 	path = toolchain/src/rust
-	url = https://github.com/twizzler/rust.git
+	url = ../../twizzler/rust.git
 	branch = twizzler-dynlink
 [submodule "src/lib/nvme-rs"]
 	path = src/lib/nvme-rs
-	url = https://twizzler/nvme-rs.git
+	url = ../../twizzler/nvme-rs.git
 	branch = twizzler-dynlink

--- a/doc/src/develop.md
+++ b/doc/src/develop.md
@@ -21,11 +21,7 @@ runs on the Twizzler operating system you can follow these steps:
 3. add the following to the main.rs file within hello/src:
 
 ```rust
-use twizzler_abi::pager::{CompletionToKernel, KernelCompletionData, RequestFromKernel};
-
-async fn handle_request(_request: RequestFromKernel) -> Option<CompletionToKernel> {
-   Some(CompletionToKernel::new(KernelCompletionData::EchoResp))
-}
+extern crate twizzler_abi;
 ```
 
 4. Edit the Cargo.toml file in the root directory to add the program to the Twizzler build system.

--- a/doc/src/develop.md
+++ b/doc/src/develop.md
@@ -11,19 +11,29 @@ the main repo in your own branches.
 Twizzler makes heavy use of Rust's Cargo system of crates in order to manage both kernel and user space programs.  To create a new program that
 runs on the Twizzler operating system you can follow these steps:
 
-  1. Change directories into the bin directory:
+1. Change directories into the bin directory:
 
 ```cd twizzler/src/bin```
 
-  2. Create a new program, named ```hello```.  The ```Cargo``` command will actually create the canonical ```Hello world``` program for you.
+2. Create a new program, named ```hello```.  The ```Cargo``` command will actually create the canonical ```Hello world``` program for you.
 ```cargo new --bin hello```
 
-  3. Edit the Cargo.toml file in the root directory to add the program to the Twizzler build system.
+3. add the following to the main.rs file within hello/src:
+
+```rust
+use twizzler_abi::pager::{CompletionToKernel, KernelCompletionData, RequestFromKernel};
+
+async fn handle_request(_request: RequestFromKernel) -> Option<CompletionToKernel> {
+   Some(CompletionToKernel::new(KernelCompletionData::EchoResp))
+}
+```
+
+4. Edit the Cargo.toml file in the root directory to add the program to the Twizzler build system.
 ```vi ../../Cargo.toml```
 
 The following diff shows the two lines you need to add:
 
-```
+```diff
 diff --git a/Cargo.toml b/Cargo.toml
 index 338455b..cb38fb5 100644
 --- a/Cargo.toml


### PR DESCRIPTION
1. Fixed develop.md by noting the necessary addition of a few lines at the top of the file to ensure that the main function would actually get called.

2. Changed the gitmodules so that they link back to the twizzler-operating-system/twizzler submodules so I don't have to fork all of the various submodules.