### PR TITLE
Added cryptographic operations to the kernel, complete with tests

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,8 +1,8 @@
 [submodule "toolchain/src/rust"]
 	path = toolchain/src/rust
-	url = ../rust.git
+	url = https://github.com/twizzler/rust.git
 	branch = twizzler-dynlink
 [submodule "src/lib/nvme-rs"]
 	path = src/lib/nvme-rs
-	url = ../nvme-rs.git
+	url = https://twizzler/nvme-rs.git
 	branch = twizzler-dynlink

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,8 +1,8 @@
 [submodule "toolchain/src/rust"]
 	path = toolchain/src/rust
-	url = ../../twizzler/rust.git
+	url = ../../twizzler-operating-system/rust.git
 	branch = twizzler-dynlink
 [submodule "src/lib/nvme-rs"]
 	path = src/lib/nvme-rs
-	url = ../../twizzler/nvme-rs.git
+	url = ../../twizzler-operating-system/nvme-rs.git
 	branch = twizzler-dynlink

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,8 +1,8 @@
 [submodule "toolchain/src/rust"]
 	path = toolchain/src/rust
-	url = https://github.com/twizzler/rust.git
+	url = ../../twizzler/rust.git
 	branch = twizzler-dynlink
 [submodule "src/lib/nvme-rs"]
 	path = src/lib/nvme-rs
-	url = https://twizzler/nvme-rs.git
+	url = ../../twizzler/nvme-rs.git
 	branch = twizzler-dynlink

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -304,6 +304,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
 name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -657,6 +663,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
 name = "core-foundation"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -724,6 +736,18 @@ name = "crossbeam-utils"
 version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "248e3bacc7dc6baa3b21e405ee045c3047101a49145e7e9eca583ab4c2ca5345"
+
+[[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "generic-array",
+ "rand_core",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "crypto-common"
@@ -802,6 +826,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "der"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f55bf8e7b65898637379c1b74eb1551107c8294ed26d855ceb9fd1a09cfc9bc0"
+dependencies = [
+ "const-oid",
+ "zeroize",
+]
+
+[[package]]
 name = "devmgr"
 version = "0.1.0"
 dependencies = [
@@ -821,6 +855,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
+ "const-oid",
  "crypto-common",
  "subtle",
 ]
@@ -846,6 +881,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der",
+ "digest",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+]
+
+[[package]]
 name = "either"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -856,6 +904,24 @@ name = "elf"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f6e7d85896690fe195447717af8eceae0593ac2196fd42fe88c184e904406ce"
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "digest",
+ "ff",
+ "generic-array",
+ "group",
+ "rand_core",
+ "sec1",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "encode_unicode"
@@ -966,6 +1032,16 @@ name = "fdt"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "784a4df722dc6267a04af36895398f59d21d07dce47232adf31ec0ff2fa45e67"
+
+[[package]]
+name = "ff"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ded41244b729663b1e574f1b4fb731469f69f79c17667b5d776b16cda0479449"
+dependencies = [
+ "rand_core",
+ "subtle",
+]
 
 [[package]]
 name = "filetime"
@@ -1152,6 +1228,7 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -1238,6 +1315,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core",
+ "subtle",
+]
+
+[[package]]
 name = "guess_host_triple"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1306,6 +1394,12 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hex-literal"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fe2267d4ed49bc07b63801559be28c718ea06c4738b7a03c94df7386d2cde46"
 
 [[package]]
 name = "hmac"
@@ -2013,7 +2107,7 @@ name = "nvme"
 version = "0.1.0"
 dependencies = [
  "modular-bitfield",
- "volatile",
+ "volatile_cell",
 ]
 
 [[package]]
@@ -2145,6 +2239,18 @@ name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2",
+]
 
 [[package]]
 name = "pager"
@@ -2280,6 +2386,15 @@ name = "portable-atomic"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3bccab0e7fd7cc19f820a1c8c91720af652d0c88dc9664dd72aef2614f04af3b"
+
+[[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
+]
 
 [[package]]
 name = "proc-macro-error"
@@ -2444,6 +2559,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac",
+ "subtle",
+]
+
+[[package]]
 name = "rprompt"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2457,6 +2582,12 @@ checksum = "1ed5f33bb98eace335c13cdd159fbfc73ce203b597981a76832dfbb9cbd8101b"
 dependencies = [
  "log",
 ]
+
+[[package]]
+name = "rust-libcore"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae7a33830cc02d03ae1e50057d0e4e4b1a84be09bfb158bf95e9c3f3373aa453"
 
 [[package]]
 name = "rustc-demangle"
@@ -2548,6 +2679,19 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct",
+ "der",
+ "generic-array",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "secgate"
@@ -2700,6 +2844,16 @@ name = "shell-escape"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "45bb67a18fa91266cc7807181f62f9178a6873bfad7dc788c42e6430db40184f"
+
+[[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest",
+ "rand_core",
+]
 
 [[package]]
 name = "siphasher"
@@ -3258,6 +3412,7 @@ dependencies = [
  "bitflags 2.4.1",
  "fdt",
  "fixedbitset",
+ "hex-literal",
  "intrusive-collections",
  "lazy_static",
  "limine",
@@ -3265,6 +3420,8 @@ dependencies = [
  "memoffset",
  "nonoverlapping_interval_tree",
  "object",
+ "p256",
+ "sha2",
  "slabmalloc",
  "smccc",
  "syscall_encode",
@@ -3450,6 +3607,15 @@ name = "volatile"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9eaac9f9d9b7ae00cdd43e21b15e58ccacd903e6d29131d7536765a61969d25e"
+
+[[package]]
+name = "volatile_cell"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e89c44c56cc47ef6c4fccb52a3a5c48c4306929294fdf4ffe67321a0071bba72"
+dependencies = [
+ "rust-libcore",
+]
 
 [[package]]
 name = "vte"
@@ -3912,3 +4078,9 @@ name = "zero"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fe21bcc34ca7fe6dd56cc2cb1261ea59d6b93620215aefb5ea6032265527784"
+
+[[package]]
+name = "zeroize"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2107,7 +2107,7 @@ name = "nvme"
 version = "0.1.0"
 dependencies = [
  "modular-bitfield",
- "volatile_cell",
+ "volatile",
 ]
 
 [[package]]
@@ -2582,12 +2582,6 @@ checksum = "1ed5f33bb98eace335c13cdd159fbfc73ce203b597981a76832dfbb9cbd8101b"
 dependencies = [
  "log",
 ]
-
-[[package]]
-name = "rust-libcore"
-version = "0.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae7a33830cc02d03ae1e50057d0e4e4b1a84be09bfb158bf95e9c3f3373aa453"
 
 [[package]]
 name = "rustc-demangle"
@@ -3607,15 +3601,6 @@ name = "volatile"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9eaac9f9d9b7ae00cdd43e21b15e58ccacd903e6d29131d7536765a61969d25e"
-
-[[package]]
-name = "volatile_cell"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e89c44c56cc47ef6c4fccb52a3a5c48c4306929294fdf4ffe67321a0071bba72"
-dependencies = [
- "rust-libcore",
-]
 
 [[package]]
 name = "vte"

--- a/src/kernel/Cargo.toml
+++ b/src/kernel/Cargo.toml
@@ -23,13 +23,21 @@ linked_list_allocator = "0.10"
 tar-no-std = "0.2.0"
 object = { version = "0.32.1", default-features = false, features = ["read"] }
 addr2line = { version = "0.16.0", default-features = false, features = [
-    "rustc-demangle"
+    "rustc-demangle",
 ] }
 backtracer_core = { git = "https://github.com/twizzler-operating-system/backtracer", branch = "twizzler" }
 limine = "0.1.11"
 twizzler-queue-raw = { version = "*", path = "../lib/twizzler-queue-raw", default-features = false }
 syscall_encode = { version = "0.1.2" }
 volatile = "0.5"
+# for crypto
+p256 = { version = "0.13.2", default-features = false, features = ["ecdsa"] }
+sha2 = { version = "0.10.8", default-features = false, features = [
+    "force-soft",
+] }
+# for testing crypto
+[dev-dependencies]
+hex-literal = { version = "0.4.1", default-features = false }
 
 [target.x86_64-unknown-none.dependencies]
 uart_16550 = "0.3.0"
@@ -48,4 +56,3 @@ features = ["spin_no_std"]
 
 [package.metadata]
 twizzler-build = "kernel"
-

--- a/src/kernel/Cargo.toml
+++ b/src/kernel/Cargo.toml
@@ -35,8 +35,8 @@ p256 = { version = "0.13.2", default-features = false, features = ["ecdsa"] }
 sha2 = { version = "0.10.8", default-features = false, features = [
     "force-soft",
 ] }
+# [dev-dependencies] # kernel doesn't include dev dependencies when testing
 # for testing crypto
-[dev-dependencies]
 hex-literal = { version = "0.4.1", default-features = false }
 
 [target.x86_64-unknown-none.dependencies]

--- a/src/kernel/src/crypto.rs
+++ b/src/kernel/src/crypto.rs
@@ -11,13 +11,11 @@ use sha2::{
     Digest, Sha256,
 };
 
-pub fn sha256(
-    input: impl AsRef<[u8]>,
-) -> GenericArray<u8, UInt<UInt<UInt<UInt<UInt<UInt<UTerm, B1>, B0>, B0>, B0>, B0>, B0>> {
+pub fn sha256(input: impl AsRef<[u8]>) -> [u8; 32] {
     let mut hasher = Sha256::new();
     hasher.update(input);
     let res = hasher.finalize();
-    res
+    res.into()
 }
 
 pub fn sign(private_key: &SigningKey, message: &[u8]) -> Signature {

--- a/src/kernel/src/crypto.rs
+++ b/src/kernel/src/crypto.rs
@@ -1,0 +1,63 @@
+use p256::ecdsa::{
+    signature::{self, Signer, Verifier},
+    Signature, SigningKey, VerifyingKey,
+};
+use sha2::{
+    digest::{
+        consts::{B0, B1},
+        generic_array::GenericArray,
+        typenum::{UInt, UTerm},
+    },
+    Digest, Sha256,
+};
+
+pub fn sha256(
+    input: impl AsRef<[u8]>,
+) -> GenericArray<u8, UInt<UInt<UInt<UInt<UInt<UInt<UTerm, B1>, B0>, B0>, B0>, B0>, B0>> {
+    let mut hasher = Sha256::new();
+    hasher.update(input);
+    let res = hasher.finalize();
+    res
+}
+
+pub fn sign(private_key: &SigningKey, message: &[u8]) -> Signature {
+    private_key.sign(message)
+}
+
+pub fn verify(
+    public_key: &VerifyingKey,
+    message: &[u8],
+    signature: Signature,
+) -> signature::Result<()> {
+    public_key.verify(message, &signature)
+}
+
+mod test {
+
+    use hex_literal::hex;
+    use twizzler_kernel_macros::kernel_test;
+
+    use super::*;
+
+    #[kernel_test]
+    fn test_hashing() {
+        let expected = hex!("09ca7e4eaa6e8ae9c7d261167129184883644d07dfba7cbfbc4c8a2e08360d5b");
+        let hash = sha256(b"hello, world");
+        assert_eq!(hash[..], expected);
+    }
+
+    #[kernel_test]
+    fn test_signature() {
+        let key = [
+            168, 182, 114, 184, 168, 191, 237, 9, 90, 139, 135, 141, 26, 180, 247, 51, 86, 17, 197,
+            11, 229, 2, 25, 252, 9, 84, 135, 246, 235, 97, 11, 60,
+        ];
+        let private_key = SigningKey::from_slice(&key).unwrap();
+        let message =
+            b"ECDSA proves knowledge of a secret number in the context of a single message";
+        let signature: Signature = sign(&private_key, message);
+
+        let pub_key: VerifyingKey = private_key.into();
+        verify(&pub_key, message, signature).expect("should be a valid signature");
+    }
+}

--- a/src/kernel/src/main.rs
+++ b/src/kernel/src/main.rs
@@ -25,6 +25,7 @@ pub mod log;
 pub mod arch;
 mod clock;
 mod condvar;
+mod crypto;
 mod device;
 mod idcounter;
 mod image;


### PR DESCRIPTION
A few notes:

1. I haven't yet checked whether SSE/SIMD registers are used, although I am pretty sure I disabled them (with the `force-soft` flag on `sha2`, a flag which was required to get around a weird LLVM error). That said @dbittman might want to verify those registers don't change (I'm not exactly sure how to check, but I could probably figure it out if Daniel would rather have me do it. If so, any guidance on how to check the value of a register would be appreciated).
2. I didn't do documentation for these functions since they're pretty self explanatory. That said, I'm happy to go back and add docs if you'd like me to.
3. dev-dependencies are not included when running tests, meaning that `hex-literal`, a crate only used in the crypto tests, had to be included into the kernel in order to use it within the tests.
4. I haven't profiled or tried to enable additional potentially performance enhancing features of the crypto crates (see point 2 for one reason why performance enhancing features could be difficult to enable) and so if crypto ends up being a big performance bottleneck then we can look into enabling the crypto crates' asm features to see if that improves performance.