### PR TITLE
Disable interrupts before return to user during userinit.

### DIFF
--- a/src/kernel/src/arch/amd64/mod.rs
+++ b/src/kernel/src/arch/amd64/mod.rs
@@ -65,6 +65,7 @@ pub unsafe fn jump_to_user(
 ) {
     use crate::syscall::SyscallContext;
     let ctx = syscall::X86SyscallContext::create_jmp_context(target, stack, arg);
+    crate::interrupt::set(false);
     crate::thread::exit_kernel();
 
     {


### PR DESCRIPTION
Fixes a race condition where the kernel could see an interrupt occurring after the return_to_user code called by userinit resets the FS segment value, but before we have switched to user. This causes all TLS variables in the kernel to cause a crash on the next load. The fix mirrors the exit path code for syscalls better.