### PR TITLE
Fix aarch64 thread stack initialization

### DIFF
--- a/src/kernel/src/arch/aarch64/thread.rs
+++ b/src/kernel/src/arch/aarch64/thread.rs
@@ -12,7 +12,7 @@ use registers::interfaces::Writeable;
 use twizzler_abi::upcall::{UpcallFrame, UpcallInfo, UpcallTarget};
 
 use super::{exception::ExceptionContext, interrupt::DAIFMaskBits, syscall::Armv8SyscallContext};
-use crate::{memory::VirtAddr, thread::Thread};
+use crate::{memory::VirtAddr, processor::KERNEL_STACK_SIZE, thread::Thread};
 
 #[derive(Copy, Clone)]
 pub enum Registers {
@@ -190,9 +190,9 @@ impl Thread {
     }
 
     pub unsafe fn init(&mut self, entry: extern "C" fn()) {
-        let stack = self.kernel_stack.as_ptr() as *mut u64;
+        let stack = new_stack_top(self.kernel_stack.as_ptr() as usize, KERNEL_STACK_SIZE);
         // set the stack pointer as the last thing context (x30 + 1)
-        self.arch.context.sp = stack as u64;
+        self.arch.context.sp = stack.into();
         // set the link register as the second to last entry (x30)
         self.arch.context.lr = entry as u64;
         // by default interrupts are enabled (unmask the I bit)


### PR DESCRIPTION
This PR fixes a stack corruption bug caused by bad thread stack initialization. I discovered that the synchronization bug I was chasing was a stack corruption bug. Essentially the aarch64 thread stack initialization code simply sets the stack pointer to the end of the stack instead of the base. This is a problem since on aarch64 the stack is full descending and grows towards lower addresses. This did not cause any immediate issues when the system ran with a few threads.

However, when running the kernel tests ,the synchronization tests (mutex/condvar) failed. This is because those tests create many threads which cause execution of code to overwrite the stack of other threads. Now that the threads stacks are initialized correctly, the tests `test_condvar` and `test_mutex` pass. According to those test, there are no synchronization bugs ;)

There are still a few tests that the aarch64 version of the kernel does not pass. Those bugs will be fixed in future PRs.