### PR TITLE
Twizzler crate stubs for transactions and pointers.

### DIFF
--- a/src/lib/twizzler/src/alloc/arena.rs
+++ b/src/lib/twizzler/src/alloc/arena.rs
@@ -1,8 +1,28 @@
 use super::Allocator;
-use crate::object::Object;
+use crate::{object::Object, ptr::GlobalPtr};
+
+pub struct ArenaObject {
+    obj: Object<ArenaBase>,
+}
+
+impl ArenaObject {
+    pub fn new() -> Self {
+        todo!()
+    }
+
+    pub fn allocator(&self) -> ArenaAllocator {
+        todo!()
+    }
+}
 
 pub struct ArenaAllocator {
-    obj: Object<ArenaBase>,
+    ptr: GlobalPtr<ArenaBase>,
+}
+
+impl ArenaAllocator {
+    pub fn new(ptr: GlobalPtr<ArenaBase>) -> Self {
+        Self { ptr }
+    }
 }
 
 #[repr(C)]

--- a/src/lib/twizzler/src/alloc/invbox.rs
+++ b/src/lib/twizzler/src/alloc/invbox.rs
@@ -1,5 +1,60 @@
-use crate::{marker::Invariant, ptr::InvPtr};
+use super::Allocator;
+use crate::{
+    marker::{Invariant, Storable},
+    ptr::InvPtr,
+    tx::{Result, TxHandle},
+};
 
-pub struct InvBox<T: Invariant> {
+pub struct InvBox<T: Invariant, Alloc: Allocator> {
     raw: InvPtr<T>,
+    alloc: Alloc,
+}
+
+impl<T: Invariant, Alloc: Allocator> InvBox<T, Alloc> {
+    pub unsafe fn from_invptr(raw: InvPtr<T>, alloc: Alloc) -> Self {
+        todo!()
+    }
+
+    pub fn new_in(val: T, alloc: Alloc, tx: &impl TxHandle) -> Result<Storable<Self>> {
+        todo!()
+    }
+}
+
+mod tests {
+    use super::InvBox;
+    use crate::{
+        alloc::arena::{ArenaAllocator, ArenaBase, ArenaObject},
+        marker::{BaseType, Storable},
+        object::{ObjectBuilder, TypedObject},
+        tx::TxHandle,
+    };
+
+    struct Foo {
+        x: InvBox<u32, ArenaAllocator>,
+    }
+
+    impl Foo {
+        pub fn new_in(
+            target: &impl TxHandle,
+            ptr: Storable<InvBox<u32, ArenaAllocator>>,
+        ) -> Storable<Self> {
+            //ptr.check_target(target);
+            unsafe {
+                Storable::new(Foo {
+                    x: ptr.into_inner_unchecked(),
+                })
+            }
+        }
+    }
+
+    impl BaseType for Foo {}
+    fn box_simple() {
+        let builder = ObjectBuilder::<Foo>::default();
+        let alloc = ArenaObject::new().allocator();
+        let obj = builder
+            .build_with(|uo| Foo::new_in(&uo, InvBox::new_in(3, alloc, &uo).unwrap()))
+            .unwrap();
+        let base = obj.base();
+        assert_eq!(*base.x.raw.resolve(), 3);
+    }
 }

--- a/src/lib/twizzler/src/marker.rs
+++ b/src/lib/twizzler/src/marker.rs
@@ -1,5 +1,7 @@
 //! Marker types for invariance, store side-effects, and base types.
 
+use std::mem::MaybeUninit;
+
 /// Indicates that a type is _invariant_ and thus can be stored in an object.
 ///
 /// # Safety
@@ -50,9 +52,41 @@ pub struct PhantomStoreEffect;
 impl !StoreCopy for PhantomStoreEffect {}
 impl !Unpin for PhantomStoreEffect {}
 
+#[derive(Debug)]
+pub struct Storable<T>(MaybeUninit<T>, Option<()>);
+
+unsafe impl<T> StoreCopy for Storable<T> {}
+
+impl<T: StoreCopy> From<T> for Storable<T> {
+    fn from(value: T) -> Self {
+        Self(MaybeUninit::new(value), None)
+    }
+}
+
+impl<T: StoreCopy> Storable<T> {
+    pub fn into_inner(self) -> T {
+        unsafe { self.0.assume_init() }
+    }
+}
+
+impl<T> Storable<T> {
+    pub unsafe fn new(value: T) -> Self {
+        Self(MaybeUninit::new(value), None)
+    }
+
+    pub unsafe fn into_inner_unchecked(self) -> T {
+        unsafe { self.0.assume_init() }
+    }
+}
+
 pub trait BaseType {
     /// The fingerprint of this type.
     fn fingerprint() -> u64 {
         0
     }
 }
+
+impl BaseType for u8 {}
+impl BaseType for u16 {}
+impl BaseType for u32 {}
+impl BaseType for u64 {}

--- a/src/lib/twizzler/src/object.rs
+++ b/src/lib/twizzler/src/object.rs
@@ -2,18 +2,18 @@
 
 use std::marker::PhantomData;
 
-use fot::FotEntry;
-use twizzler_abi::{
-    meta::MetaInfo,
-    object::{ObjID, MAX_SIZE, NULLPAGE_SIZE},
-};
+use twizzler_abi::object::{ObjID, MAX_SIZE, NULLPAGE_SIZE};
 use twizzler_rt_abi::object::ObjectHandle;
 
-use crate::{marker::BaseType, ptr::Ref};
+use crate::{marker::BaseType, ptr::Ref, tx::TxObject};
 
 mod builder;
 mod fot;
 mod meta;
+
+pub use builder::*;
+pub use fot::*;
+pub use meta::*;
 
 /// Operations common to structured objects.
 pub trait TypedObject {
@@ -98,6 +98,12 @@ impl RawObject for ObjectHandle {
 pub struct Object<Base> {
     handle: ObjectHandle,
     _pd: PhantomData<*const Base>,
+}
+
+impl<Base> Object<Base> {
+    pub fn tx(self) -> crate::tx::Result<TxObject<Base>> {
+        todo!()
+    }
 }
 
 impl<Base> RawObject for Object<Base> {

--- a/src/lib/twizzler/src/ptr/invariant.rs
+++ b/src/lib/twizzler/src/ptr/invariant.rs
@@ -1,6 +1,9 @@
 use std::marker::PhantomData;
 
-use crate::marker::{Invariant, PhantomStoreEffect};
+use crate::{
+    marker::{Invariant, PhantomStoreEffect, Storable},
+    tx::TxHandle,
+};
 
 #[repr(C)]
 #[derive(Debug, PartialEq, PartialOrd, Ord, Eq)]
@@ -8,4 +11,10 @@ pub struct InvPtr<T: Invariant> {
     value: u64,
     _pse: PhantomStoreEffect,
     _pd: PhantomData<*const T>,
+}
+
+impl<T: Invariant> InvPtr<T> {
+    pub fn new_in<'a>(target: &impl TxHandle<'a>) -> Storable<Self> {
+        todo!()
+    }
 }

--- a/src/lib/twizzler/src/ptr/invariant.rs
+++ b/src/lib/twizzler/src/ptr/invariant.rs
@@ -1,5 +1,6 @@
 use std::marker::PhantomData;
 
+use super::{GlobalPtr, Ref};
 use crate::{
     marker::{Invariant, PhantomStoreEffect, Storable},
     tx::TxHandle,
@@ -14,7 +15,11 @@ pub struct InvPtr<T: Invariant> {
 }
 
 impl<T: Invariant> InvPtr<T> {
-    pub fn new_in<'a>(target: &impl TxHandle<'a>) -> Storable<Self> {
+    pub fn new_in(target: &impl TxHandle, global: impl Into<GlobalPtr<T>>) -> Storable<Self> {
+        todo!()
+    }
+
+    pub fn resolve<'a>(&self) -> Ref<'a, T> {
         todo!()
     }
 }

--- a/src/lib/twizzler/src/ptr/resolved.rs
+++ b/src/lib/twizzler/src/ptr/resolved.rs
@@ -1,4 +1,4 @@
-use std::marker::PhantomData;
+use std::{marker::PhantomData, ops::Deref};
 
 use twizzler_rt_abi::object::ObjectHandle;
 
@@ -6,4 +6,12 @@ pub struct Ref<'obj, T> {
     ptr: *const T,
     handle: *const ObjectHandle,
     _pd: PhantomData<&'obj T>,
+}
+
+impl<'obj, T> Deref for Ref<'obj, T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        unsafe { self.ptr.as_ref().unwrap_unchecked() }
+    }
 }

--- a/src/lib/twizzler/src/ptr/resolved.rs
+++ b/src/lib/twizzler/src/ptr/resolved.rs
@@ -1,6 +1,11 @@
-use std::{marker::PhantomData, ops::Deref};
+use std::{
+    marker::PhantomData,
+    ops::{Deref, DerefMut},
+};
 
 use twizzler_rt_abi::object::ObjectHandle;
+
+use super::GlobalPtr;
 
 pub struct Ref<'obj, T> {
     ptr: *const T,
@@ -13,5 +18,37 @@ impl<'obj, T> Deref for Ref<'obj, T> {
 
     fn deref(&self) -> &Self::Target {
         unsafe { self.ptr.as_ref().unwrap_unchecked() }
+    }
+}
+
+impl<'a, T> From<Ref<'a, T>> for GlobalPtr<T> {
+    fn from(value: Ref<'a, T>) -> Self {
+        todo!()
+    }
+}
+
+pub struct RefMut<'obj, T> {
+    ptr: *mut T,
+    handle: *const ObjectHandle,
+    _pd: PhantomData<&'obj mut T>,
+}
+
+impl<'obj, T> Deref for RefMut<'obj, T> {
+    type Target = T;
+
+    fn deref(&self) -> &Self::Target {
+        unsafe { self.ptr.as_ref().unwrap_unchecked() }
+    }
+}
+
+impl<'obj, T> DerefMut for RefMut<'obj, T> {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        unsafe { self.ptr.as_mut().unwrap_unchecked() }
+    }
+}
+
+impl<'a, T> From<RefMut<'a, T>> for GlobalPtr<T> {
+    fn from(value: RefMut<'a, T>) -> Self {
+        todo!()
     }
 }

--- a/src/lib/twizzler/src/tx.rs
+++ b/src/lib/twizzler/src/tx.rs
@@ -1,21 +1,22 @@
-/// A trait for implementing transaction handles.
-///
-/// Takes a lifetime argument, 'obj. All object handles referenced by this transaction must have
-/// this lifetime or longer.
-pub trait TxHandle<'obj> {
-    /// Ensures transactional safety for mutably accessing data given by the range [data, data +
-    /// sizeof(T)).
-    fn tx_mut<T, E>(&self, data: *const T) -> TxResult<*mut T, E>;
+mod batch;
+mod object;
+mod unsafetx;
+
+pub use batch::*;
+pub use object::*;
+pub use unsafetx::*;
+
+/// A trait for implementing per-object transaction handles.
+pub trait TxHandle {
+    /// Ensures transactional safety for mutably accessing data in the range [data, data + len).
+    fn tx_mut(&self, data: *const u8, len: usize) -> Result<*mut u8>;
 }
 
-pub type TxResult<T, E = ()> = Result<T, TxError<E>>;
+pub type Result<T> = std::result::Result<T, TxError>;
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, thiserror::Error)]
 /// Transaction errors, with user-definable abort type.
-pub enum TxError<E> {
-    /// Transaction aborted.
-    #[error("aborted: {0}")]
-    Abort(E),
+pub enum TxError {
     /// Resources exhausted.
     #[error("resources exhausted")]
     Exhausted,

--- a/src/lib/twizzler/src/tx/batch.rs
+++ b/src/lib/twizzler/src/tx/batch.rs
@@ -1,0 +1,73 @@
+use std::marker::PhantomData;
+
+use super::{Result, TxHandle, TxObject};
+use crate::object::Object;
+
+#[derive(Default)]
+pub struct TxBatch {
+    txs: Vec<Box<dyn TxHandle>>,
+}
+
+#[repr(transparent)]
+#[derive(PartialEq, Eq, PartialOrd, Ord, Hash, Debug)]
+pub struct HandleIdx<B>(usize, PhantomData<B>);
+
+impl<B> Clone for HandleIdx<B> {
+    fn clone(&self) -> Self {
+        Self(self.0, self.1)
+    }
+}
+
+impl<B> Copy for HandleIdx<B> {}
+
+impl TxBatch {
+    pub fn tx<B>(&mut self, obj: Object<B>) -> Result<HandleIdx<B>> {
+        todo!()
+    }
+
+    pub fn handle<B>(&self, idx: HandleIdx<B>) -> &TxObject<B> {
+        todo!()
+    }
+
+    pub fn handle_mut<B>(&mut self, idx: HandleIdx<B>) -> &mut TxObject<B> {
+        todo!()
+    }
+
+    pub fn commit<B>(&mut self, idx: HandleIdx<B>) -> Result<Object<B>> {
+        todo!()
+    }
+}
+
+mod tests {
+    use crate::{
+        marker::BaseType,
+        object::{ObjectBuilder, TypedObject},
+        tx::TxBatch,
+    };
+
+    struct Simple {
+        x: u32,
+    }
+
+    impl BaseType for Simple {}
+
+    fn simple_batch_tx() {
+        let builder = ObjectBuilder::default();
+        let obj1 = builder.build(Simple { x: 3 }).unwrap();
+        let obj2 = builder.build(Simple { x: 7 }).unwrap();
+
+        let (obj1, obj2) = {
+            let mut batch = TxBatch::default();
+            let tx1 = batch.tx(obj1).unwrap();
+            let tx2 = batch.tx(obj2).unwrap();
+            batch.handle_mut(tx1).base_mut().x = 8;
+            batch.handle_mut(tx2).base_mut().x = 12;
+            let obj1 = batch.commit(tx1).unwrap();
+            let obj2 = batch.commit(tx2).unwrap();
+            (obj1, obj2)
+        };
+
+        assert_eq!(obj1.base().x, 8);
+        assert_eq!(obj2.base().x, 12);
+    }
+}

--- a/src/lib/twizzler/src/tx/object.rs
+++ b/src/lib/twizzler/src/tx/object.rs
@@ -1,0 +1,70 @@
+use super::{Result, TxHandle};
+use crate::{
+    marker::BaseType,
+    object::{Object, RawObject, TypedObject},
+    ptr::RefMut,
+};
+
+pub struct TxObject<T> {
+    object: Object<T>,
+}
+
+impl<T> TxObject<T> {
+    pub fn commit(self) -> Result<Object<T>> {
+        todo!()
+    }
+
+    pub fn abort(self) -> Object<T> {
+        todo!()
+    }
+
+    pub fn base_mut(&mut self) -> RefMut<'_, T> {
+        todo!()
+    }
+}
+
+impl<B> TxHandle for TxObject<B> {
+    fn tx_mut(&self, data: *const u8, len: usize) -> super::Result<*mut u8> {
+        todo!()
+    }
+}
+
+impl<T> RawObject for TxObject<T> {
+    fn handle(&self) -> &twizzler_rt_abi::object::ObjectHandle {
+        self.object.handle()
+    }
+}
+
+impl<B: BaseType> TypedObject for TxObject<B> {
+    type Base = B;
+
+    fn base(&self) -> crate::ptr::Ref<'_, Self::Base> {
+        todo!()
+    }
+}
+
+mod tests {
+    use crate::{
+        marker::BaseType,
+        object::{ObjectBuilder, TypedObject},
+    };
+
+    struct Simple {
+        x: u32,
+    }
+
+    impl BaseType for Simple {}
+
+    fn single_tx() {
+        let builder = ObjectBuilder::default();
+        let obj = builder.build(Simple { x: 3 }).unwrap();
+        let base = obj.base();
+        assert_eq!(base.x, 3);
+
+        let mut tx = obj.tx().unwrap();
+        let mut base = tx.base_mut();
+        base.x = 42;
+        let obj = tx.commit().unwrap();
+        assert_eq!(obj.base().x, 42);
+    }
+}

--- a/src/lib/twizzler/src/tx/unsafetx.rs
+++ b/src/lib/twizzler/src/tx/unsafetx.rs
@@ -1,0 +1,15 @@
+use super::TxHandle;
+
+pub struct UnsafeTxHandle {}
+
+impl UnsafeTxHandle {
+    pub unsafe fn new() -> Self {
+        UnsafeTxHandle {}
+    }
+}
+
+impl TxHandle for UnsafeTxHandle {
+    fn tx_mut(&self, data: *const u8, len: usize) -> super::Result<*mut u8> {
+        todo!()
+    }
+}


### PR DESCRIPTION
PR 2/n in this set for the Twizzler crate. This one adds stubs for transactions and pointers, and starts in on tests for invbox and object builder.