### PR TITLE
Add support for benchmarking

### DIFF
--- a/src/bin/init/src/main.rs
+++ b/src/bin/init/src/main.rs
@@ -241,15 +241,14 @@ fn exec2(name: &str, id: ObjID) -> Option<ObjID> {
     //println!("ELF: {:?}", elf);
 }
 
-fn exec_n(name: &str, id: ObjID, args: &[&str]) {
+fn exec_n(name: &str, id: ObjID, args: &[&str]) -> Option<ObjID> {
     let env: Vec<String> = std::env::vars()
         .map(|(n, v)| format!("{}={}", n, v))
         .collect();
     let env_ref: Vec<&[u8]> = env.iter().map(|x| x.as_str().as_bytes()).collect();
     let mut fullargs = vec![name.as_bytes()];
     fullargs.extend(args.iter().map(|x| x.as_bytes()));
-    let _elf = twizzler_abi::runtime::load_elf::spawn_new_executable(id, &fullargs, &env_ref);
-    //println!("ELF: {:?}", elf);
+    twizzler_abi::runtime::load_elf::spawn_new_executable(id, &fullargs, &env_ref).ok()
 }
 
 fn find_init_name(name: &str) -> Option<ObjID> {
@@ -360,49 +359,8 @@ fn main() {
     twizzler_net::wait_until_network_manager_ready(netid);
     println!("network manager is up!");
 
-    if let Some(id) = find_init_name("test_bins") {
-        println!("=== found init test list ===");
-        let runtime = __twz_get_runtime();
-        let handle = runtime.map_object(id, Protections::READ.into()).unwrap();
-
-        let addr = unsafe { handle.start.add(NULLPAGE_SIZE) };
-        let bytes = unsafe {
-            core::slice::from_raw_parts(addr as *const u8, twizzler_abi::object::MAX_SIZE)
-        };
-        let bytes = &bytes[0..bytes.iter().position(|r| *r == 0).unwrap_or(0)];
-        let str = String::from_utf8(bytes.to_vec()).unwrap();
-        let mut test_failed = false;
-        for line in str.split("\n").filter(|l| !l.is_empty()) {
-            println!("STARTING TEST {}", line);
-            if let Some(id) = find_init_name(line) {
-                let tid = exec2(line, id);
-                if let Some(tid) = tid {
-                    let thandle = runtime.map_object(tid, Protections::READ.into()).unwrap();
-
-                    let taddr = unsafe { thandle.start.add(NULLPAGE_SIZE) };
-                    let tr = taddr as *const ThreadRepr;
-                    unsafe {
-                        let val = tr.as_ref().unwrap().wait(None);
-                        if let Some(val) = val {
-                            if val.0 == ExecutionState::Exited && val.1 != 0
-                                || val.0 == ExecutionState::Suspended
-                            {
-                                test_failed = true;
-                            }
-                        }
-                    }
-                }
-            } else {
-                println!("FAILED to start {}", line);
-                test_failed = true;
-            }
-        }
-        if test_failed {
-            println!("!!! TEST MODE FAILED");
-        }
-        #[allow(deprecated)]
-        twizzler_abi::syscall::sys_debug_shutdown(if test_failed { 1 } else { 0 });
-    }
+    run_tests("test_bins", false);
+    run_tests("bench_bins", true);
 
     println!("Hi, welcome to the basic twizzler test console.");
     println!("If you wanted line-editing, you've come to the wrong place.");
@@ -444,6 +402,53 @@ fn main() {
     }
 
     loop {}
+}
+
+fn run_tests(test_list_name: &str, benches: bool) {
+    if let Some(id) = find_init_name(test_list_name) {
+        println!("=== found init test list ===");
+        let runtime = __twz_get_runtime();
+        let handle = runtime.map_object(id, Protections::READ.into()).unwrap();
+
+        let addr = unsafe { handle.start.add(NULLPAGE_SIZE) };
+        let bytes = unsafe {
+            core::slice::from_raw_parts(addr as *const u8, twizzler_abi::object::MAX_SIZE)
+        };
+        let bytes = &bytes[0..bytes.iter().position(|r| *r == 0).unwrap_or(0)];
+        let str = String::from_utf8(bytes.to_vec()).unwrap();
+        let mut test_failed = false;
+        for line in str.split("\n").filter(|l| !l.is_empty()) {
+            println!("STARTING TEST {}", line);
+            if let Some(id) = find_init_name(line) {
+                let args = &if benches { ["--bench"] } else { ["--test"] };
+                let tid = exec_n(line, id, args);
+                if let Some(tid) = tid {
+                    let thandle = runtime.map_object(tid, Protections::READ.into()).unwrap();
+
+                    let taddr = unsafe { thandle.start.add(NULLPAGE_SIZE) };
+                    let tr = taddr as *const ThreadRepr;
+                    unsafe {
+                        let val = tr.as_ref().unwrap().wait(None);
+                        if let Some(val) = val {
+                            if val.0 == ExecutionState::Exited && val.1 != 0
+                                || val.0 == ExecutionState::Suspended
+                            {
+                                test_failed = true;
+                            }
+                        }
+                    }
+                }
+            } else {
+                println!("FAILED to start {}", line);
+                test_failed = true;
+            }
+        }
+        if test_failed {
+            println!("!!! TEST MODE FAILED");
+        }
+        #[allow(deprecated)]
+        twizzler_abi::syscall::sys_debug_shutdown(if test_failed { 1 } else { 0 });
+    }
 }
 
 /*

--- a/src/lib/twizzler-abi/src/lib.rs
+++ b/src/lib/twizzler-abi/src/lib.rs
@@ -22,6 +22,7 @@
 #![feature(asm_const)]
 #![feature(linkage)]
 #![feature(error_in_core)]
+#![feature(test)]
 pub mod arch;
 
 #[allow(unused_extern_crates)]
@@ -85,5 +86,22 @@ fn internal_unwrap_result<T, E>(t: Result<T, E>, msg: &str) -> T {
         unsafe {
             internal_abort();
         }
+    }
+}
+
+#[cfg(test)]
+extern crate test;
+
+#[cfg(test)]
+mod tester {
+    use crate::print_err;
+
+    #[bench]
+    fn test_bench(bench: &mut test::Bencher) {
+        bench.iter(|| {
+            for i in 0..10000 {
+                core::hint::black_box(i);
+            }
+        });
     }
 }

--- a/tools/xtask/src/build.rs
+++ b/tools/xtask/src/build.rs
@@ -295,7 +295,6 @@ fn maybe_build_tests<'a>(
             })
             .collect(),
     );
-    println!("==> {:?}", options.spec);
     options.build_config.force_rebuild = other_options.needs_full_rebuild;
     Ok(Some(cargo::ops::compile(workspace, &options)?))
 }

--- a/tools/xtask/src/image.rs
+++ b/tools/xtask/src/image.rs
@@ -147,20 +147,26 @@ fn build_initrd(cli: &ImageOptions, comp: &TwizzlerCompilation) -> anyhow::Resul
         }
 
         if let Some(ref test_comp) = comp.borrow_test_compilation() {
+            let mut testlist = String::new();
+            for bin in test_comp.tests.iter() {
+                initrd_files.push(bin.path.clone());
+                testlist += &bin.path.file_name().unwrap().to_string_lossy();
+                testlist += "\n";
+            }
             if cli.tests {
-                let mut testlist = String::new();
-                for bin in test_comp.tests.iter() {
-                    initrd_files.push(bin.path.clone());
-                    testlist += &bin.path.file_name().unwrap().to_string_lossy();
-                    testlist += "\n";
-                }
                 let test_file_path = get_genfile_path(comp, "test_bins");
                 let mut file = File::create(&test_file_path)?;
                 file.write_all(testlist.as_bytes())?;
                 initrd_files.push(test_file_path);
             }
+            if cli.benches {
+                let test_file_path = get_genfile_path(comp, "bench_bins");
+                let mut file = File::create(&test_file_path)?;
+                file.write_all(testlist.as_bytes())?;
+                initrd_files.push(test_file_path);
+            }
         } else {
-            assert!(!cli.tests);
+            assert!(!cli.tests && !cli.benches);
         }
 
         let mut lib_path = crate::toolchain::get_rustlib_lib(&cli.config.twz_triple().to_string())?;
@@ -206,21 +212,30 @@ pub(crate) fn do_make_image(cli: ImageOptions) -> anyhow::Result<ImageInfo> {
     let initrd_path = build_initrd(&cli, &comp)?;
 
     crate::print_status_line("disk image", Some(&cli.config));
-    let cmdline = if cli.tests { "--tests" } else { "" };
+    let mut cmdline = String::new();
+    if cli.tests {
+        cmdline.push_str("--tests ");
+    }
+    if cli.benches {
+        cmdline.push_str("--benches");
+    }
     let efi_binary = match cli.config.arch {
         Arch::X86_64 => "toolchain/install/BOOTX64.EFI",
         Arch::Aarch64 => "toolchain/install/BOOTAA64.EFI",
     };
     let image_path = get_genfile_path(&comp, "disk.img");
-    println!("kernel: {:?}", comp.get_kernel_image(cli.tests));
+    println!(
+        "kernel: {:?}",
+        comp.get_kernel_image(cli.tests || cli.benches)
+    );
     let status = Command::new(get_tool_path(&comp, "image_builder")?)
         .arg("--disk-path")
         .arg(&image_path)
         .arg("--kernel-path")
-        .arg(comp.get_kernel_image(cli.tests))
+        .arg(comp.get_kernel_image(cli.tests || cli.benches))
         .arg("--initrd-path")
         .arg(initrd_path)
-        .arg(format!("--cmdline={}", cmdline))
+        .arg(format!("--cmdline={}", cmdline.trim()))
         .arg("--efi-binary")
         .arg(efi_binary)
         .status()?;

--- a/tools/xtask/src/main.rs
+++ b/tools/xtask/src/main.rs
@@ -122,6 +122,8 @@ struct ImageOptions {
     pub config: BuildConfig,
     #[clap(long, short, help = "Build tests-enabled system.")]
     tests: bool,
+    #[clap(long, short, help = "Build benchmark-enabled system.")]
+    benches: bool,
     #[clap(long, short, help = "Only build kernel part of system.")]
     kernel: bool,
 }
@@ -130,7 +132,7 @@ impl From<ImageOptions> for BuildOptions {
     fn from(io: ImageOptions) -> Self {
         Self {
             config: io.config,
-            tests: io.tests,
+            tests: io.tests || io.benches,
             kernel: io.kernel,
         }
     }
@@ -148,6 +150,12 @@ struct QemuOptions {
     qemu_options: Vec<String>,
     #[clap(long, short, help = "Run tests instead of booting normally.")]
     tests: bool,
+    #[clap(
+        long,
+        short,
+        help = "Run benchmarks instead of booting normally. Can be used with --tests."
+    )]
+    benches: bool,
     #[clap(long, short, help = "Only build kernel part of system.")]
     kernel: bool,
 }
@@ -157,6 +165,7 @@ impl From<&QemuOptions> for ImageOptions {
         Self {
             config: qo.config,
             tests: qo.tests,
+            benches: qo.benches,
             kernel: qo.kernel,
         }
     }

--- a/tools/xtask/src/qemu.rs
+++ b/tools/xtask/src/qemu.rs
@@ -85,7 +85,7 @@ impl QemuCommand {
                 self.cmd.arg("-machine").arg("q35,nvdimm=on");
 
                 // add qemu exit device for testing
-                if options.tests {
+                if options.tests || options.benches {
                     // x86 specific
                     self.cmd
                         .arg("-device")
@@ -145,7 +145,7 @@ pub(crate) fn do_start_qemu(cli: QemuOptions) -> anyhow::Result<()> {
     if exit_status.success() {
         Ok(())
     } else {
-        if cli.tests {
+        if cli.tests || cli.benches {
             if exit_status.code().unwrap() == 1 {
                 eprintln!("qemu reports tests passed");
                 std::process::exit(0);

--- a/tools/xtask/src/toolchain.rs
+++ b/tools/xtask/src/toolchain.rs
@@ -292,6 +292,12 @@ pub(crate) fn init_for_build(abi_changes_ok: bool) -> anyhow::Result<()> {
     std::env::set_var("RUSTC", &get_rustc_path()?);
     std::env::set_var("RUSTDOC", &get_rustdoc_path()?);
 
+    let compiler_rt_path = "toolchain/src/rust/src/llvm-project/compiler-rt";
+    std::env::set_var(
+        "RUST_COMPILER_RT_ROOT",
+        Path::new(compiler_rt_path).canonicalize().unwrap(),
+    );
+
     let path = std::env::var("PATH").unwrap();
     let lld_bin = get_lld_bin(guess_host_triple().unwrap())?;
     let llvm_bin = get_llvm_bin(guess_host_triple().unwrap())?;


### PR DESCRIPTION
This PR adds support for the unstable bench framework that's part of rust's test system. The following changes were made:

1. Add a --benches flag to xtask's start-qemu command. This works similar to --tests, but sets up the test binaries to be invoked for benchmarking.
2. Modifies rust to add support for the math library (benchmarks need math functions, we don't link against libm by default because we don't have libc, so I had to bump compiler_builtins to a version that exposes its math library).

With this PR, a programmer can add #[bench] attributes to test functions and use the benchmarking system. These then get run as part of the test system if --benches is supplied. The results are, for now, only printed, and not used as part of CI.