### PR TITLE
Add support for x2apic mode on amd64

### DIFF
--- a/src/kernel/src/arch/amd64/apic/ipi.rs
+++ b/src/kernel/src/arch/amd64/apic/ipi.rs
@@ -21,12 +21,10 @@ pub fn send_ipi(dest: Destination, vector: u32) {
     };
     unsafe {
         let apic = get_lapic();
-        apic.write(LAPIC_ICRHI, dest_val);
-        apic.write(
-            LAPIC_ICRLO,
+        apic.write_icr(
+            dest_val,
             vector | dest_short << LAPIC_ICRLO_DEST_SHORT_OFFSET,
         );
-
         while apic.read(LAPIC_ICRLO) & LAPIC_ICRLO_STATUS_PEND != 0 {
             core::arch::asm!("pause")
         }

--- a/src/kernel/src/arch/amd64/apic/mod.rs
+++ b/src/kernel/src/arch/amd64/apic/mod.rs
@@ -3,5 +3,5 @@ mod local;
 mod trampolines;
 
 pub use ipi::send_ipi;
-pub(super) use local::{get_lapic, init, lapic_interrupt};
+pub(super) use local::{get_lapic, init, lapic_interrupt, try_get_lapic};
 pub use trampolines::poke_cpu;

--- a/src/kernel/src/arch/amd64/ioapic.rs
+++ b/src/kernel/src/arch/amd64/ioapic.rs
@@ -219,8 +219,11 @@ fn disable_pic() {
         x86::io::outb(PIC1_DATA, mask1);
         iowait();
         x86::io::outb(PIC2_DATA, mask2);
+        iowait();
 
-        x86::io::outb(PIC2_DATA, 0xff);
         x86::io::outb(PIC1_DATA, 0xff);
+        iowait();
+        x86::io::outb(PIC2_DATA, 0xff);
+        iowait();
     }
 }

--- a/src/kernel/src/machine/pc/serial.rs
+++ b/src/kernel/src/machine/pc/serial.rs
@@ -124,6 +124,9 @@ impl core::fmt::Write for SerialPort {
     fn write_str(&mut self, s: &str) -> core::fmt::Result {
         for byte in s.bytes() {
             self.send(byte);
+            if byte == b'\n' {
+                self.send(b'\r');
+            }
         }
         Ok(())
     }

--- a/src/kernel/src/memory/context.rs
+++ b/src/kernel/src/memory/context.rs
@@ -14,7 +14,9 @@ use twizzler_abi::{
 };
 
 use self::virtmem::KernelObjectVirtHandle;
+use super::{PhysAddr, VirtAddr};
 use crate::{
+    memory::pagetables::{ContiguousProvider, MappingFlags, MappingSettings},
     obj::{InvalidateMode, ObjectRef, PageNumber},
     syscall::object::ObjectHandle,
 };

--- a/src/kernel/src/processor.rs
+++ b/src/kernel/src/processor.rs
@@ -394,7 +394,8 @@ pub fn boot_all_secondaries(tls_template: TlsInfo) {
 
 pub fn register(id: u32, bsp_id: u32) {
     if id as usize >= unsafe { &ALL_PROCESSORS }.len() {
-        unimplemented!("processor ID too large");
+        logln!("processor ID {} not supported (too large)", id);
+        return;
     }
 
     unsafe {


### PR DESCRIPTION
This PR adds support for the X2 mode of the advanced programmed interrupt controller on AMD64 machines. This is an extension to the original APIC, but on some CPU models, seems to be required. It makes programming the interrupt controller faster, too, since it allows for access to the registers via MSRs instead of MMIO.