### PR TITLE
Upcall support for aarch64

### DIFF
--- a/src/kernel/src/arch/aarch64/exception.rs
+++ b/src/kernel/src/arch/aarch64/exception.rs
@@ -139,7 +139,7 @@ pub struct ExceptionContext {
 }
 
 impl ExceptionContext {
-    // save the register context onto the stack to be used by upcall handler
+    // Save the register context onto the stack to be used by upcall handler
     // and modify the current register state to prepare a jump into the
     // upcall handler.
     pub(super) fn setup_upcall(
@@ -277,6 +277,44 @@ impl ExceptionContext {
         self.x1 = data_start;
 
         true
+    }
+
+    // Restore all register state from the upcall frame by overwriting our current registers
+    pub(super) unsafe fn restore_from_upcall(&mut self, frame: &UpcallFrame) {
+        self.x0 = frame.x0;
+        self.x1 = frame.x1;
+        self.x2 = frame.x2;
+        self.x3 = frame.x3;
+        self.x4 = frame.x4;
+        self.x5 = frame.x5;
+        self.x6 = frame.x6;
+        self.x7 = frame.x7;
+        self.x8 = frame.x8;
+        self.x9 = frame.x9;
+        self.x10 = frame.x10;
+        self.x11 = frame.x11;
+        self.x12 = frame.x12;
+        self.x13 = frame.x13;
+        self.x14 = frame.x14;
+        self.x15 = frame.x15;
+        self.x16 = frame.x16;
+        self.x17 = frame.x17;
+        self.x18 = frame.x18;
+        self.x19 = frame.x19;
+        self.x20 = frame.x20;
+        self.x21 = frame.x21;
+        self.x22 = frame.x22;
+        self.x23 = frame.x23;
+        self.x24 = frame.x24;
+        self.x25 = frame.x25;
+        self.x26 = frame.x26;
+        self.x27 = frame.x27;
+        self.x28 = frame.x28;
+        self.x29 = frame.x29;
+        self.x30 = frame.fp;
+        self.sp = frame.sp;
+        self.elr = frame.pc;
+        self.spsr = frame.spsr;
     }
 }
 

--- a/src/kernel/src/arch/aarch64/exception.rs
+++ b/src/kernel/src/arch/aarch64/exception.rs
@@ -7,17 +7,20 @@
 /// We currently do not handle nested exceptions.
 use core::fmt::{Display, Formatter, Result};
 
-use arm64::registers::{ESR_EL1, VBAR_EL1};
+use arm64::registers::{ESR_EL1, TPIDRRO_EL0, TPIDR_EL0, VBAR_EL1};
 use registers::{
     interfaces::{Readable, Writeable},
     registers::InMemoryRegister,
 };
 use twizzler_abi::{
     arch::syscall::SYSCALL_MAGIC,
-    upcall::{MemoryAccessKind, UpcallFrame},
+    object::{ObjID, MAX_SIZE, NULLPAGE_SIZE},
+    upcall::{
+        MemoryAccessKind, UpcallData, UpcallFrame, UpcallHandlerFlags, UpcallInfo, UpcallTarget,
+        UPCALL_EXIT_CODE,
+    },
 };
 
-use super::thread::UpcallAble;
 use crate::{
     memory::{context::virtmem::PageFaultFlags, VirtAddr},
     thread::current_thread_ref,
@@ -135,6 +138,148 @@ pub struct ExceptionContext {
     pub far: u64,
 }
 
+impl ExceptionContext {
+    // save the register context onto the stack to be used by upcall handler
+    // and modify the current register state to prepare a jump into the
+    // upcall handler.
+    pub(super) fn setup_upcall(
+        &mut self,
+        // pub fn set_upcall2<T: UpcallAble + Copy>(
+        // regs: &mut T,
+        target: UpcallTarget,
+        info: UpcallInfo,
+        source_ctx: ObjID,
+        thread_id: ObjID,
+        sup: bool,
+    ) -> bool {
+        // Stack must always be 16-bytes aligned.
+        const MIN_STACK_ALIGN: usize = 16;
+        // We have to leave room for the red zone.
+        const RED_ZONE_SIZE: usize = 512;
+
+        // Minimum amount of stack space we need left over for execution
+        const MIN_STACK_REMAINING: usize = 1024 * 1024; // 1MB
+
+        let current_stack_pointer = self.sp;
+        // We only switch contexts if it was requested and we aren't in that context.
+        // TODO: once security contexts are more fully implemented, we'll need to change this code.
+
+        // TODO: verify that the stack ranges are correct here
+        let switch_to_super = sup
+            && !(current_stack_pointer as usize >= target.super_stack
+                && (current_stack_pointer as usize)
+                    < (target.super_stack + target.super_stack_size));
+
+        let target_addr = if switch_to_super {
+            target.super_address
+        } else {
+            target.self_address
+        };
+
+        // If the address is not canonical, leave.
+        let Ok(target_addr) = VirtAddr::new(target_addr as u64) else {
+            logln!("warning -- thread aborted to non-canonical jump address for upcall");
+            return false;
+        };
+
+        let upcall_data = UpcallData {
+            info,
+            flags: if switch_to_super {
+                UpcallHandlerFlags::SWITCHED_CONTEXT
+            } else {
+                UpcallHandlerFlags::empty()
+            },
+            source_ctx,
+            thread_id,
+        };
+
+        // Step 1: determine where we are going to put the frame. If we have
+        // a supervisor stack, and we aren't currently on it, use that. Otherwise,
+        // use the current stack pointer.
+        let stack_pointer = if switch_to_super {
+            // (target.super_stack + target.super_stack_size) as u64
+            todo!("supervisor stack requested")
+        } else {
+            current_stack_pointer
+        };
+
+        if stack_pointer == 0 {
+            logln!("warning -- thread aborted to null stack pointer for upcall");
+            return false;
+        }
+
+        // TODO: once security contexts are more implemented, we'll need to do a bunch of permission
+        // checks on the stack and target jump addresses.
+
+        // Don't touch the red zone for the function we were in.
+        let stack_top = stack_pointer - RED_ZONE_SIZE as u64;
+        let stack_top = stack_top & (!(MIN_STACK_ALIGN as u64 - 1));
+
+        // Step 2: compute all the sizes for things we're going to shuffle around, and check
+        // if we even have enough space.
+        let data_size = core::mem::size_of::<UpcallData>();
+        let data_size = (data_size + MIN_STACK_ALIGN) & !(MIN_STACK_ALIGN - 1);
+        let frame_size = core::mem::size_of::<UpcallFrame>();
+        let data_start = stack_top - data_size as u64;
+        let frame_start = data_start - frame_size as u64;
+
+        let total_size = data_size + frame_size + RED_ZONE_SIZE;
+        let total_size = (total_size + MIN_STACK_ALIGN) & !(MIN_STACK_ALIGN - 1);
+
+        if switch_to_super {
+            if target.super_stack_size < (total_size + MIN_STACK_REMAINING) {
+                logln!("warning -- thread aborted due to insufficient super stack space");
+                return false;
+            }
+        } else {
+            let stack_object_base = (stack_top as usize / MAX_SIZE) * MAX_SIZE + NULLPAGE_SIZE;
+            if stack_object_base + (total_size + MIN_STACK_REMAINING) >= stack_pointer as usize {
+                logln!("warning -- thread aborted due to insufficient stack space");
+                return false;
+            }
+        }
+
+        // Step 3: write out the frame and the data into the stack.
+        let data_ptr = data_start as usize as *mut UpcallData;
+        let frame_ptr = frame_start as usize as *mut UpcallFrame;
+        // convert the calling context into an upcall frame
+        let mut frame: UpcallFrame = (*self).into();
+
+        // Step 3a: we need to fill out the TLS register state
+        frame.tpidr = TPIDR_EL0.get();
+        frame.tpidrro = TPIDRRO_EL0.get();
+
+        // TODO: save fpu registers / sse state
+
+        // write all register state and upcall information
+        unsafe {
+            data_ptr.write(upcall_data);
+            frame_ptr.write(frame);
+        }
+
+        // Step 4: final alignment, and then call into the context code
+        // to do the final setup of registers for the upcall.
+        let stack_start = frame_start - MIN_STACK_ALIGN as u64;
+        let stack_start = stack_start & !(MIN_STACK_ALIGN as u64 - 1);
+        // We have to enter with a mis-aligned stack, so that the function prelude
+        // of the receiver will re-align it. In this case, we control the ABI, so
+        // we preserve this just for consistency.
+        let stack_start = stack_start - core::mem::size_of::<u64>() as u64;
+
+        // write down the arguments and things needed for the upcall
+        // set the jump target
+        self.elr = target_addr.raw();
+        // set the stack pointer
+        self.sp = stack_start;
+        // set the upcall frame pointer as the first argument
+        self.x0 = frame_start;
+        // set the upcall info pointer as the second argument
+        self.x1 = data_start;
+
+        true
+    }
+}
+
 impl Display for ExceptionContext {
     fn fmt(&self, f: &mut Formatter<'_>) -> Result {
         writeln!(f, "ExceptionContext (registers x0-x30):")?;
@@ -186,19 +331,46 @@ impl Display for ExceptionContext {
     }
 }
 
-impl UpcallAble for ExceptionContext {
-    fn set_upcall(&mut self, _target: usize, _frame: u64, _info: u64, _stack: u64) {
-        todo!("set_upcall for ExceptionContext")
-    }
-
-    fn get_stack_top(&self) -> u64 {
-        todo!("get_stat for ExceptionContext")
-    }
-}
-
 impl From<ExceptionContext> for UpcallFrame {
-    fn from(_ctx: ExceptionContext) -> Self {
-        todo!("conversion from ExceptionContext to UpcallFrame")
+    fn from(ctx: ExceptionContext) -> Self {
+        let mut frame = UpcallFrame::default();
+
+        frame.x0 = ctx.x0;
+        frame.x1 = ctx.x1;
+        frame.x2 = ctx.x2;
+        frame.x3 = ctx.x3;
+        frame.x4 = ctx.x4;
+        frame.x5 = ctx.x5;
+        frame.x6 = ctx.x6;
+        frame.x7 = ctx.x7;
+        frame.x8 = ctx.x8;
+        frame.x9 = ctx.x9;
+        frame.x10 = ctx.x10;
+        frame.x11 = ctx.x11;
+        frame.x12 = ctx.x12;
+        frame.x13 = ctx.x13;
+        frame.x14 = ctx.x14;
+        frame.x15 = ctx.x15;
+        frame.x16 = ctx.x16;
+        frame.x17 = ctx.x17;
+        frame.x18 = ctx.x18;
+        frame.x19 = ctx.x19;
+        frame.x20 = ctx.x20;
+        frame.x21 = ctx.x21;
+        frame.x22 = ctx.x22;
+        frame.x23 = ctx.x23;
+        frame.x24 = ctx.x24;
+        frame.x25 = ctx.x25;
+        frame.x26 = ctx.x26;
+        frame.x27 = ctx.x27;
+        frame.x28 = ctx.x28;
+        frame.x29 = ctx.x29;
+        frame.fp = ctx.x30;
+        frame.sp = ctx.sp;
+        frame.pc = ctx.elr;
+        frame.spsr = ctx.spsr;
+
+        frame
     }
 }
 

--- a/src/kernel/src/arch/aarch64/syscall.rs
+++ b/src/kernel/src/arch/aarch64/syscall.rs
@@ -169,7 +169,6 @@ fn handle_upcall(ctx: &mut ExceptionContext) {
             // using the upcall frame given to us
             ctx.restore_from_upcall(&up_frame);
         }
-        emerglogln!("registers set ... {}", ctx);
     }
     // from here we return using the normal syscall/exception return path
 }

--- a/src/kernel/src/arch/aarch64/syscall.rs
+++ b/src/kernel/src/arch/aarch64/syscall.rs
@@ -9,7 +9,7 @@ use arm64::registers::{ELR_EL1, SPSR_EL1, SP_EL0};
 use registers::interfaces::Writeable;
 use twizzler_abi::upcall::UpcallFrame;
 
-use super::{exception::ExceptionContext, thread::UpcallAble};
+use super::exception::ExceptionContext;
 use crate::{memory::VirtAddr, syscall::SyscallContext};
 
 /// The register state needed to transition between kernel and user.
@@ -29,21 +29,6 @@ pub struct Armv8SyscallContext {
     x7: u64,
     elr: u64,
     sp: u64,
-}
-impl From<Armv8SyscallContext> for UpcallFrame {
-    fn from(_int: Armv8SyscallContext) -> Self {
-        todo!()
-    }
-}
-
-impl UpcallAble for Armv8SyscallContext {
-    fn set_upcall(&mut self, _target: usize, _frame: u64, _info: u64, _stack: u64) {
-        todo!()
-    }
-
-    fn get_stack_top(&self) -> u64 {
-        todo!()
-    }
 }
 
 // Arguments 0-5 are passed in via registers x0-x5,

--- a/src/kernel/src/arch/aarch64/thread.rs
+++ b/src/kernel/src/arch/aarch64/thread.rs
@@ -124,7 +124,6 @@ impl Thread {
         if !self.arch.entry_registers.borrow().is_null() {
             let ok = {
                 let regs = unsafe { &mut *(*self.arch.entry_registers.borrow()) };
-                emerglogln!("entry registers: {}", regs.clone());
                 regs.setup_upcall(target, info, source_ctx, self.objid(), sup)
             };
             if !ok {

--- a/src/lib/twizzler-abi/src/arch/aarch64/upcall.rs
+++ b/src/lib/twizzler-abi/src/arch/aarch64/upcall.rs
@@ -2,41 +2,101 @@
 use crate::upcall::{UpcallData, UpcallInfo};
 
 /// Arch-specific frame info for upcall.
-#[derive(Clone, Debug)]
+#[derive(Clone, Copy, Debug, Default)]
 #[repr(C)]
-pub struct UpcallFrame {}
+pub struct UpcallFrame {
+    // general purpose registers
+    pub x0: u64,
+    pub x1: u64,
+    pub x2: u64,
+    pub x3: u64,
+    pub x4: u64,
+    pub x5: u64,
+    pub x6: u64,
+    pub x7: u64,
+    pub x8: u64,
+    pub x9: u64,
+    pub x10: u64,
+    pub x11: u64,
+    pub x12: u64,
+    pub x13: u64,
+    pub x14: u64,
+    pub x15: u64,
+    pub x16: u64,
+    pub x17: u64,
+    pub x18: u64,
+
+    // callee-saved registers
+    pub x19: u64,
+    pub x20: u64,
+    pub x21: u64,
+    pub x22: u64,
+    pub x23: u64,
+    pub x24: u64,
+    pub x25: u64,
+    pub x26: u64,
+    pub x27: u64,
+    pub x28: u64,
+
+    /// link register
+    pub x29: u64,
+    /// frame pointer (i.e., x30)
+    pub fp: u64,
+    /// The stack pointer, depending on the context where the exception
+    /// occurred, this is either sp_el0 or sp_el1
+    pub sp: u64,
+    /// The program counter. The address where the exception occurred (i.e., ELR_EL1)
+    pub pc: u64,
+    /// The state of the processor (SPSR_EL1). Determines execution environment (e.g., interrupts)
+    pub spsr: u64,
+    // Thread local storage for user space
+    pub tpidr: u64,
+    pub tpidrro: u64,
+
+    // security context
+    pub prior_ctx: crate::object::ObjID,
+}
 
 impl UpcallFrame {
     /// Get the instruction pointer of the frame.
     pub fn ip(&self) -> usize {
-        todo!()
+        self.pc as usize
     }
 
     /// Get the stack pointer of the frame.
     pub fn sp(&self) -> usize {
-        todo!()
+        self.sp as usize
     }
 
     /// Get the base pointer of the frame.
     pub fn bp(&self) -> usize {
-        todo!()
+        self.fp as usize
     }
 }
 
 #[no_mangle]
 #[cfg(feature = "runtime")]
 pub(crate) unsafe extern "C" fn upcall_entry2(
-    _frame: *mut UpcallFrame,
-    _info: *const UpcallInfo,
+    frame: *mut UpcallFrame,
+    data: *const UpcallData,
 ) -> ! {
-    todo!()
+    use crate::runtime::__twz_get_runtime;
+
+    crate::runtime::upcall::upcall_rust_entry(&*frame, &*data);
+    let runtime = __twz_get_runtime();
+    runtime.abort()
 }
 
 #[cfg(feature = "runtime")]
 #[no_mangle]
 pub(crate) unsafe extern "C-unwind" fn upcall_entry(
-    _frame: *mut UpcallFrame,
-    _info: *const UpcallData,
+    frame: *mut UpcallFrame,
+    data: *const UpcallData,
 ) -> ! {
-    todo!()
+    core::arch::asm!(
+        "b upcall_entry2",
+        in("x0") frame,
+        in("x1") data,
+        options(noreturn)
+    );
 }


### PR DESCRIPTION
This PR implements basic queue and restore upcall operations for aarch64. The implementation largely follows the x86 version, only with differences due to the exception/interrupt handling paths. 

Functionality was tested with a "simple" unmapped page test. The test writes to some region of memory that is not mapped, an exception is triggered in the kernel which is sent as an upcall, the upcall handler patches that address to some valid mapped region of memory, and the test then checks if the correct value was written and if the upcall handler modified some register state. 

Now the ARM kernel can handle basic upcalls sent to user space. Switching to a supervisor stack is left for future work.