### PR TITLE
Security montitor (1)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,6 +43,9 @@ initrd = [
     "lib:monitor",
     "crate:mnemosyne",
     "crate:stdfs_demo",
+    #"lib:twz-rt",
+    #"lib:monitor",
+>>>>>>> 5e5e713 (Cleanup.)
     #"third-party:hello-world-rs"
 ]
 
@@ -64,4 +67,5 @@ async-executor = { git = "https://github.com/twizzler-operating-system/async-exe
 twizzler-futures = { path = "src/lib/twizzler-futures" }
 twizzler-abi = { path = "src/lib/twizzler-abi" }
 parking_lot = { git = "https://github.com/twizzler-operating-system/parking_lot.git", branch = "twizzler" }
+# lock_api comes from the parking_lot repo
 lock_api = { git = "https://github.com/twizzler-operating-system/parking_lot.git", branch = "twizzler" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,9 +43,6 @@ initrd = [
     "lib:monitor",
     "crate:mnemosyne",
     "crate:stdfs_demo",
-    #"lib:twz-rt",
-    #"lib:monitor",
->>>>>>> 5e5e713 (Cleanup.)
     #"third-party:hello-world-rs"
 ]
 

--- a/src/lib/twizzler-abi/src/arch/aarch64/upcall.rs
+++ b/src/lib/twizzler-abi/src/arch/aarch64/upcall.rs
@@ -72,6 +72,18 @@ impl UpcallFrame {
     pub fn bp(&self) -> usize {
         self.fp as usize
     }
+
+    /// Build a new frame set up to enter a context at a start point.
+    pub fn new_entry_frame(
+        stack_base: usize,
+        stack_size: usize,
+        tp: usize,
+        ctx: crate::object::ObjID,
+        entry: usize,
+        arg: usize,
+    ) -> Self {
+        todo!()
+    }
 }
 
 #[no_mangle]

--- a/src/lib/twizzler-abi/src/arch/x86_64/upcall.rs
+++ b/src/lib/twizzler-abi/src/arch/x86_64/upcall.rs
@@ -58,6 +58,42 @@ impl UpcallFrame {
     pub fn bp(&self) -> usize {
         self.rbp as usize
     }
+
+    /// Build a new frame set up to enter a context at a start point.
+    pub fn new_entry_frame(
+        stack_base: usize,
+        stack_size: usize,
+        tp: usize,
+        ctx: crate::object::ObjID,
+        entry: usize,
+        arg: usize,
+    ) -> Self {
+        // TODO: check alignment and sizes better.
+        Self {
+            xsave_region: [0; XSAVE_LEN],
+            rip: entry as u64,
+            // Default has the interrupt enabled flag set, and the reserved bit.
+            rflags: 0x202,
+            rsp: (stack_base + stack_size - 8) as u64,
+            rbp: 0,
+            rax: 0,
+            rbx: 0,
+            rcx: 0,
+            rdx: 0,
+            rdi: arg as u64,
+            rsi: 0,
+            r8: 0,
+            r9: 0,
+            r10: 0,
+            r11: 0,
+            r12: 0,
+            r13: 0,
+            r14: 0,
+            r15: 0,
+            thread_ptr: tp as u64,
+            prior_ctx: ctx,
+        }
+    }
 }
 
 #[no_mangle]

--- a/src/lib/twizzler-abi/src/arch/x86_64/upcall.rs
+++ b/src/lib/twizzler-abi/src/arch/x86_64/upcall.rs
@@ -68,7 +68,6 @@ impl UpcallFrame {
         entry: usize,
         arg: usize,
     ) -> Self {
-        // TODO: check alignment and sizes better.
         Self {
             xsave_region: [0; XSAVE_LEN],
             rip: entry as u64,

--- a/src/runtime/monitor/src/lib.rs
+++ b/src/runtime/monitor/src/lib.rs
@@ -99,7 +99,7 @@ fn monitor_init(state: Arc<Mutex<MonitorState>>) -> miette::Result<()> {
         }
     }
 
-    //load_hello_world_test(&state).unwrap();
+    load_hello_world_test(&state).unwrap();
 
     Ok(())
 }

--- a/src/runtime/monitor/src/mon/compartment.rs
+++ b/src/runtime/monitor/src/mon/compartment.rs
@@ -1,1 +1,65 @@
-pub struct CompartmentMgr {}
+use std::collections::HashMap;
+
+use twizzler_runtime_api::ObjID;
+
+use self::runcomp::RunComp;
+use crate::api::MONITOR_INSTANCE_ID;
+
+mod comp_config;
+mod compthread;
+mod runcomp;
+
+/// Manages compartments.
+pub struct CompartmentMgr {
+    names: HashMap<String, ObjID>,
+    instances: HashMap<ObjID, RunComp>,
+}
+
+impl CompartmentMgr {
+    /// Get a [RunComp] by instance ID.
+    pub fn get(&self, id: ObjID) -> Option<&RunComp> {
+        self.instances.get(&id)
+    }
+
+    /// Get a [RunComp] by name.
+    pub fn get_name(&self, name: &str) -> Option<&RunComp> {
+        let id = self.names.get(name)?;
+        self.get(*id)
+    }
+
+    /// Get a [RunComp] by instance ID.
+    pub fn get_mut(&mut self, id: ObjID) -> Option<&mut RunComp> {
+        self.instances.get_mut(&id)
+    }
+
+    /// Get a [RunComp] by name.
+    pub fn get_name_mut(&mut self, name: &str) -> Option<&mut RunComp> {
+        let id = self.names.get(name)?;
+        self.get_mut(*id)
+    }
+
+    /// Insert a [RunComp].
+    pub fn insert(&mut self, rc: RunComp) {
+        self.names.insert(rc.name.clone(), rc.instance);
+        self.instances.insert(rc.instance, rc);
+    }
+
+    /// Remove a [RunComp].
+    pub fn remove(&mut self, id: ObjID) -> Option<RunComp> {
+        let rc = self.instances.remove(&id)?;
+        self.names.remove(&rc.name);
+        Some(rc)
+    }
+
+    /// Get the [RunComp] for the monitor.
+    pub fn get_monitor(&self) -> &RunComp {
+        // Unwrap-Ok: this instance is always present.
+        self.get(MONITOR_INSTANCE_ID).unwrap()
+    }
+
+    /// Get the [RunComp] for the monitor.
+    pub fn get_monitor_mut(&mut self) -> &mut RunComp {
+        // Unwrap-Ok: this instance is always present.
+        self.get_mut(MONITOR_INSTANCE_ID).unwrap()
+    }
+}

--- a/src/runtime/monitor/src/mon/compartment.rs
+++ b/src/runtime/monitor/src/mon/compartment.rs
@@ -5,7 +5,7 @@ use twizzler_runtime_api::ObjID;
 use self::runcomp::RunComp;
 use crate::api::MONITOR_INSTANCE_ID;
 
-mod comp_config;
+mod compconfig;
 mod compthread;
 mod runcomp;
 

--- a/src/runtime/monitor/src/mon/compartment/comp_config.rs
+++ b/src/runtime/monitor/src/mon/compartment/comp_config.rs
@@ -1,0 +1,54 @@
+use monitor_api::SharedCompConfig;
+use talc::Span;
+use twizzler_abi::object::{MAX_SIZE, NULLPAGE_SIZE};
+
+use crate::mon::space::MapHandle;
+
+/// Manages a comp config object.
+pub struct CompConfigObject {
+    handle: MapHandle,
+}
+
+impl CompConfigObject {
+    /// Create a new CompConfigObject from a handle. Initializes the comp config.
+    pub fn new(handle: MapHandle, init_val: SharedCompConfig) -> Self {
+        let mut this = Self { handle };
+        this.write_config(init_val);
+        this
+    }
+
+    /// Write a comp config to this object.
+    pub fn write_config(&mut self, val: SharedCompConfig) {
+        // Safety: only the monitor can write to a comp config object, and we have a mutable
+        // reference to it.
+        unsafe {
+            let base = self.handle.monitor_data_base();
+            (base as *mut SharedCompConfig).write(val);
+        }
+    }
+
+    /// Read the comp config data.
+    pub(crate) fn read_comp_config(&self) -> SharedCompConfig {
+        // Safety: no other compartment can write this.
+        unsafe { self.get_comp_config().read() }
+    }
+
+    /// Get a pointer to this comp config data.
+    pub fn get_comp_config(&self) -> *const SharedCompConfig {
+        self.handle.monitor_data_base() as *const SharedCompConfig
+    }
+
+    /// Return a span that can be used for allocations in the comp config object.
+    pub fn alloc_span(&self) -> Span {
+        let offset_from_base =
+            core::mem::size_of::<SharedCompConfig>().next_multiple_of(NULLPAGE_SIZE);
+        assert!(offset_from_base < MAX_SIZE / 2);
+        // Safety: the pointers stay in-bounds (in an object).
+        unsafe {
+            Span::new(
+                self.handle.monitor_data_base().add(offset_from_base),
+                self.handle.monitor_data_null().add(MAX_SIZE / 2),
+            )
+        }
+    }
+}

--- a/src/runtime/monitor/src/mon/compartment/compconfig.rs
+++ b/src/runtime/monitor/src/mon/compartment/compconfig.rs
@@ -4,7 +4,7 @@ use twizzler_abi::object::{MAX_SIZE, NULLPAGE_SIZE};
 
 use crate::mon::space::MapHandle;
 
-/// Manages a comp config object.
+/// Manages a compartment configuration object.
 pub struct CompConfigObject {
     handle: MapHandle,
 }
@@ -47,7 +47,7 @@ impl CompConfigObject {
         unsafe {
             Span::new(
                 self.handle.monitor_data_base().add(offset_from_base),
-                self.handle.monitor_data_null().add(MAX_SIZE / 2),
+                self.handle.monitor_data_start().add(MAX_SIZE / 2),
             )
         }
     }

--- a/src/runtime/monitor/src/mon/compartment/compthread.rs
+++ b/src/runtime/monitor/src/mon/compartment/compthread.rs
@@ -12,6 +12,8 @@ pub(super) struct CompThread {
 }
 
 impl CompThread {
+    /// Start a new thread using the given stack, in the provided security context instance, using
+    /// the start function.
     pub fn new(
         stack: StackObject,
         instance: ObjID,
@@ -20,6 +22,7 @@ impl CompThread {
         todo!()
     }
 
+    /// Get the entry frame for this thread into a given compartment.
     pub fn get_entry_frame(&self, ctx: ObjID, entry: usize, arg: usize) -> UpcallFrame {
         UpcallFrame::new_entry_frame(
             self.stack_object.initial_stack_ptr(),
@@ -38,6 +41,7 @@ pub(crate) struct StackObject {
 }
 
 impl StackObject {
+    /// Make a new stack object from a given handle and stack size.
     pub fn new(handle: MapHandle, stack_size: usize) -> miette::Result<Self> {
         // Find the stack size, with max and min values, and correct alignment.
         let stack_size = std::cmp::max(std::cmp::min(stack_size, MAX_SIZE / 2), DEFAULT_STACK_SIZE)
@@ -46,15 +50,20 @@ impl StackObject {
         Ok(Self { handle, stack_size })
     }
 
+    /// Get the start start address for the compartment.
     pub fn stack_comp_start(&self) -> usize {
         self.handle.addrs().start
     }
 
+    /// Get the stack size.
     pub fn stack_size(&self) -> usize {
         self.stack_size
     }
 
+    // This works for architectures where the stack grows down. If your architecture does not use a
+    // downward-growing stack, implement this function differently.
     #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+    /// Get the initial stack pointer.
     pub fn initial_stack_ptr(&self) -> usize {
         self.stack_comp_start() + self.stack_size
     }

--- a/src/runtime/monitor/src/mon/compartment/compthread.rs
+++ b/src/runtime/monitor/src/mon/compartment/compthread.rs
@@ -1,0 +1,61 @@
+use twizzler_abi::{object::MAX_SIZE, upcall::UpcallFrame};
+use twizzler_runtime_api::ObjID;
+
+use crate::mon::{
+    space::MapHandle,
+    thread::{ManagedThread, DEFAULT_STACK_SIZE, STACK_SIZE_MIN_ALIGN},
+};
+
+pub(super) struct CompThread {
+    stack_object: StackObject,
+    thread: ManagedThread,
+}
+
+impl CompThread {
+    pub fn new(
+        stack: StackObject,
+        instance: ObjID,
+        start: impl FnOnce() + Send + 'static,
+    ) -> miette::Result<Self> {
+        todo!()
+    }
+
+    pub fn get_entry_frame(&self, ctx: ObjID, entry: usize, arg: usize) -> UpcallFrame {
+        UpcallFrame::new_entry_frame(
+            self.stack_object.initial_stack_ptr(),
+            self.stack_object.stack_size(),
+            0,
+            ctx,
+            entry,
+            arg,
+        )
+    }
+}
+
+pub(crate) struct StackObject {
+    handle: MapHandle,
+    stack_size: usize,
+}
+
+impl StackObject {
+    pub fn new(handle: MapHandle, stack_size: usize) -> miette::Result<Self> {
+        // Find the stack size, with max and min values, and correct alignment.
+        let stack_size = std::cmp::max(std::cmp::min(stack_size, MAX_SIZE / 2), DEFAULT_STACK_SIZE)
+            .next_multiple_of(STACK_SIZE_MIN_ALIGN);
+
+        Ok(Self { handle, stack_size })
+    }
+
+    pub fn stack_comp_start(&self) -> usize {
+        self.handle.addrs().start
+    }
+
+    pub fn stack_size(&self) -> usize {
+        self.stack_size
+    }
+
+    #[cfg(any(target_arch = "x86_64", target_arch = "aarch64"))]
+    pub fn initial_stack_ptr(&self) -> usize {
+        self.stack_comp_start() + self.stack_size
+    }
+}

--- a/src/runtime/monitor/src/mon/compartment/runcomp.rs
+++ b/src/runtime/monitor/src/mon/compartment/runcomp.rs
@@ -14,17 +14,25 @@ use twizzler_abi::syscall::{
 };
 use twizzler_runtime_api::{MapError, ObjID};
 
-use super::{comp_config::CompConfigObject, compthread::CompThread};
+use super::{compconfig::CompConfigObject, compthread::CompThread};
 use crate::mon::space::{MapHandle, MapInfo};
 
+/// Compartment is ready (loaded, reloacated, runtime started and ctors run).
 pub const COMP_READY: u64 = 0x1;
+/// Compartment is a binary, not a library.
 pub const COMP_IS_BINARY: u64 = 0x2;
+/// Compartment runtime thread may exit.
 pub const COMP_THREAD_CAN_EXIT: u64 = 0x4;
 
+/// A runnable or running compartment.
 pub struct RunComp {
+    /// The security context for this compartment.
     pub sctx: ObjID,
+    /// The instance of the security context.
     pub instance: ObjID,
+    /// The name of this compartment.
     pub name: String,
+    /// The dynlink ID of this compartment.
     pub compartment_id: CompartmentId,
     main: Option<CompThread>,
     deps: Vec<ObjID>,
@@ -130,6 +138,7 @@ pub struct RunCompReadyWaiter<'a> {
 }
 
 impl<'a> RunCompReadyWaiter<'a> {
+    /// Wait until the compartment is marked as ready.
     pub fn wait(&self) {
         loop {
             let Some(sleep) = self.sleep else { return };

--- a/src/runtime/monitor/src/mon/compartment/runcomp.rs
+++ b/src/runtime/monitor/src/mon/compartment/runcomp.rs
@@ -1,0 +1,147 @@
+use std::{
+    alloc::Layout,
+    collections::HashMap,
+    marker::PhantomData,
+    ptr::NonNull,
+    sync::atomic::{AtomicU64, Ordering},
+};
+
+use dynlink::compartment::CompartmentId;
+use monitor_api::SharedCompConfig;
+use talc::{ErrOnOom, Talc};
+use twizzler_abi::syscall::{
+    ThreadSync, ThreadSyncFlags, ThreadSyncOp, ThreadSyncReference, ThreadSyncSleep, ThreadSyncWake,
+};
+use twizzler_runtime_api::{MapError, ObjID};
+
+use super::{comp_config::CompConfigObject, compthread::CompThread};
+use crate::mon::space::{MapHandle, MapInfo};
+
+pub const COMP_READY: u64 = 0x1;
+pub const COMP_IS_BINARY: u64 = 0x2;
+pub const COMP_THREAD_CAN_EXIT: u64 = 0x4;
+
+pub struct RunComp {
+    pub sctx: ObjID,
+    pub instance: ObjID,
+    pub name: String,
+    pub compartment_id: CompartmentId,
+    main: Option<CompThread>,
+    deps: Vec<ObjID>,
+    comp_config_object: CompConfigObject,
+    alloc: Talc<ErrOnOom>,
+    mapped_objects: HashMap<MapInfo, MapHandle>,
+    flags: Box<AtomicU64>,
+}
+
+impl RunComp {
+    /// Map an object into this compartment.
+    pub fn map_object(&mut self, info: MapInfo) -> Result<MapHandle, MapError> {
+        todo!()
+    }
+
+    /// Unmap and object from this compartment.
+    pub fn unmap_object(&mut self, info: MapInfo) {
+        let _ = self.mapped_objects.remove(&info);
+        // Unmapping handled by dropping
+    }
+
+    /// Read the compartment config.
+    pub fn comp_config(&self) -> SharedCompConfig {
+        self.comp_config_object.read_comp_config()
+    }
+
+    /// Set the compartment config.
+    pub fn set_comp_config(&mut self, scc: SharedCompConfig) {
+        self.comp_config_object.write_config(scc)
+    }
+
+    /// Allocate some space in the compartment allocator, and initialize it.
+    pub fn monitor_new<T: Copy + Sized + Send + Sync>(&mut self, data: T) -> Result<*mut T, ()> {
+        unsafe {
+            let place: NonNull<T> = self.alloc.malloc(Layout::new::<T>())?.cast();
+            place.as_ptr().write(data);
+            Ok(place.as_ptr() as *mut T)
+        }
+    }
+
+    /// Allocate some space in the compartment allocator for a slice, and initialize it.
+    pub fn monitor_new_slice<T: Copy + Sized + Send + Sync>(
+        &mut self,
+        data: &[T],
+    ) -> Result<*mut T, ()> {
+        unsafe {
+            let place = self.alloc.malloc(Layout::array::<T>(data.len()).unwrap())?;
+            let slice = core::slice::from_raw_parts_mut(place.as_ptr() as *mut T, data.len());
+            slice.copy_from_slice(data);
+            Ok(place.as_ptr() as *mut T)
+        }
+    }
+
+    /// Set a flag on this compartment, and wakeup anyone waiting on flag change.
+    pub fn set_flag(&self, val: u64) {
+        self.flags.fetch_or(val, Ordering::SeqCst);
+        let _ = twizzler_abi::syscall::sys_thread_sync(
+            &mut [ThreadSync::new_wake(ThreadSyncWake::new(
+                ThreadSyncReference::Virtual(&*self.flags),
+                usize::MAX,
+            ))],
+            None,
+        );
+    }
+
+    /// Check if a flag is set.
+    pub fn has_flag(&self, flag: u64) -> bool {
+        self.flags.load(Ordering::SeqCst) & flag != 0
+    }
+
+    /// Setup a [ThreadSyncSleep] for waiting until the flag is set. Returns None if the flag is
+    /// already set.
+    pub fn flag_waitable(&self, flag: u64) -> Option<ThreadSyncSleep> {
+        let flags = self.flags.load(Ordering::SeqCst);
+        if flags & flag == 0 {
+            Some(ThreadSyncSleep::new(
+                ThreadSyncReference::Virtual(&*self.flags),
+                flags,
+                ThreadSyncOp::Equal,
+                ThreadSyncFlags::empty(),
+            ))
+        } else {
+            None
+        }
+    }
+
+    /// Return a waiter for this flag, allows calling .wait later to wait until a flag is set.
+    pub fn waiter(&self, flag: u64) -> RunCompReadyWaiter<'_> {
+        RunCompReadyWaiter {
+            flag,
+            sleep: self.flag_waitable(flag),
+            _pd: PhantomData,
+        }
+    }
+}
+
+/// Allows waiting for a compartment to set a flag, sleeping the calling thread until the flag is
+/// set.
+pub struct RunCompReadyWaiter<'a> {
+    flag: u64,
+    sleep: Option<ThreadSyncSleep>,
+    _pd: PhantomData<&'a ()>,
+}
+
+impl<'a> RunCompReadyWaiter<'a> {
+    pub fn wait(&self) {
+        loop {
+            let Some(sleep) = self.sleep else { return };
+            if sleep.ready() {
+                return;
+            }
+
+            if let Err(e) =
+                twizzler_abi::syscall::sys_thread_sync(&mut [ThreadSync::new_sleep(sleep)], None)
+            {
+                tracing::warn!("thread sync error: {:?}", e);
+            }
+        }
+    }
+}

--- a/src/runtime/monitor/src/mon/space.rs
+++ b/src/runtime/monitor/src/mon/space.rs
@@ -111,6 +111,7 @@ impl Space {
         }
     }
 
+    /// Utility function for creating an object and mapping it, deleting it if the mapping fails.
     pub(crate) fn safe_create_and_map_object(
         &mut self,
         spec: ObjectCreate,

--- a/src/runtime/monitor/src/mon/space/handle.rs
+++ b/src/runtime/monitor/src/mon/space/handle.rs
@@ -6,26 +6,33 @@ use twizzler_abi::object::NULLPAGE_SIZE;
 use super::MapInfo;
 use crate::mon::get_monitor;
 
+/// A handle for an object mapped into the address space. This handle is owning, and when dropped,
+/// the mapping is sent to the background unmapping thread.
 pub struct MapHandleInner {
     info: MapInfo,
     map: MappedObjectAddrs,
 }
 
+/// A shared map handle.
 pub type MapHandle = Arc<MapHandleInner>;
 
 impl MapHandleInner {
+    /// Create a new map handle.
     pub(crate) fn new(info: MapInfo, map: MappedObjectAddrs) -> Self {
         Self { info, map }
     }
 
+    /// Get the mapped addresses of this handle.
     pub fn addrs(&self) -> MappedObjectAddrs {
         self.map
     }
 
-    pub fn monitor_data_null(&self) -> *mut u8 {
+    /// Get a pointer to the start address of the object.
+    pub fn monitor_data_start(&self) -> *mut u8 {
         self.map.start as *mut u8
     }
 
+    /// Get a pointer to the base address of the object.
     pub fn monitor_data_base(&self) -> *mut u8 {
         (self.map.start + NULLPAGE_SIZE) as *mut u8
     }

--- a/src/runtime/monitor/src/mon/space/unmapper.rs
+++ b/src/runtime/monitor/src/mon/space/unmapper.rs
@@ -3,40 +3,48 @@ use std::{panic::catch_unwind, sync::mpsc::Sender, thread::JoinHandle};
 use super::MapInfo;
 use crate::mon::get_monitor;
 
+/// Manages a background thread that unmaps mappings.
 pub struct Unmapper {
     sender: Sender<MapInfo>,
     thread: JoinHandle<()>,
 }
 
 impl Unmapper {
-    pub fn new(cb: fn(MapInfo)) -> Self {
+    /// Make a new unmapper.
+    pub fn new() -> Self {
         let (sender, receiver) = std::sync::mpsc::channel();
         Self {
-            thread: std::thread::spawn(move || loop {
-                let key = happylock::ThreadKey::get().unwrap();
-                match receiver.recv() {
-                    Ok(info) => {
-                        if let Err(_) = catch_unwind(|| {
-                            let monitor = get_monitor();
-                            let mut space = monitor.space.write(key);
-                            space.handle_drop(info);
-                        }) {
-                            tracing::error!("clean_call panicked -- exiting map cleaner thread");
+            thread: std::thread::Builder::new()
+                .name("unmapper".to_string())
+                .spawn(move || loop {
+                    let key = happylock::ThreadKey::get().unwrap();
+                    match receiver.recv() {
+                        Ok(info) => {
+                            if let Err(_) = catch_unwind(|| {
+                                let monitor = get_monitor();
+                                let mut space = monitor.space.write(key);
+                                space.handle_drop(info);
+                            }) {
+                                tracing::error!(
+                                    "clean_call panicked -- exiting map cleaner thread"
+                                );
+                                break;
+                            }
+                        }
+                        Err(_) => {
+                            // If receive fails, we can't recover, but this probably doesn't happen
+                            // since the sender won't get dropped since this
+                            // struct is used in the MapMan static.
                             break;
                         }
                     }
-                    Err(_) => {
-                        // If receive fails, we can't recover, but this probably doesn't happen
-                        // since the sender won't get dropped since this
-                        // struct is used in the MapMan static.
-                        break;
-                    }
-                }
-            }),
+                })
+                .unwrap(),
             sender,
         }
     }
 
+    /// Enqueue a mapping to be unmapped.
     pub(super) fn background_unmap_info(&self, info: MapInfo) {
         // If the receiver is down, this will fail, but that also shouldn't happen, unless the
         // call to clean_call above panics. In any case, handle this gracefully.

--- a/src/runtime/monitor/src/mon/thread.rs
+++ b/src/runtime/monitor/src/mon/thread.rs
@@ -3,18 +3,21 @@ use std::{collections::HashMap, mem::MaybeUninit, sync::Arc};
 use dynlink::tls::TlsRegion;
 use twizzler_abi::{
     object::NULLPAGE_SIZE,
-    syscall::{
-        sys_spawn, sys_thread_exit, ThreadSyncReference, ThreadSyncSleep, UpcallTargetSpawnOption,
-    },
+    syscall::{sys_spawn, sys_thread_exit, ThreadSyncSleep, UpcallTargetSpawnOption},
     thread::{ExecutionState, ThreadRepr},
     upcall::{UpcallFlags, UpcallInfo, UpcallMode, UpcallOptions, UpcallTarget},
 };
 use twizzler_runtime_api::{ObjID, SpawnError};
 
 use super::space::MapHandle;
-use crate::{api::MONITOR_INSTANCE_ID, thread::SUPER_UPCALL_STACK_SIZE};
+use crate::api::MONITOR_INSTANCE_ID;
 
 mod cleaner;
+
+pub const SUPER_UPCALL_STACK_SIZE: usize = 8 * 1024 * 1024; // 8MB
+pub const DEFAULT_STACK_SIZE: usize = 8 * 1024 * 1024; // 8MB
+pub const STACK_SIZE_MIN_ALIGN: usize = 0x1000; // 4K
+pub const DEFAULT_TLS_ALIGN: usize = 0x1000; // 4K
 
 /// Manages all threads owned by the monitor. Typically, this is all threads.
 /// Threads are spawned here and tracked in the background by a [cleaner::ThreadCleaner]. The thread

--- a/src/runtime/monitor/src/mon/thread.rs
+++ b/src/runtime/monitor/src/mon/thread.rs
@@ -14,9 +14,13 @@ use crate::api::MONITOR_INSTANCE_ID;
 
 mod cleaner;
 
+/// Stack size for the supervisor upcall stack.
 pub const SUPER_UPCALL_STACK_SIZE: usize = 8 * 1024 * 1024; // 8MB
+/// Default stack size for the user stack.
 pub const DEFAULT_STACK_SIZE: usize = 8 * 1024 * 1024; // 8MB
+/// Stack minimium alignment.
 pub const STACK_SIZE_MIN_ALIGN: usize = 0x1000; // 4K
+/// TLS minimum alignment.
 pub const DEFAULT_TLS_ALIGN: usize = 0x1000; // 4K
 
 /// Manages all threads owned by the monitor. Typically, this is all threads.
@@ -87,7 +91,9 @@ impl ThreadMgr {
 
 /// Internal managed thread data.
 pub struct ManagedThreadInner {
+    /// The ID of the thread.
     pub id: ObjID,
+    /// The thread repr.
     pub(crate) repr: ManagedThreadRepr,
     super_stack: Box<[MaybeUninit<u8>]>,
     super_tls: TlsRegion,

--- a/src/runtime/monitor/src/mon/thread/cleaner.rs
+++ b/src/runtime/monitor/src/mon/thread/cleaner.rs
@@ -18,6 +18,7 @@ use twizzler_runtime_api::ObjID;
 use super::ManagedThread;
 use crate::mon::get_monitor;
 
+/// Tracks threads that do not exit cleanly, so their monitor-internal resources can be cleaned up.
 pub(super) struct ThreadCleaner {
     thread: std::thread::JoinHandle<()>,
     send: Sender<WaitOp>,
@@ -30,6 +31,7 @@ struct ThreadCleanerData {
     _unpin: PhantomPinned,
 }
 
+// All the threads we are tracking.
 #[derive(Default)]
 struct Waits {
     threads: HashMap<ObjID, ManagedThread>,
@@ -42,6 +44,7 @@ enum WaitOp {
 }
 
 impl ThreadCleaner {
+    /// Makes a new ThreadCleaner.
     pub(super) fn new() -> Self {
         let (send, recv) = std::sync::mpsc::channel();
         let data = Arc::pin(ThreadCleanerData::default());


### PR DESCRIPTION
Implements initial stubbing and code for the security monitor. The security monitor state is split into managing the address space and mapping objects, managing threads, and managing compartments (these are the main abstractions the security monitor is responsible for). Many core functions here are still unimplemented, but those will come in the next PR.

