### PR TITLE
Fix PL011 baud configuration

### DIFF
--- a/src/kernel/src/machine/arm/common/uart.rs
+++ b/src/kernel/src/machine/arm/common/uart.rs
@@ -103,7 +103,7 @@ impl PL011 {
         // int = (64 * brd - f) / 64 (integer division)
         // since f / 64 < 1, int = (64 * brd) / 64
         // f ~= to 6 remaining bits after division
-        let brd_scaled: u32 = 4 * clk / baud; // brd * 64
+        let brd_scaled: u32 = (4 * clk) / baud; // brd * 64
         let int: u32 = brd_scaled >> 6;
         let frac: u32 = brd_scaled & 0x3f;
 

--- a/src/kernel/src/machine/arm/common/uart.rs
+++ b/src/kernel/src/machine/arm/common/uart.rs
@@ -67,7 +67,7 @@ impl PL011 {
     }
 
     /// Configure the PL011 UART with desired baud, given the clock frequency
-    pub unsafe fn init(&self, baud: u32, clk: u32) {
+    pub unsafe fn init(&self, clk: u32, baud: u32) {
         // program the UART: (page 26/3-16)
         // disable UART
         {


### PR DESCRIPTION
This PR fixes two minor bugs that only manifested on real hardware. The first bug was that the arguments in the init were passed in the wrong order. 
https://github.com/twizzler-operating-system/twizzler/blob/eceaf1eb8a78ae72d48ecfbb6962fc5eb38722a0/src/kernel/src/machine/arm/common/uart.rs#L70

The second bug had to do with the way we computed the values for the registers controlling the baud rate. The method of scaling the clock value is correct, but since it is integer division we need to use parenthesis. This causes the values for the baud configuration registers to be zero.
https://github.com/twizzler-operating-system/twizzler/blob/eceaf1eb8a78ae72d48ecfbb6962fc5eb38722a0/src/kernel/src/machine/arm/common/uart.rs#L106-L108

These bugs didn't stop the qemu device from working, but it did on real hardware (e.g., RPi4). With these two fixes we can configure a PL011 device and perform reads/writes. This was tested on a Raspberry Pi 4.