### PR TITLE
Support security context attach.

### DIFF
--- a/src/kernel/src/memory/context/virtmem.rs
+++ b/src/kernel/src/memory/context/virtmem.rs
@@ -730,7 +730,6 @@ pub fn page_fault(addr: VirtAddr, cause: MemoryAccessKind, flags: PageFaultFlags
             if let Some((page, cow)) =
                 obj_page_tree.get_page(page_number, cause == MemoryAccessKind::Write)
             {
-                // TODO: select user context here.
                 ctx.with_arch(sctx_id, |arch| {
                     // TODO: don't need all three every time.
                     arch.unmap(
@@ -752,7 +751,6 @@ pub fn page_fault(addr: VirtAddr, cause: MemoryAccessKind, flags: PageFaultFlags
                 let (page, cow) = obj_page_tree
                     .get_page(page_number, cause == MemoryAccessKind::Write)
                     .unwrap();
-                // TODO: select user context here.
                 ctx.with_arch(sctx_id, |arch| {
                     // TODO: don't need all three every time.
                     arch.unmap(

--- a/src/kernel/src/memory/context/virtmem.rs
+++ b/src/kernel/src/memory/context/virtmem.rs
@@ -178,6 +178,9 @@ impl VirtContext {
 
     pub fn register_sctx(&self, sctx: ObjID, arch: ArchContext) {
         let mut secctx = self.secctx.lock();
+        if secctx.contains_key(&sctx) {
+            return;
+        }
         secctx.insert(sctx, arch);
         // Rebuild the target cache. We have to do it this way because we cannot allocate
         // memory while holding the target_cache lock (as it's a spinlock).
@@ -667,6 +670,9 @@ pub fn page_fault(addr: VirtAddr, cause: MemoryAccessKind, flags: PageFaultFlags
             return;
         }
 
+        let sctx_id = current_thread_ref()
+            .map(|ct| ct.secctx.active_id())
+            .unwrap_or(KERNEL_SCTX);
         let user_ctx = current_memory_context();
         let (ctx, is_kern_obj) = if addr.is_kernel_object_memory() {
             assert!(!flags.contains(PageFaultFlags::USER));
@@ -725,7 +731,7 @@ pub fn page_fault(addr: VirtAddr, cause: MemoryAccessKind, flags: PageFaultFlags
                 obj_page_tree.get_page(page_number, cause == MemoryAccessKind::Write)
             {
                 // TODO: select user context here.
-                ctx.with_arch(KERNEL_SCTX, |arch| {
+                ctx.with_arch(sctx_id, |arch| {
                     // TODO: don't need all three every time.
                     arch.unmap(
                         info.mapping_cursor(page_number.as_byte_offset(), PageNumber::PAGE_SIZE),
@@ -747,7 +753,7 @@ pub fn page_fault(addr: VirtAddr, cause: MemoryAccessKind, flags: PageFaultFlags
                     .get_page(page_number, cause == MemoryAccessKind::Write)
                     .unwrap();
                 // TODO: select user context here.
-                ctx.with_arch(KERNEL_SCTX, |arch| {
+                ctx.with_arch(sctx_id, |arch| {
                     // TODO: don't need all three every time.
                     arch.unmap(
                         info.mapping_cursor(page_number.as_byte_offset(), PageNumber::PAGE_SIZE),

--- a/src/kernel/src/syscall/object.rs
+++ b/src/kernel/src/syscall/object.rs
@@ -12,6 +12,7 @@ use twizzler_abi::{
 };
 
 use crate::{
+    arch::context::ArchContext,
     memory::context::{Context, ContextRef},
     mutex::Mutex,
     obj::{LookupFlags, Object, ObjectRef},
@@ -177,7 +178,10 @@ pub fn sys_unbind_handle(id: ObjID) {
 pub fn sys_sctx_attach(id: ObjID) -> Result<u32, SctxAttachError> {
     let sctx = get_sctx(id)?;
 
-    current_thread_ref().unwrap().secctx.attach(sctx);
+    current_memory_context()
+        .unwrap()
+        .register_sctx(sctx.id(), ArchContext::new());
+    current_thread_ref().unwrap().secctx.attach(sctx)?;
 
     Ok(0)
 }

--- a/src/kernel/src/syscall/thread.rs
+++ b/src/kernel/src/syscall/thread.rs
@@ -38,6 +38,9 @@ pub fn thread_ctrl(cmd: ThreadControl, arg: u64) -> (u64, u64) {
             crate::sched::schedule(true);
         }
         ThreadControl::GetSelfId => return current_thread_ref().unwrap().objid().split(),
+        ThreadControl::GetActiveSctxId => {
+            return current_thread_ref().unwrap().secctx.active_id().split()
+        }
         _ => todo!(),
     }
     (0, 0)

--- a/src/lib/twizzler-abi/src/syscall/security.rs
+++ b/src/lib/twizzler-abi/src/syscall/security.rs
@@ -32,6 +32,9 @@ pub enum SctxAttachError {
     /// Permission denied.
     #[error("permission denied")]
     PermissionDenied = 3,
+    /// Permission denied.
+    #[error("already attached")]
+    AlreadyAttached = 4,
 }
 
 impl core::error::Error for SctxAttachError {}
@@ -43,7 +46,7 @@ pub fn sys_sctx_attach(id: ObjID) -> Result<(), SctxAttachError> {
     convert_codes_to_result(
         code,
         val,
-        |c, _| c == 0,
+        |c, _| c == 1,
         |_, _| (),
         |_, v| SctxAttachError::from(v),
     )

--- a/src/lib/twizzler-abi/src/syscall/thread_control.rs
+++ b/src/lib/twizzler-abi/src/syscall/thread_control.rs
@@ -57,6 +57,8 @@ pub enum ThreadControl {
     ResumeFromUpcall = 16,
     /// Get the repr ID of the calling thread.
     GetSelfId = 17,
+    /// Get the ID of the active security context.
+    GetActiveSctxId = 18,
 }
 
 /// Exit the thread. The code will be written to the [crate::thread::ThreadRepr] for the current
@@ -88,6 +90,17 @@ pub fn sys_thread_settls(tls: u64) {
 /// Get the repr ID of the calling thread.
 pub fn sys_thread_self_id() -> ObjID {
     let (hi, lo) = unsafe { raw_syscall(Syscall::ThreadCtrl, &[ThreadControl::GetSelfId as u64]) };
+    ObjID::new_from_parts(hi, lo)
+}
+
+/// Get the active security context ID for the calling thread.
+pub fn sys_thread_active_sctx_id() -> ObjID {
+    let (hi, lo) = unsafe {
+        raw_syscall(
+            Syscall::ThreadCtrl,
+            &[ThreadControl::GetActiveSctxId as u64],
+        )
+    };
     ObjID::new_from_parts(hi, lo)
 }
 


### PR DESCRIPTION
Adds support for attaching to security contexts, and fixes selecting the current active context on page fault and the return handling for the attach syscall. Also add support for reading the current active context.