### PR TITLE
Initial monitor state management overhaul

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2590,7 +2590,7 @@ version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a908a6e00f1fdd0dfd9c0eb08ce85126f6d8bbda50017e74bc4a4b7d4a926a4"
 dependencies = [
- "bitflags 2.4.1",
+ "bitflags 2.6.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1357,6 +1357,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "happylock"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1949ae82dd58a6d8a76ec4761e3b1e01ffd9eb3871cb2d8eba6eda8e66a7b3d6"
+dependencies = [
+ "lock_api",
+ "once_cell",
+ "parking_lot",
+ "thread_local",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1968,9 +1980,11 @@ name = "monitor"
 version = "0.1.0"
 dependencies = [
  "dynlink",
+ "happylock",
  "lazy_static",
  "miette",
  "monitor-api",
+ "parking_lot",
  "secgate",
  "static_assertions",
  "talc",
@@ -2275,6 +2289,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb813b8af86854136c6922af0598d719255ecb2179515e6e7730d468f05c9cae"
 
 [[package]]
+name = "parking_lot"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
+dependencies = [
+ "lock_api",
+ "parking_lot_core",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
+dependencies = [
+ "cfg-if 1.0.0",
+ "libc",
+ "redox_syscall 0.5.3",
+ "smallvec",
+ "windows-targets 0.52.4",
+]
+
+[[package]]
 name = "pathdiff"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2487,6 +2524,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
 dependencies = [
  "bitflags 1.3.2",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a908a6e00f1fdd0dfd9c0eb08ce85126f6d8bbda50017e74bc4a4b7d4a926a4"
+dependencies = [
+ "bitflags 2.4.1",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1861,9 +1861,8 @@ dependencies = [
 
 [[package]]
 name = "lock_api"
-version = "0.4.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c168f8615b12bc01f9c17e2eb0cc07dcae1940121185446edc3744920e8ef45"
+version = "0.4.12"
+source = "git+https://github.com/twizzler-operating-system/parking_lot.git?branch=twizzler#81ce3c45b8ab118bc8ab543b435e4fe4fe509ca9"
 dependencies = [
  "autocfg",
  "scopeguard",
@@ -2291,8 +2290,7 @@ checksum = "bb813b8af86854136c6922af0598d719255ecb2179515e6e7730d468f05c9cae"
 [[package]]
 name = "parking_lot"
 version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
+source = "git+https://github.com/twizzler-operating-system/parking_lot.git?branch=twizzler#81ce3c45b8ab118bc8ab543b435e4fe4fe509ca9"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -2301,13 +2299,13 @@ dependencies = [
 [[package]]
 name = "parking_lot_core"
 version = "0.9.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
+source = "git+https://github.com/twizzler-operating-system/parking_lot.git?branch=twizzler#81ce3c45b8ab118bc8ab543b435e4fe4fe509ca9"
 dependencies = [
  "cfg-if 1.0.0",
  "libc",
  "redox_syscall 0.5.3",
  "smallvec",
+ "twizzler-abi",
  "windows-targets 0.52.4",
 ]
 
@@ -4115,8 +4113,3 @@ name = "zeroize"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
-
-[[patch.unused]]
-name = "parking_lot"
-version = "0.12.3"
-source = "git+https://github.com/twizzler-operating-system/parking_lot.git?branch=twizzler#81ce3c45b8ab118bc8ab543b435e4fe4fe509ca9"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,8 +37,8 @@ initrd = [
     "crate:netmgr",
     "crate:nettest",
     "crate:pager",
-    #"lib:twz-rt",
-    #"lib:monitor",
+    "lib:twz-rt",
+    "lib:monitor",
     #"third-party:hello-world-rs"
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,3 +60,4 @@ async-executor = { git = "https://github.com/twizzler-operating-system/async-exe
 twizzler-futures = { path = "src/lib/twizzler-futures" }
 twizzler-abi = { path = "src/lib/twizzler-abi" }
 parking_lot = { git = "https://github.com/twizzler-operating-system/parking_lot.git", branch = "twizzler" }
+lock_api = { git = "https://github.com/twizzler-operating-system/parking_lot.git", branch = "twizzler" }

--- a/src/kernel/src/initrd.rs
+++ b/src/kernel/src/initrd.rs
@@ -59,7 +59,7 @@ pub fn init(modules: &[BootModule]) {
             }
             let obj = Arc::new(obj);
             obj::register_object(obj.clone());
-            if e.filename().as_str() == "init" {
+            if e.filename().as_str() == "bootstrap" {
                 boot_objects.init = Some(obj.clone());
             }
             boot_objects

--- a/src/kernel/src/initrd.rs
+++ b/src/kernel/src/initrd.rs
@@ -59,7 +59,7 @@ pub fn init(modules: &[BootModule]) {
             }
             let obj = Arc::new(obj);
             obj::register_object(obj.clone());
-            if e.filename().as_str() == "bootstrap" {
+            if e.filename().as_str() == "init" {
                 boot_objects.init = Some(obj.clone());
             }
             boot_objects

--- a/src/lib/twizzler-abi/src/runtime/debug.rs
+++ b/src/lib/twizzler-abi/src/runtime/debug.rs
@@ -74,4 +74,8 @@ impl DebugRuntime for MinimalRuntime {
     ) -> core::ffi::c_int {
         0
     }
+
+    fn next_library_id(&self, _id: LibraryId) -> Option<LibraryId> {
+        None
+    }
 }

--- a/src/lib/twizzler-runtime-api/src/lib.rs
+++ b/src/lib/twizzler-runtime-api/src/lib.rs
@@ -745,6 +745,10 @@ pub trait DebugRuntime {
     fn get_full_mapping(&self, lib: &Library) -> Option<ObjectHandle>;
     /// Handler for calls to the dl_iterate_phdr call.
     fn iterate_phdr(&self, f: &mut dyn FnMut(DlPhdrInfo) -> core::ffi::c_int) -> core::ffi::c_int;
+    /// Get the library ID immediately following the given one.
+    fn next_library_id(&self, id: LibraryId) -> Option<LibraryId> {
+        Some(LibraryId(id.0 + 1))
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Ord, Eq)]

--- a/src/runtime/monitor-api/src/lib.rs
+++ b/src/runtime/monitor-api/src/lib.rs
@@ -15,7 +15,7 @@ use std::{
 };
 
 use dynlink::tls::{Tcb, TlsRegion};
-use twizzler_abi::object::ObjID;
+use twizzler_abi::object::{ObjID, MAX_SIZE, NULLPAGE_SIZE};
 
 mod gates {
     include! {"../../monitor/secapi/gates.rs"}
@@ -163,3 +163,21 @@ impl SharedCompConfig {
 }
 
 pub use gates::LibraryInfo;
+
+/// Contains raw mapping addresses, for use when translating to object handles for the runtime.
+#[derive(Copy, Clone, PartialEq, PartialOrd, Ord, Eq)]
+pub struct MappedObjectAddrs {
+    pub slot: usize,
+    pub start: usize,
+    pub meta: usize,
+}
+
+impl MappedObjectAddrs {
+    pub fn new(slot: usize) -> Self {
+        Self {
+            start: slot * MAX_SIZE,
+            meta: (slot + 1) * MAX_SIZE - NULLPAGE_SIZE,
+            slot,
+        }
+    }
+}

--- a/src/runtime/monitor/Cargo.toml
+++ b/src/runtime/monitor/Cargo.toml
@@ -25,6 +25,8 @@ monitor-api = { path = "../monitor-api" }
 static_assertions = "1.1"
 lazy_static = "1.4"
 talc = "3.1"
+happylock = "0.3"
+parking_lot = "*"
 
 [features]
 secgate-impl = []

--- a/src/runtime/monitor/src/api.rs
+++ b/src/runtime/monitor/src/api.rs
@@ -1,0 +1,3 @@
+use twizzler_runtime_api::ObjID;
+
+pub const MONITOR_INSTANCE_ID: ObjID = ObjID::new(0);

--- a/src/runtime/monitor/src/api.rs
+++ b/src/runtime/monitor/src/api.rs
@@ -1,3 +1,4 @@
 use twizzler_runtime_api::ObjID;
 
+/// Reserved instance ID for the security monitor.
 pub const MONITOR_INSTANCE_ID: ObjID = ObjID::new(0);

--- a/src/runtime/monitor/src/lib.rs
+++ b/src/runtime/monitor/src/lib.rs
@@ -2,6 +2,7 @@
 #![feature(thread_local)]
 #![feature(c_str_literals)]
 #![feature(new_uninit)]
+#![feature(hash_extract_if)]
 
 use std::sync::{Arc, Mutex};
 
@@ -29,6 +30,7 @@ mod state;
 mod thread;
 mod upcall;
 
+mod api;
 mod mon;
 
 #[path = "../secapi/gates.rs"]

--- a/src/runtime/monitor/src/lib.rs
+++ b/src/runtime/monitor/src/lib.rs
@@ -29,6 +29,8 @@ mod state;
 mod thread;
 mod upcall;
 
+mod mon;
+
 #[path = "../secapi/gates.rs"]
 mod gates;
 
@@ -95,7 +97,7 @@ fn monitor_init(state: Arc<Mutex<MonitorState>>) -> miette::Result<()> {
         }
     }
 
-    load_hello_world_test(&state).unwrap();
+    //load_hello_world_test(&state).unwrap();
 
     Ok(())
 }

--- a/src/runtime/monitor/src/mon/compartment.rs
+++ b/src/runtime/monitor/src/mon/compartment.rs
@@ -1,0 +1,1 @@
+pub struct CompartmentMgr {}

--- a/src/runtime/monitor/src/mon/mod.rs
+++ b/src/runtime/monitor/src/mon/mod.rs
@@ -1,0 +1,29 @@
+use std::sync::OnceLock;
+
+use happylock::RwLock;
+
+use self::space::Unmapper;
+
+mod compartment;
+mod space;
+mod thread;
+
+pub struct Monitor {
+    space: RwLock<space::Space>,
+    thread_mgr: RwLock<thread::ThreadMgr>,
+    compartments: RwLock<compartment::CompartmentMgr>,
+    dynlink: RwLock<dynlink::context::Context>,
+    unmapper: Unmapper,
+}
+
+static MONITOR: OnceLock<Monitor> = OnceLock::new();
+
+pub fn get_monitor() -> &'static Monitor {
+    MONITOR.get().unwrap()
+}
+
+pub fn set_monitor(monitor: Monitor) {
+    if MONITOR.set(monitor).is_err() {
+        panic!("second call to set_monitor");
+    }
+}

--- a/src/runtime/monitor/src/mon/mod.rs
+++ b/src/runtime/monitor/src/mon/mod.rs
@@ -4,9 +4,9 @@ use happylock::RwLock;
 
 use self::space::Unmapper;
 
-mod compartment;
-mod space;
-mod thread;
+pub(crate) mod compartment;
+pub(crate) mod space;
+pub(crate) mod thread;
 
 pub struct Monitor {
     space: RwLock<space::Space>,

--- a/src/runtime/monitor/src/mon/mod.rs
+++ b/src/runtime/monitor/src/mon/mod.rs
@@ -8,6 +8,12 @@ pub(crate) mod compartment;
 pub(crate) mod space;
 pub(crate) mod thread;
 
+/// A security monitor instance. All monitor logic is implemented as methods for this type.
+/// We split the state into the following components: 'space', managing the virtual memory space and
+/// mapping objects, 'thread_mgr', which manages all threads owned by the monitor (typically, all
+/// threads started by compartments), 'compartments', which manages compartment state, and
+/// 'dynlink', which contains the dynamic linker state. The unmapper allows for background unmapping
+/// and cleanup of objects and handles.
 pub struct Monitor {
     space: RwLock<space::Space>,
     thread_mgr: RwLock<thread::ThreadMgr>,
@@ -18,10 +24,13 @@ pub struct Monitor {
 
 static MONITOR: OnceLock<Monitor> = OnceLock::new();
 
+/// Get the monitor instance. Panics if called before first call to [set_monitor].
 pub fn get_monitor() -> &'static Monitor {
     MONITOR.get().unwrap()
 }
 
+/// Set the monitor instance. Can only be called once. Must be called before any call to
+/// [get_monitor].
 pub fn set_monitor(monitor: Monitor) {
     if MONITOR.set(monitor).is_err() {
         panic!("second call to set_monitor");

--- a/src/runtime/monitor/src/mon/space.rs
+++ b/src/runtime/monitor/src/mon/space.rs
@@ -1,0 +1,119 @@
+use std::{collections::HashMap, sync::Arc};
+
+use monitor_api::MappedObjectAddrs;
+use twizzler_abi::syscall::{sys_object_map, sys_object_unmap, UnmapFlags};
+use twizzler_object::Protections;
+use twizzler_runtime_api::{MapError, MapFlags, ObjID};
+
+use self::handle::{MapHandle, MapHandleInner};
+
+mod handle;
+mod unmapper;
+
+pub use unmapper::Unmapper;
+
+#[derive(Debug, Copy, Clone, PartialEq, PartialOrd, Ord, Eq, Hash)]
+pub struct MapInfo {
+    pub(crate) id: ObjID,
+    pub(crate) flags: MapFlags,
+}
+
+#[derive(Default)]
+pub struct Space {
+    maps: HashMap<MapInfo, MappedObject>,
+}
+
+struct MappedObject {
+    addrs: MappedObjectAddrs,
+    handle_count: usize,
+}
+
+fn mapflags_into_prot(flags: MapFlags) -> Protections {
+    let mut prot = Protections::empty();
+    if flags.contains(MapFlags::READ) {
+        prot.insert(Protections::READ);
+    }
+    if flags.contains(MapFlags::WRITE) {
+        prot.insert(Protections::WRITE);
+    }
+    if flags.contains(MapFlags::EXEC) {
+        prot.insert(Protections::EXEC);
+    }
+    prot
+}
+
+impl Space {
+    pub fn map(&mut self, info: MapInfo) -> Result<MapHandle, MapError> {
+        // Can't use the entry API here because the closure may fail.
+        let item = match self.maps.get_mut(&info) {
+            Some(item) => item,
+            None => {
+                // Not yet mapped, so allocate a slot and map it.
+                let slot = twz_rt::OUR_RUNTIME
+                    .allocate_slot()
+                    .ok_or(MapError::OutOfResources)?;
+
+                let Ok(_) = sys_object_map(
+                    None,
+                    info.id,
+                    slot,
+                    mapflags_into_prot(info.flags),
+                    twizzler_abi::syscall::MapFlags::empty(),
+                ) else {
+                    twz_rt::OUR_RUNTIME.release_slot(slot);
+                    return Err(MapError::InternalError);
+                };
+
+                let map = MappedObject {
+                    addrs: MappedObjectAddrs::new(slot),
+                    handle_count: 0,
+                };
+                self.maps.insert(info, map);
+                // Unwrap-Ok: just inserted.
+                self.maps.get_mut(&info).unwrap()
+            }
+        };
+
+        // New maps will be set to zero, so this is unconditional.
+        item.handle_count += 1;
+        Ok(Arc::new(MapHandleInner::new(info, item.addrs)))
+    }
+
+    pub fn handle_drop(&mut self, info: MapInfo) -> Option<UnmapOnDrop> {
+        // Missing maps in unmap should be ignored.
+        let Some(item) = self.maps.get_mut(&info) else {
+            tracing::warn!("unmap called for missing object {:?}", info);
+            return None;
+        };
+        if item.handle_count == 0 {
+            tracing::error!("unmap called for unmapped object {:?}", info);
+            return None;
+        }
+
+        // Decrement and maybe actually unmap.
+        item.handle_count -= 1;
+        if item.handle_count == 0 {
+            let slot = item.addrs.slot;
+            self.maps.remove(&info);
+            Some(UnmapOnDrop { slot })
+        } else {
+            None
+        }
+    }
+}
+
+// Allows us to call handle_drop and do all the hard work in the caller, since
+// the caller probably had to hold a lock to call these functions.
+pub(crate) struct UnmapOnDrop {
+    slot: usize,
+}
+
+impl Drop for UnmapOnDrop {
+    fn drop(&mut self) {
+        if sys_object_unmap(None, self.slot, UnmapFlags::empty()).is_ok() {
+            twz_rt::OUR_RUNTIME.release_slot(self.slot);
+        } else {
+            tracing::warn!("failed to unmap slot {}", self.slot);
+        }
+    }
+}

--- a/src/runtime/monitor/src/mon/space.rs
+++ b/src/runtime/monitor/src/mon/space.rs
@@ -5,11 +5,12 @@ use twizzler_abi::syscall::{sys_object_map, sys_object_unmap, UnmapFlags};
 use twizzler_object::Protections;
 use twizzler_runtime_api::{MapError, MapFlags, ObjID};
 
-use self::handle::{MapHandle, MapHandleInner};
+use self::handle::MapHandleInner;
 
 mod handle;
 mod unmapper;
 
+pub use handle::MapHandle;
 pub use unmapper::Unmapper;
 
 #[derive(Debug, Copy, Clone, PartialEq, PartialOrd, Ord, Eq, Hash)]

--- a/src/runtime/monitor/src/mon/space.rs
+++ b/src/runtime/monitor/src/mon/space.rs
@@ -14,12 +14,14 @@ pub use handle::MapHandle;
 pub use unmapper::Unmapper;
 
 #[derive(Debug, Copy, Clone, PartialEq, PartialOrd, Ord, Eq, Hash)]
+/// A mapping of an object and flags.
 pub struct MapInfo {
     pub(crate) id: ObjID,
     pub(crate) flags: MapFlags,
 }
 
 #[derive(Default)]
+/// An address space we can map objects into.
 pub struct Space {
     maps: HashMap<MapInfo, MappedObject>,
 }
@@ -44,6 +46,7 @@ fn mapflags_into_prot(flags: MapFlags) -> Protections {
 }
 
 impl Space {
+    /// Map an object into the space.
     pub fn map(&mut self, info: MapInfo) -> Result<MapHandle, MapError> {
         // Can't use the entry API here because the closure may fail.
         let item = match self.maps.get_mut(&info) {
@@ -80,6 +83,8 @@ impl Space {
         Ok(Arc::new(MapHandleInner::new(info, item.addrs)))
     }
 
+    /// Remove an object from the space. The actual unmapping syscall only happens once the returned
+    /// value from this function is dropped.
     pub fn handle_drop(&mut self, info: MapInfo) -> Option<UnmapOnDrop> {
         // Missing maps in unmap should be ignored.
         let Some(item) = self.maps.get_mut(&info) else {

--- a/src/runtime/monitor/src/mon/space/handle.rs
+++ b/src/runtime/monitor/src/mon/space/handle.rs
@@ -1,0 +1,40 @@
+use std::sync::Arc;
+
+use monitor_api::MappedObjectAddrs;
+use twizzler_abi::object::NULLPAGE_SIZE;
+
+use super::MapInfo;
+use crate::mon::get_monitor;
+
+pub struct MapHandleInner {
+    info: MapInfo,
+    map: MappedObjectAddrs,
+}
+
+pub type MapHandle = Arc<MapHandleInner>;
+
+impl MapHandleInner {
+    pub(crate) fn new(info: MapInfo, map: MappedObjectAddrs) -> Self {
+        Self { info, map }
+    }
+
+    pub fn addrs(&self) -> MappedObjectAddrs {
+        self.map
+    }
+
+    pub fn monitor_data_null(&self) -> *mut u8 {
+        self.map.start as *mut u8
+    }
+
+    pub fn monitor_data_base(&self) -> *mut u8 {
+        (self.map.start + NULLPAGE_SIZE) as *mut u8
+    }
+}
+
+impl Drop for MapHandleInner {
+    fn drop(&mut self) {
+        // Toss this work onto a background thread.
+        let monitor = get_monitor();
+        monitor.unmapper.background_unmap_info(self.info);
+    }
+}

--- a/src/runtime/monitor/src/mon/space/unmapper.rs
+++ b/src/runtime/monitor/src/mon/space/unmapper.rs
@@ -1,0 +1,47 @@
+use std::{panic::catch_unwind, sync::mpsc::Sender, thread::JoinHandle};
+
+use super::MapInfo;
+use crate::mon::get_monitor;
+
+pub struct Unmapper {
+    sender: Sender<MapInfo>,
+    thread: JoinHandle<()>,
+}
+
+impl Unmapper {
+    pub fn new(cb: fn(MapInfo)) -> Self {
+        let (sender, receiver) = std::sync::mpsc::channel();
+        Self {
+            thread: std::thread::spawn(move || loop {
+                let key = happylock::ThreadKey::get().unwrap();
+                match receiver.recv() {
+                    Ok(info) => {
+                        if let Err(_) = catch_unwind(|| {
+                            let monitor = get_monitor();
+                            let mut space = monitor.space.write(key);
+                            space.handle_drop(info);
+                        }) {
+                            tracing::error!("clean_call panicked -- exiting map cleaner thread");
+                            break;
+                        }
+                    }
+                    Err(_) => {
+                        // If receive fails, we can't recover, but this probably doesn't happen
+                        // since the sender won't get dropped since this
+                        // struct is used in the MapMan static.
+                        break;
+                    }
+                }
+            }),
+            sender,
+        }
+    }
+
+    pub(super) fn background_unmap_info(&self, info: MapInfo) {
+        // If the receiver is down, this will fail, but that also shouldn't happen, unless the
+        // call to clean_call above panics. In any case, handle this gracefully.
+        if self.sender.send(info).is_err() {
+            tracing::warn!("failed to enqueue {:?} onto cleaner thread", info);
+        }
+    }
+}

--- a/src/runtime/monitor/src/mon/thread.rs
+++ b/src/runtime/monitor/src/mon/thread.rs
@@ -1,0 +1,1 @@
+pub struct ThreadMgr {}

--- a/src/runtime/monitor/src/mon/thread.rs
+++ b/src/runtime/monitor/src/mon/thread.rs
@@ -1,1 +1,165 @@
-pub struct ThreadMgr {}
+use std::{collections::HashMap, mem::MaybeUninit, sync::Arc};
+
+use dynlink::tls::TlsRegion;
+use twizzler_abi::{
+    object::NULLPAGE_SIZE,
+    syscall::{sys_spawn, sys_thread_exit, ThreadSyncSleep, UpcallTargetSpawnOption},
+    thread::ThreadRepr,
+    upcall::{UpcallFlags, UpcallInfo, UpcallMode, UpcallOptions, UpcallTarget},
+};
+use twizzler_runtime_api::{ObjID, SpawnError};
+
+use super::space::MapHandle;
+use crate::{api::MONITOR_INSTANCE_ID, thread::SUPER_UPCALL_STACK_SIZE};
+
+mod cleaner;
+
+pub struct ThreadMgr {
+    all: HashMap<ObjID, ManagedThread>,
+    cleaner: cleaner::ThreadCleaner,
+}
+
+impl ThreadMgr {
+    fn do_remove(&mut self, thread: &ManagedThread) {
+        todo!()
+    }
+
+    unsafe fn spawn_thread(
+        start: usize,
+        super_stack_start: usize,
+        super_thread_pointer: usize,
+        arg: usize,
+    ) -> Result<ObjID, SpawnError> {
+        let upcall_target = UpcallTarget::new(
+            None,
+            Some(twz_rt::rr_upcall_entry),
+            super_stack_start,
+            SUPER_UPCALL_STACK_SIZE,
+            super_thread_pointer,
+            MONITOR_INSTANCE_ID,
+            [UpcallOptions {
+                flags: UpcallFlags::empty(),
+                mode: UpcallMode::CallSuper,
+            }; UpcallInfo::NR_UPCALLS],
+        );
+
+        sys_spawn(twizzler_abi::syscall::ThreadSpawnArgs {
+            entry: start,
+            stack_base: super_stack_start,
+            stack_size: SUPER_UPCALL_STACK_SIZE,
+            tls: super_thread_pointer,
+            arg,
+            flags: twizzler_abi::syscall::ThreadSpawnFlags::empty(),
+            vm_context_handle: None,
+            upcall_target: UpcallTargetSpawnOption::SetTo(upcall_target),
+        })
+        .map_err(|_| SpawnError::KernelError)
+    }
+
+    fn do_spawn(start: unsafe extern "C" fn(usize) -> !, arg: usize) -> Result<Self, SpawnError> {
+        /*
+        let mut cm = COMPMAN.lock();
+        let mon_comp = cm.get_monitor_dynlink_compartment();
+        let super_tls = mon_comp
+            .build_tls_region(RuntimeThreadControl::default(), |layout| unsafe {
+                NonNull::new(std::alloc::alloc_zeroed(layout))
+            })
+            .map_err(|_| SpawnError::Other)?;
+        drop(cm);
+        let super_thread_pointer = super_tls.get_thread_pointer_value();
+
+        let super_stack = Box::new_zeroed_slice(SUPER_UPCALL_STACK_SIZE);
+
+        // Safety: we are allocating and tracking both the stack and the tls region for greater than
+        // the lifetime of this thread. The start entry points to our given start function.
+        let id = unsafe {
+            Self::spawn_thread(
+                start as *const () as usize,
+                super_stack.as_ptr() as usize,
+                super_thread_pointer,
+                arg,
+            )
+        }?;
+
+        // TODO
+        let repr = crate::mapman::map_object(MapInfo {
+            id,
+            flags: MapFlags::READ,
+        })
+        .unwrap();
+
+        Ok(Self {
+            id,
+            super_stack,
+            super_tls,
+            repr: ManagedThreadRepr::new(repr),
+        })
+        */
+        todo!()
+    }
+
+    fn do_start(main: Box<dyn FnOnce()>) -> Result<Self, SpawnError> {
+        let main_addr = Box::into_raw(Box::new(main)) as usize;
+        unsafe extern "C" fn managed_thread_entry(main: usize) -> ! {
+            {
+                let main = Box::from_raw(main as *mut Box<dyn FnOnce()>);
+                main();
+            }
+
+            sys_thread_exit(0);
+        }
+
+        Self::do_spawn(managed_thread_entry, main_addr)
+    }
+}
+
+#[allow(dead_code)]
+pub struct ManagedThreadInner {
+    pub id: ObjID,
+    pub(crate) repr: ManagedThreadRepr,
+    super_stack: Box<[MaybeUninit<u8>]>,
+    super_tls: TlsRegion,
+}
+
+impl ManagedThreadInner {
+    pub fn has_exited(&self) -> bool {
+        todo!()
+    }
+
+    pub fn waitable_until_exit(&self) -> ThreadSyncSleep {
+        todo!()
+    }
+}
+
+// Safety: TlsRegion is not changed, and points to only globally- and permanently-allocated data.
+unsafe impl Send for ManagedThreadInner {}
+unsafe impl Sync for ManagedThreadInner {}
+
+impl core::fmt::Debug for ManagedThreadInner {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "ManagedThread({})", self.id)
+    }
+}
+
+impl Drop for ManagedThreadInner {
+    fn drop(&mut self) {
+        tracing::trace!("dropping ManagedThread {}", self.id);
+    }
+}
+
+pub type ManagedThread = Arc<ManagedThreadInner>;
+
+pub(crate) struct ManagedThreadRepr {
+    handle: MapHandle,
+}
+
+impl ManagedThreadRepr {
+    fn new(handle: MapHandle) -> Self {
+        Self { handle }
+    }
+
+    pub fn get_repr(&self) -> &ThreadRepr {
+        let addr = self.handle.addrs().start + NULLPAGE_SIZE;
+        unsafe { (addr as *const ThreadRepr).as_ref().unwrap() }
+    }
+}

--- a/src/runtime/monitor/src/mon/thread/cleaner.rs
+++ b/src/runtime/monitor/src/mon/thread/cleaner.rs
@@ -1,0 +1,148 @@
+use std::{
+    collections::HashMap,
+    marker::PhantomPinned,
+    pin::Pin,
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        mpsc::{Receiver, Sender},
+        Arc,
+    },
+};
+
+use twizzler_abi::syscall::{
+    sys_thread_sync, ThreadSync, ThreadSyncFlags, ThreadSyncOp, ThreadSyncReference,
+    ThreadSyncSleep, ThreadSyncWake,
+};
+use twizzler_runtime_api::ObjID;
+
+use super::ManagedThread;
+use crate::mon::get_monitor;
+
+pub(super) struct ThreadCleaner {
+    thread: std::thread::JoinHandle<()>,
+    send: Sender<WaitOp>,
+    inner: Pin<Arc<ThreadCleanerData>>,
+}
+
+#[derive(Default)]
+struct ThreadCleanerData {
+    notify: AtomicU64,
+    _unpin: PhantomPinned,
+}
+
+#[derive(Default)]
+struct Waits {
+    threads: HashMap<ObjID, ManagedThread>,
+}
+
+// Changes to the collection of threads we are tracking
+enum WaitOp {
+    Add(ManagedThread),
+    Remove(ObjID),
+}
+
+impl ThreadCleaner {
+    pub(super) fn new() -> Self {
+        let (send, recv) = std::sync::mpsc::channel();
+        let data = Arc::pin(ThreadCleanerData::default());
+        let inner = data.clone();
+        let thread = std::thread::Builder::new()
+            .name("thread-exit cleanup tracker".into())
+            .spawn(move || cleaner_thread_main(data, recv))
+            .unwrap();
+        Self {
+            send,
+            inner,
+            thread,
+        }
+    }
+
+    /// Track a thread. If that thread exits, the cleanup thread will remove the exited thread from
+    /// tracking and from the global thread manager.
+    pub fn track(&self, th: ManagedThread) {
+        tracing::debug!("tracking thread {}", th.id);
+        let _ = self.send.send(WaitOp::Add(th));
+        self.inner.notify();
+    }
+
+    /// Untrack a thread. Threads removed this way do not trigger a removal from the global thread
+    /// manager.
+    pub fn untrack(&self, id: ObjID) {
+        let _ = self.send.send(WaitOp::Remove(id));
+        self.inner.notify();
+    }
+}
+
+impl ThreadCleanerData {
+    /// Notify the cleanup thread that new items are on the queue.
+    fn notify(&self) {
+        self.notify.store(1, Ordering::SeqCst);
+        let mut ops = [ThreadSync::new_wake(ThreadSyncWake::new(
+            ThreadSyncReference::Virtual(&self.notify),
+            1,
+        ))];
+        if let Err(e) = sys_thread_sync(&mut ops, None) {
+            tracing::warn!("thread sync error when trying to notify: {}", e);
+        }
+    }
+}
+
+impl Waits {
+    fn process_queue(&mut self, recv: &mut Receiver<WaitOp>) {
+        while let Ok(wo) = recv.try_recv() {
+            match wo {
+                WaitOp::Add(th) => {
+                    self.threads.insert(th.id, th);
+                }
+                WaitOp::Remove(id) => {
+                    self.threads.remove(&id);
+                }
+            }
+        }
+    }
+}
+
+#[tracing::instrument(skip(data, recv))]
+fn cleaner_thread_main(data: Pin<Arc<ThreadCleanerData>>, mut recv: Receiver<WaitOp>) {
+    // TODO (dbittman): when we have support for async thread events, we can use that API.
+    let mut ops = Vec::new();
+    let mut cleanups = Vec::new();
+    let mut waits = Waits::default();
+    let mut key = happylock::ThreadKey::get().unwrap();
+    loop {
+        ops.truncate(0);
+        // Apply any waiting operations.
+        waits.process_queue(&mut recv);
+
+        // Add the notify sleep op.
+        ops.push(ThreadSync::new_sleep(ThreadSyncSleep::new(
+            ThreadSyncReference::Virtual(&data.notify),
+            0,
+            ThreadSyncOp::Equal,
+            ThreadSyncFlags::empty(),
+        )));
+
+        // Add all sleep ops for threads.
+        cleanups.extend(waits.threads.extract_if(|_, th| th.has_exited()));
+        for th in waits.threads.values() {
+            ops.push(ThreadSync::new_sleep(th.waitable_until_exit()));
+        }
+
+        // Remove any exited threads from the thread manager.
+        for (_, th) in cleanups.drain(..) {
+            tracing::debug!("cleaning thread: {}", th.id);
+            let monitor = get_monitor();
+            let mut tmgr = monitor.thread_mgr.write(&mut key);
+            tmgr.do_remove(&th);
+        }
+
+        // Check for notifications, and sleep.
+        if data.notify.swap(0, Ordering::SeqCst) == 0 {
+            // no notification, go to sleep. hold the lock over the sleep so that someone cannot
+            // modify waits.threads on us while we're asleep.
+            if let Err(e) = sys_thread_sync(&mut ops, None) {
+                tracing::warn!("thread sync error: {}", e);
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR implements the scaffolding for the rest of the implementation of the security monitor, organizing the state management, initial support for mapping and unmapping objects in the space, and managing threads. Most of this is stubbed and not hooked up yet. Next PR will implement more functionality.