### PR TITLE
Port parking_lot.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4069,3 +4069,8 @@ name = "zeroize"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+
+[[patch.unused]]
+name = "parking_lot"
+version = "0.12.3"
+source = "git+https://github.com/twizzler-operating-system/parking_lot.git?branch=twizzler#81ce3c45b8ab118bc8ab543b435e4fe4fe509ca9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,3 +59,4 @@ async-io = { git = "https://github.com/twizzler-operating-system/async-io.git", 
 async-executor = { git = "https://github.com/twizzler-operating-system/async-executor.git", branch = "twizzler" }
 twizzler-futures = { path = "src/lib/twizzler-futures" }
 twizzler-abi = { path = "src/lib/twizzler-abi" }
+parking_lot = { git = "https://github.com/twizzler-operating-system/parking_lot.git", branch = "twizzler" }


### PR DESCRIPTION
This PR adds a ported version of parking_lot to [patch.crates-io]. The parking_lot crate provides a set of synchronizations primitives with riches semantics than the ones from std, and is widely used in the crate ecosystem. The port effort is small, as the only OS-dependent code is in parking_lot_core/thread_parker/<os>.rs.

The change in this repo is small, as much of the actual work is in [our parking_lot fork (link to diff)](https://github.com/twizzler-operating-system/parking_lot/commit/81ce3c45b8ab118bc8ab543b435e4fe4fe509ca9). That code should be reviewed, but note that it is basically a direct copy of the linux version (see linux.rs in the same directory as twizzler.rs).