### PR TITLE
Security Monitor (2)

### DIFF
--- a/src/kernel/src/initrd.rs
+++ b/src/kernel/src/initrd.rs
@@ -59,7 +59,7 @@ pub fn init(modules: &[BootModule]) {
             }
             let obj = Arc::new(obj);
             obj::register_object(obj.clone());
-            if e.filename().as_str() == "init" {
+            if e.filename().as_str() == "bootstrap" {
                 boot_objects.init = Some(obj.clone());
             }
             boot_objects

--- a/src/kernel/src/initrd.rs
+++ b/src/kernel/src/initrd.rs
@@ -59,7 +59,7 @@ pub fn init(modules: &[BootModule]) {
             }
             let obj = Arc::new(obj);
             obj::register_object(obj.clone());
-            if e.filename().as_str() == "bootstrap" {
+            if e.filename().as_str() == "init" {
                 boot_objects.init = Some(obj.clone());
             }
             boot_objects

--- a/src/runtime/monitor/secapi/gates.rs
+++ b/src/runtime/monitor/secapi/gates.rs
@@ -73,19 +73,16 @@ pub fn monitor_rt_object_map(
     id: ObjID,
     flags: twizzler_runtime_api::MapFlags,
 ) -> Result<crate::MappedObjectAddrs, MapError> {
-    use happylock::ThreadKey;
     use twz_rt::{RuntimeState, OUR_RUNTIME};
 
     use crate::{api::MONITOR_INSTANCE_ID, mon::space::MapInfo};
     if OUR_RUNTIME.state().contains(RuntimeState::READY) {
         let monitor = crate::mon::get_monitor();
-        let key = ThreadKey::get().unwrap();
         monitor
-            .comp_mgr
-            .write(key)
-            .get_mut(info.source_context().unwrap_or(MONITOR_INSTANCE_ID))
-            .unwrap()
-            .map_object(MapInfo { id, flags })
+            .map_object(
+                info.source_context().unwrap_or(MONITOR_INSTANCE_ID),
+                MapInfo { id, flags },
+            )
             .map(|handle| handle.addrs())
     } else {
         Ok(crate::mon::early_object_map(MapInfo { id, flags }))
@@ -99,7 +96,7 @@ pub fn monitor_rt_object_map(
 )]
 pub fn monitor_rt_object_unmap(
     info: &secgate::GateCallInfo,
-    slot: usize,
+    _slot: usize,
     id: ObjID,
     flags: twizzler_runtime_api::MapFlags,
 ) {

--- a/src/runtime/monitor/secapi/gates.rs
+++ b/src/runtime/monitor/secapi/gates.rs
@@ -66,8 +66,24 @@ pub fn monitor_rt_object_map(
     info: &secgate::GateCallInfo,
     id: ObjID,
     flags: twizzler_runtime_api::MapFlags,
-) -> Result<usize, MapError> {
-    crate::object::map_object(info, id, flags)
+) -> Result<crate::MappedObjectAddrs, MapError> {
+    use happylock::ThreadKey;
+    use twz_rt::{RuntimeState, OUR_RUNTIME};
+
+    use crate::{api::MONITOR_INSTANCE_ID, mon::space::MapInfo};
+    if OUR_RUNTIME.state().contains(RuntimeState::READY) {
+        let monitor = crate::mon::get_monitor();
+        let key = ThreadKey::get().unwrap();
+        monitor
+            .comp_mgr
+            .write(key)
+            .get_mut(info.source_context().unwrap_or(MONITOR_INSTANCE_ID))
+            .unwrap()
+            .map_object(MapInfo { id, flags })
+            .map(|handle| handle.addrs())
+    } else {
+        Ok(crate::mon::early_object_map(MapInfo { id, flags }))
+    }
 }
 
 #[cfg_attr(feature = "secgate-impl", secgate::secure_gate(options(info)))]

--- a/src/runtime/monitor/secapi/gates.rs
+++ b/src/runtime/monitor/secapi/gates.rs
@@ -15,7 +15,7 @@ pub fn monitor_rt_spawn_thread(
     stack_pointer: usize,
 ) -> Result<ObjID, SpawnError> {
     let monitor = crate::mon::get_monitor();
-    monitor.spawn_user_thread(
+    monitor.spawn_compartment_thread(
         info.source_context().unwrap_or(0.into()),
         args,
         stack_pointer,

--- a/src/runtime/monitor/src/lib.rs
+++ b/src/runtime/monitor/src/lib.rs
@@ -60,7 +60,9 @@ pub fn main() {
     let mon = mon::Monitor::new(init);
     mon::set_monitor(mon);
 
+    info!("Ok: set monitor");
     unsafe { OUR_RUNTIME.set_runtime_ready() };
+    info!("Ok: start threads");
     mon::get_monitor().start_background_threads();
 
     info!("Ok");

--- a/src/runtime/monitor/src/lib.rs
+++ b/src/runtime/monitor/src/lib.rs
@@ -16,7 +16,7 @@ use twizzler_abi::{
     syscall::{sys_object_create, ObjectCreate},
 };
 use twizzler_object::ObjID;
-use twizzler_runtime_api::AuxEntry;
+use twizzler_runtime_api::{AuxEntry, RustTimeRuntime};
 use twz_rt::{set_upcall_handler, CompartmentInitInfo, OUR_RUNTIME};
 
 use crate::{compartment::Comp, state::set_monitor_state};
@@ -61,6 +61,7 @@ pub fn main() {
     mon::set_monitor(mon);
 
     unsafe { OUR_RUNTIME.set_runtime_ready() };
+    mon::get_monitor().start_background_threads();
 
     info!("Ok");
 

--- a/src/runtime/monitor/src/lib.rs
+++ b/src/runtime/monitor/src/lib.rs
@@ -53,7 +53,9 @@ pub fn main() {
     let mon = mon::Monitor::new(init);
     mon::set_monitor(mon);
 
+    // Safety: the monitor is ready, and so we can set our runtime as ready to use the monitor.
     unsafe { OUR_RUNTIME.set_runtime_ready() };
+    // Had to wait till now to be able to spawn threads.
     mon::get_monitor().start_background_threads();
 
     debug!("Ok");

--- a/src/runtime/monitor/src/lib.rs
+++ b/src/runtime/monitor/src/lib.rs
@@ -17,7 +17,7 @@ use twizzler_abi::{
 };
 use twizzler_object::ObjID;
 use twizzler_runtime_api::AuxEntry;
-use twz_rt::{set_upcall_handler, CompartmentInitInfo};
+use twz_rt::{set_upcall_handler, CompartmentInitInfo, OUR_RUNTIME};
 
 use crate::{compartment::Comp, state::set_monitor_state};
 
@@ -32,6 +32,8 @@ mod upcall;
 
 mod api;
 mod mon;
+
+pub use monitor_api::MappedObjectAddrs;
 
 #[path = "../secapi/gates.rs"]
 mod gates;
@@ -54,6 +56,16 @@ pub fn main() {
     trace!("monitor entered, discovering dynlink context");
     let init =
         init::bootstrap_dynlink_context().expect("failed to discover initial dynlink context");
+
+    let mon = mon::Monitor::new(init);
+    mon::set_monitor(mon);
+
+    unsafe { OUR_RUNTIME.set_runtime_ready() };
+
+    info!("Ok");
+
+    loop {}
+
     let mut state = state::MonitorState::new(init);
 
     let monitor_comp_id = state.dynlink.lookup_compartment("monitor").unwrap();

--- a/src/runtime/monitor/src/lib.rs
+++ b/src/runtime/monitor/src/lib.rs
@@ -4,22 +4,15 @@
 #![feature(new_uninit)]
 #![feature(hash_extract_if)]
 
-use std::sync::{Arc, Mutex};
-
-use dynlink::{engines::Backing, symbol::LookupFlags};
-use state::MonitorState;
-use tracing::{debug, info, trace, warn, Level};
+use dynlink::engines::Backing;
+use tracing::{debug, info, warn, Level};
 use tracing_subscriber::{fmt::format::FmtSpan, FmtSubscriber};
 use twizzler_abi::{
     aux::KernelInitInfo,
     object::{MAX_SIZE, NULLPAGE_SIZE},
-    syscall::{sys_object_create, ObjectCreate},
 };
 use twizzler_object::ObjID;
-use twizzler_runtime_api::{AuxEntry, RustTimeRuntime};
-use twz_rt::{set_upcall_handler, CompartmentInitInfo, OUR_RUNTIME};
-
-use crate::{compartment::Comp, state::set_monitor_state};
+use twz_rt::{set_upcall_handler, OUR_RUNTIME};
 
 mod compartment;
 mod init;
@@ -53,142 +46,29 @@ pub fn main() {
     }))
     .unwrap();
 
-    trace!("monitor entered, discovering dynlink context");
+    debug!("monitor entered, discovering dynlink context");
     let init =
         init::bootstrap_dynlink_context().expect("failed to discover initial dynlink context");
 
     let mon = mon::Monitor::new(init);
     mon::set_monitor(mon);
 
-    info!("Ok: set monitor");
     unsafe { OUR_RUNTIME.set_runtime_ready() };
-    info!("Ok: start threads");
     mon::get_monitor().start_background_threads();
 
-    info!("Ok");
-
-    loop {}
-
-    let mut state = state::MonitorState::new(init);
-
-    let monitor_comp_id = state.dynlink.lookup_compartment("monitor").unwrap();
-    let monitor_comp = Comp::new(
-        0.into(),
-        state.dynlink.get_compartment_mut(monitor_comp_id).unwrap(),
-    )
-    .unwrap();
-    state.add_comp(monitor_comp, twizzler_runtime_api::LibraryId(0));
-
-    let state = Arc::new(Mutex::new(state));
-    tracing::info!(".. state: {:p}", state);
-    debug!(
-        "found dynlink context, with root {}",
-        state.lock().unwrap().root
-    );
-
+    debug!("Ok");
     std::env::set_var("RUST_BACKTRACE", "1");
-
     set_upcall_handler(&crate::upcall::upcall_monitor_handler).unwrap();
-    set_monitor_state(state.clone());
 
-    let main_thread = std::thread::spawn(|| monitor_init(state));
+    let main_thread = std::thread::spawn(|| monitor_init());
     let _r = main_thread.join().unwrap().map_err(|e| {
         tracing::error!("{:?}", e);
     });
     warn!("monitor main thread exited");
 }
 
-fn monitor_init(state: Arc<Mutex<MonitorState>>) -> miette::Result<()> {
+fn monitor_init() -> miette::Result<()> {
     info!("monitor early init completed, starting init");
-
-    {
-        let state = state.lock().unwrap();
-        let comp = state.dynlink.lookup_compartment("monitor").unwrap();
-        let mon = state.dynlink.lookup_library(comp, "libmonitor.so").unwrap();
-
-        let mon = state.dynlink.get_library(mon)?;
-
-        for gate in mon.iter_secgates().unwrap() {
-            let name = gate.name().to_string_lossy();
-            info!("secure gate in {} => {}: {:x}", mon.name, name, gate.imp);
-        }
-    }
-
-    load_hello_world_test(&state).unwrap();
-
-    Ok(())
-}
-
-fn load_hello_world_test(state: &Arc<Mutex<MonitorState>>) -> miette::Result<()> {
-    let lib = dynlink::library::UnloadedLibrary::new("hello-world");
-    let rt_lib = dynlink::library::UnloadedLibrary::new("libtwz_rt.so");
-
-    let mut state = state.lock().unwrap();
-    let test_comp_id = state.dynlink.add_compartment("test")?;
-
-    let libhw_id = state
-        .dynlink
-        .load_library_in_compartment(test_comp_id, lib)?;
-
-    let rt_id = match state
-        .dynlink
-        .load_library_in_compartment(test_comp_id, rt_lib)
-    {
-        Ok(rt_id) => {
-            state.dynlink.add_manual_dependency(libhw_id, rt_id);
-            rt_id
-        }
-        Err(_) => state
-            .dynlink
-            .lookup_library(test_comp_id, "libtwz_rt.so")
-            .unwrap(),
-    };
-
-    println!("found rt_id: {}", rt_id);
-    let rt_lib = state.dynlink.get_library(rt_id).unwrap();
-
-    drop(rt_lib);
-
-    state.dynlink.relocate_all(libhw_id)?;
-
-    let test_comp = Comp::new(
-        1.into(),
-        state.dynlink.get_compartment_mut(test_comp_id).unwrap(),
-    )
-    .unwrap();
-
-    info!("!! root = {}", libhw_id);
-    let ctors = state.dynlink.build_ctors_list(libhw_id).unwrap();
-
-    let rtinfo = CompartmentInitInfo {
-        ctor_array_start: ctors.as_ptr() as usize,
-        ctor_array_len: ctors.len(),
-        comp_config_addr: test_comp.get_comp_config() as *const _ as usize,
-    };
-    state.add_comp(test_comp, libhw_id.into());
-
-    info!("lookup entry");
-
-    let rt_lib = state.dynlink.get_library(rt_id).unwrap();
-    let entry = rt_lib.get_entry_address().unwrap();
-
-    let aux = [
-        AuxEntry::RuntimeInfo(&rtinfo as *const _ as usize, 1),
-        AuxEntry::Null,
-    ];
-    println!("==> {:p}", entry);
-    drop(state);
-    entry(aux.as_ptr());
-    /*
-    let sym = state
-        .dynlink
-        .lookup_symbol(libhw_id, "test_sec_call", LookupFlags::empty())?;
-
-    let addr = sym.reloc_value();
-    info!("addr = {:x}", addr);
-    let ptr: extern "C" fn() = unsafe { core::mem::transmute(addr as usize) };
-    (ptr)();
-    */
 
     Ok(())
 }

--- a/src/runtime/monitor/src/mon/compartment.rs
+++ b/src/runtime/monitor/src/mon/compartment.rs
@@ -2,14 +2,17 @@ use std::collections::HashMap;
 
 use twizzler_runtime_api::ObjID;
 
-use self::runcomp::RunComp;
 use crate::api::MONITOR_INSTANCE_ID;
 
 mod compconfig;
 mod compthread;
 mod runcomp;
 
+pub use compconfig::*;
+pub use runcomp::*;
+
 /// Manages compartments.
+#[derive(Default)]
 pub struct CompartmentMgr {
     names: HashMap<String, ObjID>,
     instances: HashMap<ObjID, RunComp>,

--- a/src/runtime/monitor/src/mon/compartment/runcomp.rs
+++ b/src/runtime/monitor/src/mon/compartment/runcomp.rs
@@ -84,6 +84,11 @@ impl RunComp {
         self.comp_config_object.read_comp_config()
     }
 
+    /// Get a pointer to the compartment config.
+    pub fn comp_config_ptr(&self) -> *const SharedCompConfig {
+        self.comp_config_object.get_comp_config()
+    }
+
     /// Set the compartment config.
     pub fn set_comp_config(&mut self, scc: SharedCompConfig) {
         self.comp_config_object.write_config(scc)

--- a/src/runtime/monitor/src/mon/compartment/runcomp.rs
+++ b/src/runtime/monitor/src/mon/compartment/runcomp.rs
@@ -69,8 +69,9 @@ impl RunComp {
     }
 
     /// Map an object into this compartment.
-    pub fn map_object(&mut self, info: MapInfo) -> Result<MapHandle, MapError> {
-        todo!()
+    pub fn map_object(&mut self, info: MapInfo, handle: MapHandle) -> Result<MapHandle, MapError> {
+        self.mapped_objects.insert(info, handle.clone());
+        Ok(handle)
     }
 
     /// Unmap and object from this compartment.

--- a/src/runtime/monitor/src/mon/compartment/runcomp.rs
+++ b/src/runtime/monitor/src/mon/compartment/runcomp.rs
@@ -43,6 +43,31 @@ pub struct RunComp {
 }
 
 impl RunComp {
+    pub fn new(
+        sctx: ObjID,
+        instance: ObjID,
+        name: String,
+        compartment_id: CompartmentId,
+        deps: Vec<ObjID>,
+        comp_config_object: CompConfigObject,
+        flags: u64,
+    ) -> Self {
+        let mut alloc = Talc::new(ErrOnOom);
+        unsafe { alloc.claim(comp_config_object.alloc_span()).unwrap() };
+        Self {
+            sctx,
+            instance,
+            name,
+            compartment_id,
+            main: None,
+            deps,
+            comp_config_object,
+            alloc,
+            mapped_objects: HashMap::default(),
+            flags: Box::new(AtomicU64::new(flags)),
+        }
+    }
+
     /// Map an object into this compartment.
     pub fn map_object(&mut self, info: MapInfo) -> Result<MapHandle, MapError> {
         todo!()

--- a/src/runtime/monitor/src/mon/mod.rs
+++ b/src/runtime/monitor/src/mon/mod.rs
@@ -1,8 +1,16 @@
-use std::sync::OnceLock;
+use std::{cell::OnceCell, sync::OnceLock};
 
-use happylock::RwLock;
+use dynlink::compartment::MONITOR_COMPARTMENT_ID;
+use happylock::{LockCollection, RwLock, ThreadKey};
+use monitor_api::SharedCompConfig;
+use twizzler_runtime_api::{MapFlags, SpawnError};
 
-use self::space::Unmapper;
+use self::{
+    compartment::{CompConfigObject, RunComp},
+    space::Unmapper,
+    thread::ManagedThread,
+};
+use crate::{api::MONITOR_INSTANCE_ID, init::InitDynlinkContext};
 
 pub(crate) mod compartment;
 pub(crate) mod space;
@@ -15,11 +23,73 @@ pub(crate) mod thread;
 /// 'dynlink', which contains the dynamic linker state. The unmapper allows for background unmapping
 /// and cleanup of objects and handles.
 pub struct Monitor {
-    space: RwLock<space::Space>,
-    thread_mgr: RwLock<thread::ThreadMgr>,
-    compartments: RwLock<compartment::CompartmentMgr>,
-    dynlink: RwLock<dynlink::context::Context>,
-    unmapper: Unmapper,
+    locks: LockCollection<MonitorInner<'static>>,
+    unmapper: OnceLock<Unmapper>,
+    pub space: &'static RwLock<space::Space>,
+    pub thread_mgr: &'static RwLock<thread::ThreadMgr>,
+    pub comp_mgr: &'static RwLock<compartment::CompartmentMgr>,
+    pub dynlink: &'static RwLock<&'static mut dynlink::context::Context>,
+}
+
+type MonitorInner<'a> = (
+    &'a RwLock<space::Space>,
+    &'a RwLock<thread::ThreadMgr>,
+    &'a RwLock<compartment::CompartmentMgr>,
+    &'a RwLock<&'static mut dynlink::context::Context>,
+);
+
+impl Monitor {
+    pub fn start_background_threads(&mut self) {
+        self.unmapper.set(Unmapper::new()).ok().unwrap();
+        self.thread_mgr
+            .write(ThreadKey::get().unwrap())
+            .start_cleaner();
+    }
+
+    pub fn new(init: InitDynlinkContext) -> Self {
+        let mut comp_mgr = compartment::CompartmentMgr::default();
+        let mut space = space::Space::default();
+        let monitor_scc = SharedCompConfig::new(MONITOR_INSTANCE_ID, std::ptr::null_mut());
+        let handle = space
+            .safe_create_and_map_runtime_object(
+                MONITOR_INSTANCE_ID,
+                MapFlags::READ | MapFlags::WRITE,
+            )
+            .unwrap();
+        comp_mgr.insert(RunComp::new(
+            MONITOR_INSTANCE_ID,
+            MONITOR_INSTANCE_ID,
+            "monitor".to_string(),
+            MONITOR_COMPARTMENT_ID,
+            vec![],
+            CompConfigObject::new(handle, monitor_scc),
+            0,
+        ));
+
+        let space = Box::leak(Box::new(RwLock::new(space)));
+        let thread_mgr = Box::leak(Box::new(RwLock::new(thread::ThreadMgr::default())));
+        let comp_mgr = Box::leak(Box::new(RwLock::new(comp_mgr)));
+        let dynlink = Box::leak(Box::new(RwLock::new(unsafe { init.ctx.as_mut().unwrap() })));
+
+        Self {
+            locks: LockCollection::try_new((&*space, &*thread_mgr, &*comp_mgr, &*dynlink)).unwrap(),
+            unmapper: OnceLock::new(),
+            space,
+            thread_mgr,
+            comp_mgr,
+            dynlink,
+        }
+    }
+
+    pub fn start_thread(&self, main: Box<dyn FnOnce()>) -> Result<ManagedThread, SpawnError> {
+        let key = ThreadKey::get().unwrap();
+        let locks = &mut *self.locks.lock(key);
+
+        let monitor_dynlink_comp = locks.3.get_compartment_mut(MONITOR_COMPARTMENT_ID).unwrap();
+        locks
+            .1
+            .start_thread(&mut *locks.0, monitor_dynlink_comp, main)
+    }
 }
 
 static MONITOR: OnceLock<Monitor> = OnceLock::new();
@@ -36,3 +106,5 @@ pub fn set_monitor(monitor: Monitor) {
         panic!("second call to set_monitor");
     }
 }
+
+pub use space::early_object_map;

--- a/src/runtime/monitor/src/mon/mod.rs
+++ b/src/runtime/monitor/src/mon/mod.rs
@@ -5,7 +5,7 @@ use happylock::{LockCollection, RwLock, ThreadKey};
 use monitor_api::{SharedCompConfig, TlsTemplateInfo};
 use twizzler_abi::upcall::UpcallFrame;
 use twizzler_runtime_api::{MapError, MapFlags, ObjID, SpawnError, ThreadSpawnArgs};
-use twz_rt::RuntimeThreadControl;
+use twz_rt::{RuntimeState, RuntimeThreadControl, OUR_RUNTIME};
 
 use self::{
     compartment::{CompConfigObject, RunComp},
@@ -25,15 +25,21 @@ pub(crate) mod thread;
 /// 'dynlink', which contains the dynamic linker state. The unmapper allows for background unmapping
 /// and cleanup of objects and handles.
 pub struct Monitor {
-    locks: LockCollection<MonitorInner<'static>>,
+    locks: LockCollection<MonitorLocks<'static>>,
     unmapper: OnceLock<Unmapper>,
+    /// Management of address space.
     pub space: &'static RwLock<space::Space>,
+    /// Management of all threads.
     pub thread_mgr: &'static RwLock<thread::ThreadMgr>,
+    /// Management of compartments.
     pub comp_mgr: &'static RwLock<compartment::CompartmentMgr>,
+    /// Dynamic linker state.
     pub dynlink: &'static RwLock<&'static mut dynlink::context::Context>,
 }
 
-type MonitorInner<'a> = (
+// We allow locking individually, using eg mon.space.write(key), or locking the collection for more
+// complex operations that touch multiple pieces of state.
+type MonitorLocks<'a> = (
     &'a RwLock<space::Space>,
     &'a RwLock<thread::ThreadMgr>,
     &'a RwLock<compartment::CompartmentMgr>,
@@ -41,7 +47,10 @@ type MonitorInner<'a> = (
 );
 
 impl Monitor {
+    /// Start the background threads for the monitor instance. Must be done only once the monitor
+    /// has been initialized.
     pub fn start_background_threads(&self) {
+        assert!(OUR_RUNTIME.state().contains(RuntimeState::READY));
         let cleaner = ThreadCleaner::new();
         self.unmapper.set(Unmapper::new()).ok().unwrap();
         self.thread_mgr
@@ -49,10 +58,12 @@ impl Monitor {
             .set_cleaner(cleaner);
     }
 
+    /// Build a new monitor state from the initial dynamic linker context.
     pub fn new(init: InitDynlinkContext) -> Self {
         let mut comp_mgr = compartment::CompartmentMgr::default();
         let mut space = space::Space::default();
 
+        // Build our TLS region, and create a template for the monitor compartment.
         let super_tls = (unsafe { &mut *init.ctx })
             .get_compartment_mut(MONITOR_COMPARTMENT_ID)
             .unwrap()
@@ -60,9 +71,9 @@ impl Monitor {
                 NonNull::new(std::alloc::alloc_zeroed(layout))
             })
             .unwrap();
-
         let template: &'static TlsTemplateInfo = Box::leak(Box::new(super_tls.into()));
 
+        // Set up the monitor's compartment.
         let monitor_scc =
             SharedCompConfig::new(MONITOR_INSTANCE_ID, template as *const _ as *mut _);
         let handle = space
@@ -81,11 +92,14 @@ impl Monitor {
             0,
         ));
 
+        // Allocate and leak all the locks (they are global and eternal, so we can do this to safely
+        // and correctly get &'static lifetime)
         let space = Box::leak(Box::new(RwLock::new(space)));
         let thread_mgr = Box::leak(Box::new(RwLock::new(thread::ThreadMgr::default())));
         let comp_mgr = Box::leak(Box::new(RwLock::new(comp_mgr)));
         let dynlink = Box::leak(Box::new(RwLock::new(unsafe { init.ctx.as_mut().unwrap() })));
 
+        // Okay to call try_new here, since it's not many locks and only happens once.
         Self {
             locks: LockCollection::try_new((&*space, &*thread_mgr, &*comp_mgr, &*dynlink)).unwrap(),
             unmapper: OnceLock::new(),
@@ -96,6 +110,7 @@ impl Monitor {
         }
     }
 
+    /// Start a managed monitor thread.
     pub fn start_thread(&self, main: Box<dyn FnOnce()>) -> Result<ManagedThread, SpawnError> {
         let key = ThreadKey::get().unwrap();
         let locks = &mut *self.locks.lock(key);
@@ -106,7 +121,8 @@ impl Monitor {
             .start_thread(&mut *locks.0, monitor_dynlink_comp, main)
     }
 
-    pub fn spawn_user_thread(
+    /// Spawn a thread into a given compartment, using initial thread arguments.
+    pub fn spawn_compartment_thread(
         &self,
         instance: ObjID,
         args: ThreadSpawnArgs,
@@ -127,11 +143,13 @@ impl Monitor {
         Ok(thread.id)
     }
 
+    /// Get the compartment config for the given compartment.
     pub fn get_comp_config(&self, sctx: ObjID) -> Option<*const SharedCompConfig> {
         let comps = self.comp_mgr.read(ThreadKey::get().unwrap());
         Some(comps.get(sctx)?.comp_config_ptr())
     }
 
+    /// Map an object into a given compartment.
     pub fn map_object(&self, sctx: ObjID, info: MapInfo) -> Result<MapHandle, MapError> {
         let handle = self.space.write(ThreadKey::get().unwrap()).map(info)?;
 

--- a/src/runtime/monitor/src/mon/mod.rs
+++ b/src/runtime/monitor/src/mon/mod.rs
@@ -3,7 +3,8 @@ use std::{cell::OnceCell, sync::OnceLock};
 use dynlink::compartment::MONITOR_COMPARTMENT_ID;
 use happylock::{LockCollection, RwLock, ThreadKey};
 use monitor_api::SharedCompConfig;
-use twizzler_runtime_api::{MapFlags, SpawnError};
+use twizzler_abi::upcall::UpcallFrame;
+use twizzler_runtime_api::{MapFlags, ObjID, SpawnError, ThreadSpawnArgs};
 
 use self::{
     compartment::{CompConfigObject, RunComp},
@@ -39,7 +40,7 @@ type MonitorInner<'a> = (
 );
 
 impl Monitor {
-    pub fn start_background_threads(&mut self) {
+    pub fn start_background_threads(&self) {
         self.unmapper.set(Unmapper::new()).ok().unwrap();
         self.thread_mgr
             .write(ThreadKey::get().unwrap())
@@ -89,6 +90,26 @@ impl Monitor {
         locks
             .1
             .start_thread(&mut *locks.0, monitor_dynlink_comp, main)
+    }
+
+    pub fn spawn_user_thread(
+        &self,
+        instance: ObjID,
+        args: ThreadSpawnArgs,
+        stack_ptr: usize,
+        thread_ptr: usize,
+    ) -> Result<ObjID, SpawnError> {
+        let thread = self.start_thread(Box::new(|| {
+            
+            let frame = UpcallFrame::
+        }
+        ))?;
+        Ok(thread.id)
+    }
+
+    pub fn get_comp_config(&self, sctx: ObjID) -> Option<*const SharedCompConfig> {
+        let comps = self.comp_mgr.read(ThreadKey::get().unwrap());
+        Some(comps.get(sctx)?.comp_config_ptr())
     }
 }
 

--- a/src/runtime/monitor/src/mon/space.rs
+++ b/src/runtime/monitor/src/mon/space.rs
@@ -157,8 +157,8 @@ impl Space {
     }
 }
 
-// Allows us to call handle_drop and do all the hard work in the caller, since
-// the caller probably had to hold a lock to call these functions.
+/// Allows us to call handle_drop and do all the hard work in the caller, since
+/// the caller probably had to hold a lock to call these functions.
 pub(crate) struct UnmapOnDrop {
     slot: usize,
 }
@@ -173,6 +173,8 @@ impl Drop for UnmapOnDrop {
     }
 }
 
+/// Map an object into the address space, without tracking it. This leaks the mapping, but is useful
+/// for bootstrapping. See the object mapping gate comments for more details.
 pub fn early_object_map(info: MapInfo) -> MappedObjectAddrs {
     let slot = twz_rt::OUR_RUNTIME.allocate_slot().unwrap();
 

--- a/src/runtime/monitor/src/mon/space/handle.rs
+++ b/src/runtime/monitor/src/mon/space/handle.rs
@@ -42,6 +42,8 @@ impl Drop for MapHandleInner {
     fn drop(&mut self) {
         // Toss this work onto a background thread.
         let monitor = get_monitor();
-        monitor.unmapper.background_unmap_info(self.info);
+        if let Some(unmapper) = monitor.unmapper.get() {
+            unmapper.background_unmap_info(self.info);
+        }
     }
 }

--- a/src/runtime/monitor/src/mon/thread.rs
+++ b/src/runtime/monitor/src/mon/thread.rs
@@ -20,6 +20,7 @@ use super::space::{MapHandle, MapInfo, Space};
 use crate::api::MONITOR_INSTANCE_ID;
 
 mod cleaner;
+pub(crate) use cleaner::ThreadCleaner;
 
 /// Stack size for the supervisor upcall stack.
 pub const SUPER_UPCALL_STACK_SIZE: usize = 8 * 1024 * 1024; // 8MB
@@ -48,11 +49,8 @@ impl Default for ThreadMgr {
 }
 
 impl ThreadMgr {
-    pub(super) fn start_cleaner(&mut self) {
-        self.cleaner
-            .set(cleaner::ThreadCleaner::new())
-            .ok()
-            .unwrap();
+    pub(super) fn set_cleaner(&mut self, cleaner: cleaner::ThreadCleaner) {
+        self.cleaner.set(cleaner).ok().unwrap();
     }
 
     fn do_remove(&mut self, thread: &ManagedThread) {
@@ -183,6 +181,7 @@ impl core::fmt::Debug for ManagedThreadInner {
 
 impl Drop for ManagedThreadInner {
     fn drop(&mut self) {
+        // TODO
         tracing::trace!("dropping ManagedThread {}", self.id);
     }
 }

--- a/src/runtime/monitor/src/mon/thread/cleaner.rs
+++ b/src/runtime/monitor/src/mon/thread/cleaner.rs
@@ -19,7 +19,7 @@ use super::ManagedThread;
 use crate::mon::get_monitor;
 
 /// Tracks threads that do not exit cleanly, so their monitor-internal resources can be cleaned up.
-pub(super) struct ThreadCleaner {
+pub(crate) struct ThreadCleaner {
     thread: std::thread::JoinHandle<()>,
     send: Sender<WaitOp>,
     inner: Pin<Arc<ThreadCleanerData>>,
@@ -45,7 +45,7 @@ enum WaitOp {
 
 impl ThreadCleaner {
     /// Makes a new ThreadCleaner.
-    pub(super) fn new() -> Self {
+    pub(crate) fn new() -> Self {
         let (send, recv) = std::sync::mpsc::channel();
         let data = Arc::pin(ThreadCleanerData::default());
         let inner = data.clone();

--- a/src/runtime/twz-rt/src/lib.rs
+++ b/src/runtime/twz-rt/src/lib.rs
@@ -17,7 +17,9 @@ pub(crate) mod arch;
 pub use arch::rr_upcall_entry;
 
 mod runtime;
-pub use runtime::{set_upcall_handler, CompartmentInitInfo, RuntimeThreadControl, OUR_RUNTIME};
+pub use runtime::{
+    set_upcall_handler, CompartmentInitInfo, RuntimeState, RuntimeThreadControl, OUR_RUNTIME,
+};
 
 mod error;
 pub use error::*;

--- a/src/runtime/twz-rt/src/runtime.rs
+++ b/src/runtime/twz-rt/src/runtime.rs
@@ -53,11 +53,14 @@ bitflags::bitflags! {
 }
 
 impl ReferenceRuntime {
-    pub(crate) fn state(&self) -> RuntimeState {
+    /// Returns the runtime state flags.
+    pub fn state(&self) -> RuntimeState {
         RuntimeState::from_bits_truncate(self.state.load(Ordering::SeqCst))
     }
 
-    fn set_runtime_ready(&self) {
+    /// Set the runtime ready state. If the runtime has not been initialized, the result is
+    /// undefined.
+    pub unsafe fn set_runtime_ready(&self) {
         self.state
             .fetch_or(RuntimeState::READY.bits(), Ordering::SeqCst);
     }

--- a/src/runtime/twz-rt/src/runtime/alloc.rs
+++ b/src/runtime/twz-rt/src/runtime/alloc.rs
@@ -92,7 +92,7 @@ fn create_and_map() -> Option<(usize, ObjID)> {
         .ok();
 
     if let Some(slot) = slot {
-        Some((slot, id))
+        Some((slot.slot, id))
     } else {
         delete_obj(id);
         None

--- a/src/runtime/twz-rt/src/runtime/alloc.rs
+++ b/src/runtime/twz-rt/src/runtime/alloc.rs
@@ -117,7 +117,8 @@ impl OomHandler for RuntimeOom {
                 .is_err()
             {
                 delete_obj(id);
-                monitor_api::monitor_rt_object_unmap(slot).unwrap();
+                monitor_api::monitor_rt_object_unmap(slot, id, MapFlags::READ | MapFlags::WRITE)
+                    .unwrap();
                 return Err(());
             }
         }

--- a/src/runtime/twz-rt/src/runtime/core.rs
+++ b/src/runtime/twz-rt/src/runtime/core.rs
@@ -122,8 +122,9 @@ impl CoreRuntime for ReferenceRuntime {
         preinit_println!("====== {}", TLS_TEST);
         if self.state().contains(RuntimeState::IS_MONITOR) {
             self.init_slots();
+        } else {
+            unsafe { self.set_runtime_ready() };
         }
-        self.set_runtime_ready();
     }
 
     fn post_main_hook(&self) {}

--- a/src/runtime/twz-rt/src/runtime/object.rs
+++ b/src/runtime/twz-rt/src/runtime/object.rs
@@ -148,7 +148,11 @@ impl ObjectHandleManager {
         if !self.map().contains_key(&key) {
             self.map().insert(
                 key,
-                LocalSlot::new(monitor_api::monitor_rt_object_map(key.0, key.1).unwrap()?),
+                LocalSlot::new(
+                    monitor_api::monitor_rt_object_map(key.0, key.1)
+                        .unwrap()?
+                        .slot,
+                ),
             );
         }
 

--- a/src/runtime/twz-rt/src/runtime/object.rs
+++ b/src/runtime/twz-rt/src/runtime/object.rs
@@ -168,7 +168,8 @@ impl ObjectHandleManager {
         let key = ObjectMapKey(handle.id.into(), handle.flags);
         if let Some(entry) = self.map().get(&key) {
             if entry.refs.fetch_sub(1, atomic::Ordering::SeqCst) == 1 {
-                monitor_api::monitor_rt_object_unmap(entry.number).unwrap();
+                monitor_api::monitor_rt_object_unmap(entry.number, handle.id, handle.flags)
+                    .unwrap();
                 self.map().remove(&key);
             }
         }


### PR DESCRIPTION
This PR is the second in a series implementing the security monitor, building off #199. It implements:

- Mapping objects using the new monitor implementation.
- Spawning compartment threads.
- Getting compartment config info.
- Implements Monitor struct locking.
- Monitor init up till ready to load a compartment (next PR :) )