### PR TITLE
Pager Implementation

### DIFF
--- a/src/bin/init/src/main.rs
+++ b/src/bin/init/src/main.rs
@@ -1,271 +1,9 @@
-//#![no_std]
-#![feature(naked_functions)]
-#![feature(thread_local)]
-#![feature(duration_constants)]
-#![allow(unreachable_code)]
-//#![no_main]
-
-/*
-#[no_mangle]
-pub extern "C" fn std_runtime_starta() {
-    twizzler_abi::syscall::sys_kernel_console_write(
-        b"hello world\n",
-        twizzler_abi::syscall::KernelConsoleWriteFlags::empty(),
-    );
-    loop {}
-}
-*/
-
-/*
-#[panic_handler]
-pub fn __panic(_: &core::panic::PanicInfo) -> ! {
-    loop {}
-}
-*/
-
-#[thread_local]
-static mut FOO: u32 = 42;
-#[thread_local]
-static mut BAR: u32 = 0;
-#[allow(named_asm_labels)]
-
-static BAZ: AtomicU64 = AtomicU64::new(0);
-
-fn test_thread_sync() {
-    let _j = std::thread::spawn(|| {
-        let reference = ThreadSyncReference::Virtual(&BAZ as *const AtomicU64);
-        let value = 0;
-        let wait = ThreadSync::new_sleep(ThreadSyncSleep::new(
-            reference,
-            value,
-            twizzler_abi::syscall::ThreadSyncOp::Equal,
-            ThreadSyncFlags::empty(),
-        ));
-
-        loop {
-            println!("{:?} going to sleep", std::thread::current().id());
-            let res = sys_thread_sync(&mut [wait], None);
-            println!("woke up: {:?} {:?}", res, wait.get_result());
-        }
-    });
-
-    let reference = ThreadSyncReference::Virtual(&BAZ as *const AtomicU64);
-    let wake = ThreadSync::new_wake(ThreadSyncWake::new(reference, 1));
-    let mut c = 0u64;
-    loop {
-        println!("{:?} waking up {}", std::thread::current().id(), c);
-        c += 1;
-        let res = sys_thread_sync(&mut [wake], None);
-        for _i in 0u64..40000u64 {}
-        println!("done {:?}", res);
-    }
-}
-
-fn test_thread_sync_timeout() {
-    let _j = std::thread::spawn(|| {
-        let reference = ThreadSyncReference::Virtual(&BAZ as *const AtomicU64);
-        let value = 0;
-        let wait = ThreadSync::new_sleep(ThreadSyncSleep::new(
-            reference,
-            value,
-            twizzler_abi::syscall::ThreadSyncOp::Equal,
-            ThreadSyncFlags::empty(),
-        ));
-
-        let mut c = 0u64;
-        loop {
-            println!("{:?} going to sleep {}", std::thread::current().id(), c);
-            let res = sys_thread_sync(&mut [wait], Some(Duration::MILLISECOND * 1000));
-            println!("woke up: {:?} {:?}", res, wait.get_result());
-            c += 1;
-        }
-    });
-
-    let reference = ThreadSyncReference::Virtual(&BAZ as *const AtomicU64);
-    let _wake = ThreadSync::new_wake(ThreadSyncWake::new(reference, 1));
-    let mut _c = 0u64;
-    loop {
-
-        // println!("{:?} waking up {}", std::thread::current().id(), c);
-        // c += 1;
-        // let res = sys_thread_sync(&mut [wake], None);
-        // for i in 0u64..40000u64 {}
-        // println!("done {:?}", res);
-    }
-}
-
-struct Foo {
-    x: u64,
-}
-
-fn test_mutex() {
-    let mutex: Arc<Mutex<Foo>> = Arc::new(Mutex::new(Foo { x: 0 }));
-    let mutex2 = mutex.clone();
-    std::thread::spawn(move || {
-        let mut c = 0u64;
-        loop {
-            let mut data = mutex.lock().unwrap();
-            data.x += 1;
-            let v = data.x;
-            c += 1;
-            if c % 1000000 == 0 {
-                println!("w {}", data.x);
-            }
-            assert_eq!(v, data.x);
-        }
-    });
-
-    let mut c = 0u64;
-    loop {
-        let mut data = mutex2.lock().unwrap();
-        data.x += 1;
-        c += 1;
-        let v = data.x;
-        // for i in 0..1000 {}
-        assert_eq!(v, data.x);
-        if c % 1000000 == 0 {
-            println!("a {}", data.x);
-        }
-        assert_eq!(v, data.x);
-    }
-}
-
-fn get_user_input() {
-    println!("enter some text:");
-    let mut s = String::new();
-    std::io::stdin()
-        .read_line(&mut s)
-        .expect("Did not enter a correct string");
-    println!("you typed: {}", s);
-}
-
-fn list_subobjs(level: usize, id: ObjID) {
-    let mut n = 0;
-    loop {
-        let res = sys_kaction(
-            KactionCmd::Generic(KactionGenericCmd::GetSubObject(
-                SubObjectType::Info.into(),
-                n,
-            )),
-            Some(id),
-            0,
-            0,
-            KactionFlags::empty(),
-        );
-        if res.is_err() {
-            break;
-        } else if let KactionValue::ObjID(id) = res.unwrap() {
-            println!("  sub {:indent$}info {}: {}", "", n, id, indent = level);
-        }
-        n += 1;
-    }
-
-    let mut n = 0;
-    loop {
-        let res = sys_kaction(
-            KactionCmd::Generic(KactionGenericCmd::GetSubObject(
-                SubObjectType::Mmio.into(),
-                n,
-            )),
-            Some(id),
-            0,
-            0,
-            KactionFlags::empty(),
-        );
-        if res.is_err() {
-            break;
-        } else if let KactionValue::ObjID(id) = res.unwrap() {
-            println!("  sub {:indent$}mmio {}: {}", "", n, id, indent = level);
-        }
-        n += 1;
-    }
-}
-
-fn enumerate_children(level: usize, id: ObjID) {
-    let mut n = 0;
-    loop {
-        let res = sys_kaction(
-            KactionCmd::Generic(KactionGenericCmd::GetChild(n)),
-            Some(id),
-            0,
-            0,
-            KactionFlags::empty(),
-        );
-        if res.is_err() {
-            break;
-        } else if let KactionValue::ObjID(id) = res.unwrap() {
-            println!("{:indent$}{}: {}", "", n, id, indent = level);
-            list_subobjs(level, id);
-            enumerate_children(level + 4, id);
-        }
-        n = n + 1;
-    }
-}
-
-fn test_kaction() {
-    let res = sys_kaction(
-        KactionCmd::Generic(KactionGenericCmd::GetKsoRoot),
-        None,
-        0,
-        0,
-        KactionFlags::empty(),
-    );
-    println!("{:?}", res);
-    let id = match res.unwrap() {
-        KactionValue::U64(_) => todo!(),
-        KactionValue::ObjID(id) => id,
-    };
-
-    enumerate_children(0, id);
-}
-
-fn exec(name: &str, id: ObjID, argid: ObjID) {
-    let env: Vec<String> = std::env::vars()
-        .map(|(n, v)| format!("{}={}", n, v))
-        .collect();
-    let env_ref: Vec<&[u8]> = env.iter().map(|x| x.as_str().as_bytes()).collect();
-    let mut args = vec![name.as_bytes()];
-    let argstr = format!("{}", argid.as_u128());
-    args.push(argstr.as_bytes());
-    let _elf = twizzler_abi::runtime::load_elf::spawn_new_executable(id, &args, &env_ref);
-    //println!("ELF: {:?}", elf);
-}
-
-fn exec2(name: &str, id: ObjID) -> Option<ObjID> {
-    let env: Vec<String> = std::env::vars()
-        .map(|(n, v)| format!("{}={}", n, v))
-        .collect();
-    let env_ref: Vec<&[u8]> = env.iter().map(|x| x.as_str().as_bytes()).collect();
-    let args = vec![name.as_bytes()];
-    twizzler_abi::runtime::load_elf::spawn_new_executable(id, &args, &env_ref).ok()
-    //println!("ELF: {:?}", elf);
-}
-
-fn exec_n(name: &str, id: ObjID, args: &[&str]) -> Option<ObjID> {
-    let env: Vec<String> = std::env::vars()
-        .map(|(n, v)| format!("{}={}", n, v))
-        .collect();
-    let env_ref: Vec<&[u8]> = env.iter().map(|x| x.as_str().as_bytes()).collect();
-    let mut fullargs = vec![name.as_bytes()];
-    fullargs.extend(args.iter().map(|x| x.as_bytes()));
-    twizzler_abi::runtime::load_elf::spawn_new_executable(id, &fullargs, &env_ref).ok()
-}
-
-fn find_init_name(name: &str) -> Option<ObjID> {
-    let init_info = twizzler_abi::runtime::get_kernel_init_info();
-    for n in init_info.names() {
-        if n.name() == name {
-            return Some(n.id());
-        }
-    }
-    None
-}
+extern crate twizzler_runtime;
 
 fn initialize_pager() { 
-    println!("starting pager");
+    info!("starting pager");
     const DEFAULT_PAGER_QUEUE_LEN: usize = 1024;
-    //Create Pager -> Kernel Queue
-    let pager_to_kernel_queue = twizzler_queue::Queue::<RequestFromKernel, CompletionToKernel>::create(
+    let queue = twizzler_queue::Queue::<RequestFromKernel, CompletionToKernel>::create(
         &CreateSpec::new(LifetimeType::Volatile, BackingType::Normal),
         DEFAULT_PAGER_QUEUE_LEN,
         DEFAULT_PAGER_QUEUE_LEN,
@@ -273,38 +11,38 @@ fn initialize_pager() {
     .unwrap();
 
     sys_new_handle(
-        pager_to_kernel_queue.object().id(),
+        queue.object().id(),
         twizzler_abi::syscall::HandleType::PagerQueue,
         NewHandleFlags::empty(),
     )
     .unwrap();
-
-    //Create Kernel -> Pager Queue
-    let kernel_to_pager_queue = twizzler_queue::Queue::<RequestFromKernel, CompletionToKernel>::create(
+    let queue2 = twizzler_queue::Queue::<RequestFromKernel, CompletionToKernel>::create(
         &CreateSpec::new(LifetimeType::Volatile, BackingType::Normal),
         DEFAULT_PAGER_QUEUE_LEN,
         DEFAULT_PAGER_QUEUE_LEN,
     )
     .unwrap();
     sys_new_handle(
-        kernel_to_pager_queue.object().id(),
+        queue2.object().id(),
         twizzler_abi::syscall::HandleType::PagerQueue,
         NewHandleFlags::empty(),
     )
     .unwrap();
-    //Start Pager
-    if let Some(id) = find_init_name("pager") {
-        exec_n(
-            "pager",
-            id,
-            &[
-                &pager_to_kernel_queue.object().id().as_u128().to_string(),
-                &kernel_to_pager_queue.object().id().as_u128().to_string(),
-            ],
-        );
-    } else {
-        eprintln!("[init] failed to start pager");
-    }
+    let pager_comp = monitor_api::CompartmentLoader::new(
+        "pager",
+        "pager",
+        monitor_api::NewCompartmentFlags::EXPORT_GATES,
+    )
+    .args([
+        "pager",
+        &queue.object().id().raw().to_string(),
+        &queue2.object().id().raw().to_string(),
+    ])
+    .load()
+    .expect("failed to start pager");
+
+    std::mem::forget(pager_comp);
+
 }
 
 fn main() {
@@ -369,9 +107,7 @@ fn main() {
     debug!("device manager is up!");
 
     initialize_pager();
-
     std::mem::forget(dev_comp);
-    std::mem::forget(pager_comp);
 
     run_tests("test_bins", false);
     run_tests("bench_bins", true);

--- a/src/bin/init/src/main.rs
+++ b/src/bin/init/src/main.rs
@@ -1,4 +1,312 @@
-extern crate twizzler_runtime;
+//#![no_std]
+#![feature(naked_functions)]
+#![feature(thread_local)]
+#![feature(duration_constants)]
+#![allow(unreachable_code)]
+//#![no_main]
+
+/*
+#[no_mangle]
+pub extern "C" fn std_runtime_starta() {
+    twizzler_abi::syscall::sys_kernel_console_write(
+        b"hello world\n",
+        twizzler_abi::syscall::KernelConsoleWriteFlags::empty(),
+    );
+    loop {}
+}
+*/
+
+/*
+#[panic_handler]
+pub fn __panic(_: &core::panic::PanicInfo) -> ! {
+    loop {}
+}
+*/
+
+#[thread_local]
+static mut FOO: u32 = 42;
+#[thread_local]
+static mut BAR: u32 = 0;
+#[allow(named_asm_labels)]
+
+static BAZ: AtomicU64 = AtomicU64::new(0);
+
+fn test_thread_sync() {
+    let _j = std::thread::spawn(|| {
+        let reference = ThreadSyncReference::Virtual(&BAZ as *const AtomicU64);
+        let value = 0;
+        let wait = ThreadSync::new_sleep(ThreadSyncSleep::new(
+            reference,
+            value,
+            twizzler_abi::syscall::ThreadSyncOp::Equal,
+            ThreadSyncFlags::empty(),
+        ));
+
+        loop {
+            println!("{:?} going to sleep", std::thread::current().id());
+            let res = sys_thread_sync(&mut [wait], None);
+            println!("woke up: {:?} {:?}", res, wait.get_result());
+        }
+    });
+
+    let reference = ThreadSyncReference::Virtual(&BAZ as *const AtomicU64);
+    let wake = ThreadSync::new_wake(ThreadSyncWake::new(reference, 1));
+    let mut c = 0u64;
+    loop {
+        println!("{:?} waking up {}", std::thread::current().id(), c);
+        c += 1;
+        let res = sys_thread_sync(&mut [wake], None);
+        for _i in 0u64..40000u64 {}
+        println!("done {:?}", res);
+    }
+}
+
+fn test_thread_sync_timeout() {
+    let _j = std::thread::spawn(|| {
+        let reference = ThreadSyncReference::Virtual(&BAZ as *const AtomicU64);
+        let value = 0;
+        let wait = ThreadSync::new_sleep(ThreadSyncSleep::new(
+            reference,
+            value,
+            twizzler_abi::syscall::ThreadSyncOp::Equal,
+            ThreadSyncFlags::empty(),
+        ));
+
+        let mut c = 0u64;
+        loop {
+            println!("{:?} going to sleep {}", std::thread::current().id(), c);
+            let res = sys_thread_sync(&mut [wait], Some(Duration::MILLISECOND * 1000));
+            println!("woke up: {:?} {:?}", res, wait.get_result());
+            c += 1;
+        }
+    });
+
+    let reference = ThreadSyncReference::Virtual(&BAZ as *const AtomicU64);
+    let _wake = ThreadSync::new_wake(ThreadSyncWake::new(reference, 1));
+    let mut _c = 0u64;
+    loop {
+
+        // println!("{:?} waking up {}", std::thread::current().id(), c);
+        // c += 1;
+        // let res = sys_thread_sync(&mut [wake], None);
+        // for i in 0u64..40000u64 {}
+        // println!("done {:?}", res);
+    }
+}
+
+struct Foo {
+    x: u64,
+}
+
+fn test_mutex() {
+    let mutex: Arc<Mutex<Foo>> = Arc::new(Mutex::new(Foo { x: 0 }));
+    let mutex2 = mutex.clone();
+    std::thread::spawn(move || {
+        let mut c = 0u64;
+        loop {
+            let mut data = mutex.lock().unwrap();
+            data.x += 1;
+            let v = data.x;
+            c += 1;
+            if c % 1000000 == 0 {
+                println!("w {}", data.x);
+            }
+            assert_eq!(v, data.x);
+        }
+    });
+
+    let mut c = 0u64;
+    loop {
+        let mut data = mutex2.lock().unwrap();
+        data.x += 1;
+        c += 1;
+        let v = data.x;
+        // for i in 0..1000 {}
+        assert_eq!(v, data.x);
+        if c % 1000000 == 0 {
+            println!("a {}", data.x);
+        }
+        assert_eq!(v, data.x);
+    }
+}
+
+fn get_user_input() {
+    println!("enter some text:");
+    let mut s = String::new();
+    std::io::stdin()
+        .read_line(&mut s)
+        .expect("Did not enter a correct string");
+    println!("you typed: {}", s);
+}
+
+fn list_subobjs(level: usize, id: ObjID) {
+    let mut n = 0;
+    loop {
+        let res = sys_kaction(
+            KactionCmd::Generic(KactionGenericCmd::GetSubObject(
+                SubObjectType::Info.into(),
+                n,
+            )),
+            Some(id),
+            0,
+            0,
+            KactionFlags::empty(),
+        );
+        if res.is_err() {
+            break;
+        } else if let KactionValue::ObjID(id) = res.unwrap() {
+            println!("  sub {:indent$}info {}: {}", "", n, id, indent = level);
+        }
+        n += 1;
+    }
+
+    let mut n = 0;
+    loop {
+        let res = sys_kaction(
+            KactionCmd::Generic(KactionGenericCmd::GetSubObject(
+                SubObjectType::Mmio.into(),
+                n,
+            )),
+            Some(id),
+            0,
+            0,
+            KactionFlags::empty(),
+        );
+        if res.is_err() {
+            break;
+        } else if let KactionValue::ObjID(id) = res.unwrap() {
+            println!("  sub {:indent$}mmio {}: {}", "", n, id, indent = level);
+        }
+        n += 1;
+    }
+}
+
+fn enumerate_children(level: usize, id: ObjID) {
+    let mut n = 0;
+    loop {
+        let res = sys_kaction(
+            KactionCmd::Generic(KactionGenericCmd::GetChild(n)),
+            Some(id),
+            0,
+            0,
+            KactionFlags::empty(),
+        );
+        if res.is_err() {
+            break;
+        } else if let KactionValue::ObjID(id) = res.unwrap() {
+            println!("{:indent$}{}: {}", "", n, id, indent = level);
+            list_subobjs(level, id);
+            enumerate_children(level + 4, id);
+        }
+        n = n + 1;
+    }
+}
+
+fn test_kaction() {
+    let res = sys_kaction(
+        KactionCmd::Generic(KactionGenericCmd::GetKsoRoot),
+        None,
+        0,
+        0,
+        KactionFlags::empty(),
+    );
+    println!("{:?}", res);
+    let id = match res.unwrap() {
+        KactionValue::U64(_) => todo!(),
+        KactionValue::ObjID(id) => id,
+    };
+
+    enumerate_children(0, id);
+}
+
+fn exec(name: &str, id: ObjID, argid: ObjID) {
+    let env: Vec<String> = std::env::vars()
+        .map(|(n, v)| format!("{}={}", n, v))
+        .collect();
+    let env_ref: Vec<&[u8]> = env.iter().map(|x| x.as_str().as_bytes()).collect();
+    let mut args = vec![name.as_bytes()];
+    let argstr = format!("{}", argid.as_u128());
+    args.push(argstr.as_bytes());
+    let _elf = twizzler_abi::runtime::load_elf::spawn_new_executable(id, &args, &env_ref);
+    //println!("ELF: {:?}", elf);
+}
+
+fn exec2(name: &str, id: ObjID) -> Option<ObjID> {
+    let env: Vec<String> = std::env::vars()
+        .map(|(n, v)| format!("{}={}", n, v))
+        .collect();
+    let env_ref: Vec<&[u8]> = env.iter().map(|x| x.as_str().as_bytes()).collect();
+    let args = vec![name.as_bytes()];
+    twizzler_abi::runtime::load_elf::spawn_new_executable(id, &args, &env_ref).ok()
+    //println!("ELF: {:?}", elf);
+}
+
+fn exec_n(name: &str, id: ObjID, args: &[&str]) -> Option<ObjID> {
+    let env: Vec<String> = std::env::vars()
+        .map(|(n, v)| format!("{}={}", n, v))
+        .collect();
+    let env_ref: Vec<&[u8]> = env.iter().map(|x| x.as_str().as_bytes()).collect();
+    let mut fullargs = vec![name.as_bytes()];
+    fullargs.extend(args.iter().map(|x| x.as_bytes()));
+    twizzler_abi::runtime::load_elf::spawn_new_executable(id, &fullargs, &env_ref).ok()
+}
+
+fn find_init_name(name: &str) -> Option<ObjID> {
+    let init_info = twizzler_abi::runtime::get_kernel_init_info();
+    for n in init_info.names() {
+        if n.name() == name {
+            return Some(n.id());
+        }
+    }
+    None
+}
+
+fn initialize_pager() { 
+    println!("starting pager");
+    const DEFAULT_PAGER_QUEUE_LEN: usize = 1024;
+    //Create Pager -> Kernel Queue
+    let pager_to_kernel_queue = twizzler_queue::Queue::<RequestFromKernel, CompletionToKernel>::create(
+        &CreateSpec::new(LifetimeType::Volatile, BackingType::Normal),
+        DEFAULT_PAGER_QUEUE_LEN,
+        DEFAULT_PAGER_QUEUE_LEN,
+    )
+    .unwrap();
+
+    sys_new_handle(
+        pager_to_kernel_queue.object().id(),
+        twizzler_abi::syscall::HandleType::PagerQueue,
+        NewHandleFlags::empty(),
+    )
+    .unwrap();
+
+    //Create Kernel -> Pager Queue
+    let kernel_to_pager_queue = twizzler_queue::Queue::<RequestFromKernel, CompletionToKernel>::create(
+        &CreateSpec::new(LifetimeType::Volatile, BackingType::Normal),
+        DEFAULT_PAGER_QUEUE_LEN,
+        DEFAULT_PAGER_QUEUE_LEN,
+    )
+    .unwrap();
+    sys_new_handle(
+        kernel_to_pager_queue.object().id(),
+        twizzler_abi::syscall::HandleType::PagerQueue,
+        NewHandleFlags::empty(),
+    )
+    .unwrap();
+    //Start Pager
+    if let Some(id) = find_init_name("pager") {
+        exec_n(
+            "pager",
+            id,
+            &[
+                &pager_to_kernel_queue.object().id().as_u128().to_string(),
+                &kernel_to_pager_queue.object().id().as_u128().to_string(),
+            ],
+        );
+    } else {
+        eprintln!("[init] failed to start pager");
+    }
+}
+
 fn main() {
     tracing::subscriber::set_global_default(
         tracing_subscriber::fmt()
@@ -60,45 +368,7 @@ fn main() {
     .unwrap();
     debug!("device manager is up!");
 
-    info!("starting pager");
-    const DEFAULT_PAGER_QUEUE_LEN: usize = 1024;
-    let queue = twizzler_queue::Queue::<RequestFromKernel, CompletionToKernel>::create(
-        &CreateSpec::new(LifetimeType::Volatile, BackingType::Normal),
-        DEFAULT_PAGER_QUEUE_LEN,
-        DEFAULT_PAGER_QUEUE_LEN,
-    )
-    .unwrap();
-
-    sys_new_handle(
-        queue.object().id(),
-        twizzler_abi::syscall::HandleType::PagerQueue,
-        NewHandleFlags::empty(),
-    )
-    .unwrap();
-    let queue2 = twizzler_queue::Queue::<RequestFromKernel, CompletionToKernel>::create(
-        &CreateSpec::new(LifetimeType::Volatile, BackingType::Normal),
-        DEFAULT_PAGER_QUEUE_LEN,
-        DEFAULT_PAGER_QUEUE_LEN,
-    )
-    .unwrap();
-    sys_new_handle(
-        queue2.object().id(),
-        twizzler_abi::syscall::HandleType::PagerQueue,
-        NewHandleFlags::empty(),
-    )
-    .unwrap();
-    let pager_comp = monitor_api::CompartmentLoader::new(
-        "pager",
-        "pager",
-        monitor_api::NewCompartmentFlags::EXPORT_GATES,
-    )
-    .args([
-        "pager",
-        &queue.object().id().raw().to_string(),
-        &queue2.object().id().raw().to_string(),
-    ])
-    .load()
-    .expect("failed to start pager");
+    initialize_pager();
 
     std::mem::forget(dev_comp);
     std::mem::forget(pager_comp);

--- a/src/bin/pager/Cargo.toml
+++ b/src/bin/pager/Cargo.toml
@@ -18,7 +18,7 @@ async-trait = "0.1.66"
 volatile = "0.5"
 tracing = "0.1"
 tracing-subscriber = "0.3.17"
-bit-set = "0.8.0"
+bitvec = "1.0.1"
 
 async-io = "2.3.2"
 async-executor = { version = "1.9.1", features = [] }

--- a/src/bin/pager/Cargo.toml
+++ b/src/bin/pager/Cargo.toml
@@ -16,6 +16,10 @@ nvme = { path = "../../lib/nvme-rs" }
 tickv = { version = "1.0.0" }
 async-trait = "0.1.66"
 volatile = "0.5"
-async-io = "*"
-async-executor = "*"
+tracing = "0.1"
+tracing-subscriber = "0.3.17"
+
+async-io = "2.3.2"
+async-executor = { version = "1.9.1", features = [] }
+polling = "3.6.0"
 futures = "*"

--- a/src/bin/pager/Cargo.toml
+++ b/src/bin/pager/Cargo.toml
@@ -18,6 +18,7 @@ async-trait = "0.1.66"
 volatile = "0.5"
 tracing = "0.1"
 tracing-subscriber = "0.3.17"
+bit-set = "0.8.0"
 
 async-io = "2.3.2"
 async-executor = { version = "1.9.1", features = [] }

--- a/src/bin/pager/src/data.rs
+++ b/src/bin/pager/src/data.rs
@@ -1,0 +1,29 @@
+use std::sync::{Arc, Mutex};
+use bit_set::BitSet;
+
+#[derive(Clone)]
+pub struct PagerData {
+    pub bitset: Arc<Mutex<BitSet>>,
+}
+
+impl PagerData {
+    /// Create a new PagerData instance with the given size
+    /// The size is the total number of bits needed.
+    pub fn new() -> Self {
+        PagerData {
+            bitset: Arc::new(Mutex::new(BitSet::new())),
+        }
+    }
+
+    /// Adjust the size of the bitmap dynamically.
+    pub fn resize_bitset(&self, new_size: usize) {
+        let mut bitset = self.bitset.lock().unwrap();
+
+        if new_size == 0 {
+            bitset.clear();
+        } else {
+            bitset.reserve_len(new_size - 1);
+        }
+
+    }
+}

--- a/src/bin/pager/src/data.rs
+++ b/src/bin/pager/src/data.rs
@@ -23,7 +23,7 @@ impl PagerDataInner {
     /// Create a new PagerDataInner instance
     /// Initializes the data structure for managing page allocations and replacements.
     pub fn new() -> Self {
-        println!("[pager] initializing PagerDataInner");
+        tracing::info!("initializing PagerDataInner");
         PagerDataInner {
             bitvec: BitVec::new(),
             hashmap: HashMap::with_capacity(0),
@@ -40,16 +40,16 @@ impl PagerDataInner {
     /// Get the next available page number and mark it as used.
     /// Returns the page number if available, or `None` if all pages are used.
     fn get_next_available_page(&mut self) -> Option<usize> {
-        println!("[pager] searching for next available page");
+        tracing::info!("searching for next available page");
         let next_page = self.bitvec.iter().position(|bit| !bit);
 
         if let Some(page_number) = next_page {
             self.bitvec.set(page_number, true);
             self.lru_queue.push_back(page_number.try_into().unwrap());
-            println!("[pager] next available page: {}", page_number);
+            tracing::info!("next available page: {}", page_number);
             Some(page_number)
         } else {
-            println!("[pager] no available pages left");
+            tracing::info!("no available pages left");
             None
         }
     }
@@ -57,68 +57,68 @@ impl PagerDataInner {
     /// Perform page replacement using the Least Recently Used (LRU) strategy.
     /// Returns the identifier of the replaced page.
     fn page_replacement(&mut self) -> u64 {
-        println!("[pager] executing page replacement");
+        tracing::info!("executing page replacement");
         if let Some(old_page) = self.lru_queue.pop_front() {
-            println!("[pager] replacing page: {}", old_page);
+            tracing::info!("replacing page: {}", old_page);
             self.remove_page(old_page as usize);
             old_page
         } else {
-            panic!("[pager] page replacement failed: no pages to replace");
+            panic!("page replacement failed: no pages to replace");
         }
     }
 
     /// Get a memory page for allocation.
     /// Triggers page replacement if all pages are used.
     fn get_mem_page(&mut self) -> usize {
-        println!("[pager] attempting to get memory page");
+        tracing::info!("attempting to get memory page");
         if self.bitvec.all() {
-            println!("[pager] all pages used, initiating page replacement");
+            tracing::info!("all pages used, initiating page replacement");
             self.page_replacement();
         }
-        self.get_next_available_page().expect("[pager] no available pages")
+        self.get_next_available_page().expect("no available pages")
     }
 
     /// Remove a page from the bit vector, freeing it for future use.
     fn remove_page(&mut self, page_number: usize) {
-        println!("[pager] attempting to remove page {}", page_number);
+        tracing::info!("attempting to remove page {}", page_number);
         if page_number < self.bitvec.len() {
             self.bitvec.set(page_number, false);
             self.remove_from_map(&(page_number as u64));
             self.lru_queue.retain(|&p| p != page_number as u64);
-            println!("[pager] page {} removed from bitvec", page_number);
+            tracing::info!("page {} removed from bitvec", page_number);
         } else {
-            println!("[pager] page {} is out of bounds and cannot be removed", page_number);
+            tracing::info!("page {} is out of bounds and cannot be removed", page_number);
         }
     }
 
     /// Resize the bit vector to accommodate more pages or clear it.
     fn resize_bitset(&mut self, new_size: usize) {
-        println!("[pager] resizing bitvec to new size: {}", new_size);
+        tracing::info!("resizing bitvec to new size: {}", new_size);
         if new_size == 0 {
-            println!("[pager] clearing bitvec");
+            tracing::info!("clearing bitvec");
             self.bitvec.clear();
         } else {
             self.bitvec.resize(new_size, false);
         }
-        println!("[pager] bitvec resized to: {}", new_size);
+        tracing::info!("bitvec resized to: {}", new_size);
     }
 
     /// Check if all pages are currently in use.
     pub fn is_full(&self) -> bool {
         let full = self.bitvec.all();
-        println!("[pager] bitvec check full: {}", full);
+        tracing::info!("bitvec check full: {}", full);
         full
     }
 
     /// Insert an object and its associated range into the hashmap.
     pub fn insert_into_map(&mut self, key: u64, obj_id: ObjID, range: ObjectRange) {
-        println!(
-            "[pager] inserting into hashmap: key = {}, ObjID = {:?}, ObjectRange = {:?}",
+        tracing::info!(
+            "inserting into hashmap: key = {}, ObjID = {:?}, ObjectRange = {:?}",
             key, obj_id, range
         );
         self.hashmap.insert(key, (obj_id.clone(), range.clone()));
-        println!(
-            "[pager] inserted into hashmap: key = {}, ObjID = {:?}, ObjectRange = {:?}",
+        tracing::info!(
+            "inserted into hashmap: key = {}, ObjID = {:?}, ObjectRange = {:?}",
             key, obj_id, range
         );
     }
@@ -132,16 +132,16 @@ impl PagerDataInner {
     /// Retrieve an object and its range from the hashmap by key.
     /// Updates the LRU queue to reflect access.
     pub fn get_from_map(&mut self, key: &u64) -> Option<(ObjID, ObjectRange)> {
-        println!("[pager] retrieving value for key {}", key);
+        tracing::info!("retrieving value for key {}", key);
         match self.hashmap.get(key) {
             Some(value) => {
-                println!("[pager] value found for key {}: {:?}", key, value);
+                tracing::info!("value found for key {}: {:?}", key, value);
                 self.lru_queue.retain(|&p| p != *key);
                 self.lru_queue.push_back(*key);
                 Some(value.clone())
             }
             None => {
-                println!("[pager] no value found for key: {}", key);
+                tracing::info!("no value found for key: {}", key);
                 None
             }
         }
@@ -149,13 +149,13 @@ impl PagerDataInner {
 
     /// Remove a key and its associated value from the hashmap.
     pub fn remove_from_map(&mut self, key: &u64) {
-        println!("[pager] removing key {} from hashmap", key);
+        tracing::info!("removing key {} from hashmap", key);
         self.hashmap.remove(key);
     }
 
     /// Reserve additional capacity in the hashmap.
     pub fn resize_map(&mut self, add_size: usize) {
-        println!("[pager] adding {} capacity to hashmap", add_size);
+        tracing::info!("adding {} capacity to hashmap", add_size);
         self.hashmap.reserve(add_size);
     }
 }
@@ -164,7 +164,7 @@ impl PagerData {
     /// Create a new PagerData instance.
     /// Wraps PagerDataInner with thread-safe access.
     pub fn new() -> Self {
-        println!("[pager] creating new PagerData instance");
+        tracing::info!("creating new PagerData instance");
         PagerData {
             inner: Arc::new(Mutex::new(PagerDataInner::new())),
         }
@@ -172,7 +172,7 @@ impl PagerData {
 
     /// Resize the internal structures to accommodate the given number of pages.
     pub fn resize(&self, pages: usize) {
-        println!("[pager] resizing resources to support {} pages", pages);
+        tracing::info!("resizing resources to support {} pages", pages);
         let mut inner = self.inner.lock().unwrap();
         inner.resize_bitset(pages);
         inner.resize_map(pages);
@@ -187,13 +187,13 @@ impl PagerData {
     /// Page in the data from disk
     /// Returns the physical range corresponding to the allocated page.
     pub fn fill_mem_page(&self, id: ObjID, obj_range: ObjectRange) -> PhysRange {
-        println!("[pager] allocating memory page for ObjID {:?}, ObjectRange {:?}", id, obj_range);
+        tracing::info!("allocating memory page for ObjID {:?}, ObjectRange {:?}", id, obj_range);
         let mut inner = self.inner.lock().unwrap();
         let page = inner.get_mem_page();
         inner.insert_into_map(page.try_into().unwrap(), id, obj_range);
         let phys_range = page_to_physrange(page, 0);
         page_in(id, obj_range, phys_range);
-        println!("[pager] memory page allocated successfully");
+        tracing::info!("memory page allocated successfully");
         return phys_range;
     }
 }

--- a/src/bin/pager/src/data.rs
+++ b/src/bin/pager/src/data.rs
@@ -1,29 +1,176 @@
+use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
-use bit_set::BitSet;
+use bitvec::prelude::*;
+use twizzler_abi::pager::{ObjectRange};
+use twizzler_object::{ObjID, Object, ObjectInitFlags, Protections};
 
 #[derive(Clone)]
 pub struct PagerData {
-    pub bitset: Arc<Mutex<BitSet>>,
+    inner: Arc<Mutex<PagerDataInner>>,
+}
+
+pub struct PagerDataInner {
+    pub bitvec: BitVec,
+    pub hashmap: HashMap<u64, (ObjID, ObjectRange)>,
+}
+
+impl PagerDataInner {
+    /// Create a new PagerDataInner instance
+    pub fn new() -> Self {
+        println!("[pager] initializing pagerdatainner");
+        PagerDataInner {
+            bitvec: BitVec::new(),
+            hashmap: HashMap::with_capacity(0),
+        }
+    }
 }
 
 impl PagerData {
-    /// Create a new PagerData instance with the given size
-    /// The size is the total number of bits needed.
+    /// Create a new PagerData instance
     pub fn new() -> Self {
+        println!("[pager] creating a new pagerdata instance");
         PagerData {
-            bitset: Arc::new(Mutex::new(BitSet::new())),
+            inner: Arc::new(Mutex::new(PagerDataInner::new())),
+        }
+    }
+    
+    /// Map + Bitset Operations
+    ///
+    pub fn resize(&self, pages: usize) {
+        self.resize_bitset(pages);
+        self.resize_map(pages);
+    }
+
+    /// Bitset Operations
+
+
+    /// Get the next available page number and insert it into the bitvec.
+    /// Returns `Some(page_number)` if a page is available, or `None` if none are left.
+    pub fn get_next_available_page(&self) -> Option<usize> {
+        println!("[pager] pager lock: acquiring lock to get the next available page");
+        let mut inner = self.inner.lock().unwrap();
+
+        // Find the first unset bit
+        let next_page = inner.bitvec.iter().position(|bit| !bit);
+
+        if let Some(page_number) = next_page {
+            if page_number >= inner.bitvec.len() {
+                inner.bitvec.resize(page_number + 1, false);
+            }
+            inner.bitvec.set(page_number, true);
+            println!("[pager] next available page: {}", page_number);
+            Some(page_number)
+        } else {
+            println!("[pager] no available pages left");
+            None
         }
     }
 
-    /// Adjust the size of the bitmap dynamically.
+    /// Check if the bitvec is full.
+    pub fn is_full(&self) -> bool {
+        println!("[pager] pager lock: acquiring lock to check if bitvec is full");
+        let inner = self.inner.lock().unwrap();
+        let full = inner.bitvec.all();
+        println!("[pager] bitvec is full: {}", full);
+        full
+    }
+
+    /// Remove a page from the bitvec.
+    pub fn remove_page(&self, page_number: usize) {
+        println!("[pager] pager lock: acquiring lock to remove page: {}", page_number);
+        let mut inner = self.inner.lock().unwrap();
+
+        if page_number < inner.bitvec.len() {
+            inner.bitvec.set(page_number, false);
+            println!("[pager] page {} removed from bitvec", page_number);
+        } else {
+            println!("[pager] page {} is out of bounds and cannot be removed", page_number);
+        }
+    }
+
+    /// Adjust the size of the bitvec dynamically.
     pub fn resize_bitset(&self, new_size: usize) {
-        let mut bitset = self.bitset.lock().unwrap();
+        println!("[pager] pager lock: acquiring lock to resize bitvec");
+        let mut inner = self.inner.lock().unwrap();
 
         if new_size == 0 {
-            bitset.clear();
+            println!("[pager] clearing bitvec");
+            inner.bitvec.clear();
         } else {
-            bitset.reserve_len(new_size - 1);
+            println!("[pager] resizing bitvec to new size: {}", new_size);
+            inner.bitvec.resize(new_size, false);
         }
 
+        println!("[pager] bitvec resized to: {}", new_size);
+    }
+
+    /// Hashmap Operations
+    
+
+    pub fn insert_into_map(&self, key: u64, obj_id: ObjID, range: ObjectRange) {
+        println!(
+            "[pager] pager lock: acquiring lock to insert into hashmap: key = {}, ObjID = {:?}, ObjectRange = {:?}",
+            key, obj_id, range
+        );
+        let mut inner = self.inner.lock().unwrap();
+        inner.hashmap.insert(key, (obj_id.clone(), range.clone()));
+        println!(
+            "[pager] inserted key-value pair into hashmap: key = {}, ObjID = {:?}, ObjectRange = {:?}",
+            key, obj_id, range
+        );
+    }
+
+    pub fn get_from_map(&self, key: &u64) -> Option<(ObjID, ObjectRange)> {
+        println!("[pager] pager lock: acquiring lock to retrieve value for key: {}", key);
+        let inner = self.inner.lock().unwrap();
+        match inner.hashmap.get(key) {
+            Some(value) => {
+                println!("[pager] value retrieved for key {}: {:?}", key, value);
+                Some(value.clone())
+            }
+            None => {
+                println!("[pager] no value found for key: {}", key);
+                None
+            }
+        }
+    }
+
+    pub fn resize_map(&self, add_size: usize) {
+        println!("[pager] pager lock: acquiring lock to resize hashmap");
+        let mut inner = self.inner.lock().unwrap();
+        inner.hashmap.reserve(add_size);
+        println!("[pager] additional capacity of {} added to hashmap", add_size);
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_resize_bitset() {
+        let pager_data = PagerData::new();
+        pager_data.resize_bitset(10);
+        assert_eq!(pager_data.inner.lock().unwrap().bitvec.len(), 10);
+        pager_data.resize_bitset(0);
+        assert!(pager_data.inner.lock().unwrap().bitvec.is_empty());
+    }
+
+    #[test]
+    fn test_insert_and_retrieve_from_map() {
+        let pager_data = PagerData::new();
+        let obj_id = ObjID(42);
+        let range = ObjectRange { start: 0, end: 100 };
+        pager_data.insert_into_map(42, obj_id.clone(), range.clone());
+        let retrieved = pager_data.get_from_map(&42);
+        assert_eq!(retrieved, Some((obj_id, range)));
+    }
+
+    #[test]
+    fn test_retrieve_nonexistent_key() {
+        let pager_data = PagerData::new();
+        let retrieved = pager_data.get_from_map(&999);
+        assert_eq!(retrieved, None);
+    }
+}
+

--- a/src/bin/pager/src/helpers.rs
+++ b/src/bin/pager/src/helpers.rs
@@ -1,0 +1,63 @@
+use twizzler_abi::pager::{
+    PhysRange, ObjectRange
+};
+
+/// A constant representing the page size (4096 bytes per page).
+pub const PAGE: u64 = 4096;
+
+
+/// Converts a `PhysRange` into the number of pages (4096 bytes per page).
+/// Returns a `u64` representing the total number of pages in the range.
+pub fn physrange_to_pages(phys_range: &PhysRange) -> u64 {
+    if phys_range.end <= phys_range.start {
+        return 0;
+    }
+    let range_size = phys_range.end - phys_range.start;
+    (range_size + PAGE - 1) / PAGE // Add PAGE - 1 for ceiling division by PAGE
+}
+
+/// Converts an `ObjectRange` representing a single page into the page number.
+/// Assumes the range is within a valid memory mapping and spans exactly one page (4096 bytes).
+/// Returns the page number starting at 0.
+pub fn objectrange_to_page_number(object_range: &ObjectRange) -> Option<u64> {
+    if object_range.end - object_range.start != PAGE {
+        return None; // Invalid ObjectRange for a single page
+    }
+    Some(object_range.start / PAGE)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_physrange_to_pages() {
+        let range = PhysRange { start: 0, end: 8192 };
+        assert_eq!(physrange_to_pages(&range), 2);
+
+        let range = PhysRange { start: 0, end: 4095 };
+        assert_eq!(physrange_to_pages(&range), 1);
+
+        let range = PhysRange { start: 0, end: 0 };
+        assert_eq!(physrange_to_pages(&range), 0);
+
+        let range = PhysRange { start: 4096, end: 8192 };
+        assert_eq!(physrange_to_pages(&range), 2);
+    }
+
+    #[test]
+    fn test_objectrange_to_page_number() {
+        let range = ObjectRange { start: 0, end: 4096 };
+        assert_eq!(objectrange_to_page_number(&range), Some(0));
+
+        let range = ObjectRange { start: 4096, end: 8192 };
+        assert_eq!(objectrange_to_page_number(&range), Some(1));
+
+        let range = ObjectRange { start: 0, end: 8192 }; // Invalid range for one page
+        assert_eq!(objectrange_to_page_number(&range), None);
+
+        let range = ObjectRange { start: 8192, end: 12288 };
+        assert_eq!(objectrange_to_page_number(&range), Some(2));
+    }
+}
+

--- a/src/bin/pager/src/helpers.rs
+++ b/src/bin/pager/src/helpers.rs
@@ -2,6 +2,8 @@ use twizzler_abi::pager::{
     PhysRange, ObjectRange
 };
 
+use twizzler_object::{ObjID, Object, ObjectInitFlags, Protections};
+
 /// A constant representing the page size (4096 bytes per page).
 pub const PAGE: u64 = 4096;
 
@@ -34,6 +36,11 @@ pub fn objectrange_to_page_number(object_range: &ObjectRange) -> Option<u64> {
         return None; // Invalid ObjectRange for a single page
     }
     Some(object_range.start / PAGE)
+}
+
+
+pub fn page_in(obj_id: ObjID, obj_range: ObjectRange, phys_range: PhysRange) {
+    //Read from Disk -> Memory for Page, how??
 }
 
 #[cfg(test)]

--- a/src/bin/pager/src/helpers.rs
+++ b/src/bin/pager/src/helpers.rs
@@ -16,6 +16,16 @@ pub fn physrange_to_pages(phys_range: &PhysRange) -> u64 {
     (range_size + PAGE - 1) / PAGE // Add PAGE - 1 for ceiling division by PAGE
 }
 
+/// Converts a `PhysRange` into the number of pages (4096 bytes per page).
+/// Returns a `u64` representing the total number of pages in the range.
+pub fn page_to_physrange(page_num: usize, range_start: u64) -> PhysRange {
+    let start = ((page_num as u64) * PAGE) + range_start;
+    let end = start + PAGE;
+
+    return PhysRange { start: start, end: end }
+
+}
+
 /// Converts an `ObjectRange` representing a single page into the page number.
 /// Assumes the range is within a valid memory mapping and spans exactly one page (4096 bytes).
 /// Returns the page number starting at 0.

--- a/src/bin/pager/src/main.rs
+++ b/src/bin/pager/src/main.rs
@@ -74,7 +74,13 @@ fn main() {
             let x = res.await;
             println!(" pager:  got {:?} in response", x);
             timeout.await;
+            println!(" pager:  submitting request 2");
             // TODO: do some other stuff?
+            let res = sq.submit_and_wait(RequestFromPager::new(
+                twizzler_abi::pager::PagerRequest::Ready,
+            ));
+            let x = res.await;
+            println!(" pager:  got {:?} in response", x);
             std::future::pending::<()>().await;
         }
     })

--- a/src/bin/pager/src/request_handle.rs
+++ b/src/bin/pager/src/request_handle.rs
@@ -1,0 +1,38 @@
+use twizzler_abi::pager::{
+    CompletionToKernel, CompletionToPager, KernelCompletionData, RequestFromKernel, KernelCommand,
+    RequestFromPager, PagerCompletionData, PhysRange, ObjectRange
+};
+
+use twizzler_object::{ObjID, Object, ObjectInitFlags, Protections};
+
+use crate::data::PagerData;
+use crate::helpers::{physrange_to_pages, page_to_physrange, PAGE};
+
+use std::sync::Arc;
+
+fn page_data_req(data: Arc<PagerData>, id: ObjID, range: ObjectRange) -> PhysRange {
+    data.test_alloc_page();
+    let mempage = data.alloc_mem_page(id, range);
+    return page_to_physrange(mempage, 0);
+}
+
+pub async fn handle_kernel_request(request: RequestFromKernel, data: Arc<PagerData>) -> Option<CompletionToKernel> {
+    println!("[pager] handling kernel request {:?}", request);
+
+    match request.cmd() {
+        KernelCommand::PageDataReq(obj_id, range) => {
+            println!(
+                "Handling PageDataReq for ObjID: {:?}, Range: start = {}, end = {}",
+                obj_id, range.start, range.end
+                );
+            let phys_range = page_data_req(data, obj_id, range);
+            Some(CompletionToKernel::new(KernelCompletionData::PageDataReq(phys_range)))
+        }
+        KernelCommand::EchoReq => {
+            println!("Handling EchoReq");
+            Some(CompletionToKernel::new(KernelCompletionData::EchoResp))
+        }
+    }
+}
+
+

--- a/src/bin/pager/src/request_handle.rs
+++ b/src/bin/pager/src/request_handle.rs
@@ -11,9 +11,7 @@ use crate::helpers::{physrange_to_pages, page_to_physrange, PAGE};
 use std::sync::Arc;
 
 fn page_data_req(data: Arc<PagerData>, id: ObjID, range: ObjectRange) -> PhysRange {
-    data.test_alloc_page();
-    let mempage = data.alloc_mem_page(id, range);
-    return page_to_physrange(mempage, 0);
+    return data.fill_mem_page(id, range);
 }
 
 pub async fn handle_kernel_request(request: RequestFromKernel, data: Arc<PagerData>) -> Option<CompletionToKernel> {

--- a/src/bin/pager/src/request_handle.rs
+++ b/src/bin/pager/src/request_handle.rs
@@ -1,6 +1,6 @@
 use twizzler_abi::pager::{
     CompletionToKernel, CompletionToPager, KernelCompletionData, RequestFromKernel, KernelCommand,
-    RequestFromPager, PagerCompletionData, PhysRange, ObjectRange
+    RequestFromPager, PagerCompletionData, PhysRange, ObjectRange, ObjectInfo
 };
 
 use twizzler_object::{ObjID, Object, ObjectInitFlags, Protections};
@@ -14,20 +14,32 @@ fn page_data_req(data: Arc<PagerData>, id: ObjID, range: ObjectRange) -> PhysRan
     return data.fill_mem_page(id, range);
 }
 
+fn object_info_req(data: Arc<PagerData>, id: ObjID) -> ObjectInfo {
+    return ObjectInfo::new(id);
+}
+
 pub async fn handle_kernel_request(request: RequestFromKernel, data: Arc<PagerData>) -> Option<CompletionToKernel> {
     println!("[pager] handling kernel request {:?}", request);
 
     match request.cmd() {
         KernelCommand::PageDataReq(obj_id, range) => {
             println!(
-                "Handling PageDataReq for ObjID: {:?}, Range: start = {}, end = {}",
+                "[pager] handling PageDataReq for ObjID: {:?}, Range: start = {}, end = {}",
                 obj_id, range.start, range.end
                 );
             let phys_range = page_data_req(data, obj_id, range);
             Some(CompletionToKernel::new(KernelCompletionData::PageDataCompletion(phys_range)))
         }
+        KernelCommand::ObjectInfoReq(obj_id) => {
+            println!(
+                "[pager] handling ObjectInfo for ObjID: {:?}",
+                obj_id
+            );
+            let obj_info = object_info_req(data, obj_id);
+            Some(CompletionToKernel::new(KernelCompletionData::ObjectInfoCompletion(obj_info)))
+        }
         KernelCommand::EchoReq => {
-            println!("Handling EchoReq");
+            println!("[pager] handling EchoReq");
             Some(CompletionToKernel::new(KernelCompletionData::EchoResp))
         }
     }

--- a/src/bin/pager/src/request_handle.rs
+++ b/src/bin/pager/src/request_handle.rs
@@ -19,27 +19,27 @@ fn object_info_req(data: Arc<PagerData>, id: ObjID) -> ObjectInfo {
 }
 
 pub async fn handle_kernel_request(request: RequestFromKernel, data: Arc<PagerData>) -> Option<CompletionToKernel> {
-    println!("[pager] handling kernel request {:?}", request);
+    tracing::info!("handling kernel request {:?}", request);
 
     match request.cmd() {
         KernelCommand::PageDataReq(obj_id, range) => {
-            println!(
-                "[pager] handling PageDataReq for ObjID: {:?}, Range: start = {}, end = {}",
+            tracing::info!(
+                "handling PageDataReq for ObjID: {:?}, Range: start = {}, end = {}",
                 obj_id, range.start, range.end
                 );
             let phys_range = page_data_req(data, obj_id, range);
             Some(CompletionToKernel::new(KernelCompletionData::PageDataCompletion(phys_range)))
         }
         KernelCommand::ObjectInfoReq(obj_id) => {
-            println!(
-                "[pager] handling ObjectInfo for ObjID: {:?}",
+            tracing::info!(
+                "handling ObjectInfo for ObjID: {:?}",
                 obj_id
             );
             let obj_info = object_info_req(data, obj_id);
             Some(CompletionToKernel::new(KernelCompletionData::ObjectInfoCompletion(obj_info)))
         }
         KernelCommand::EchoReq => {
-            println!("[pager] handling EchoReq");
+            tracing::info!("handling EchoReq");
             Some(CompletionToKernel::new(KernelCompletionData::EchoResp))
         }
     }

--- a/src/bin/pager/src/request_handle.rs
+++ b/src/bin/pager/src/request_handle.rs
@@ -24,7 +24,7 @@ pub async fn handle_kernel_request(request: RequestFromKernel, data: Arc<PagerDa
                 obj_id, range.start, range.end
                 );
             let phys_range = page_data_req(data, obj_id, range);
-            Some(CompletionToKernel::new(KernelCompletionData::PageDataReq(phys_range)))
+            Some(CompletionToKernel::new(KernelCompletionData::PageDataCompletion(phys_range)))
         }
         KernelCommand::EchoReq => {
             println!("Handling EchoReq");

--- a/src/kernel/src/pager/queues.rs
+++ b/src/kernel/src/pager/queues.rs
@@ -52,7 +52,7 @@ pub(super) fn pager_compl_handler_main() {
             twizzler_abi::pager::KernelCompletionData::EchoResp => {
                 logln!("got echo response");
             }
-            twizzler_abi::pager::KernelCompletionData::PageDataReq(phys_range) => {
+            twizzler_abi::pager::KernelCompletionData::PageDataCompletion(phys_range) => {
                 logln!("got physical range {:?}", phys_range);
             }
         }

--- a/src/kernel/src/pager/queues.rs
+++ b/src/kernel/src/pager/queues.rs
@@ -42,6 +42,9 @@ pub(super) fn pager_compl_handler_main() {
             twizzler_abi::pager::KernelCompletionData::EchoResp => {
                 logln!("got echo response");
             }
+            twizzler_abi::pager::KernelCompletionData::PageDataReq(phys_range) => {
+                logln!("got physical range {:?}", phys_range);
+            }
         }
         sender.0.release_simple(SimpleId::from(completion.0));
     }

--- a/src/kernel/src/pager/queues.rs
+++ b/src/kernel/src/pager/queues.rs
@@ -1,7 +1,7 @@
 use twizzler_abi::{
     object::ObjID,
     pager::{
-        CompletionToKernel, CompletionToPager, KernelCommand, RequestFromKernel, RequestFromPager, PagerRequest
+        CompletionToKernel, CompletionToPager, KernelCommand, RequestFromKernel, RequestFromPager, PagerRequest, PhysRange
     },
 };
 
@@ -26,7 +26,7 @@ pub(super) fn pager_request_handler_main() {
         receiver.handle_request(|id, req| {
             logln!("kernel: got req {}:{:?} from pager", id, req);
             if req.cmd() == twizzler_abi::pager::PagerRequest::Ready {
-                return CompletionToPager::new(twizzler_abi::pager::PagerCompletionData::ReadyResp)
+                return CompletionToPager::new(twizzler_abi::pager::PagerCompletionData::DramPages(PhysRange::new(0x0000, 0x3E7FFF)))
             } else {
                 return CompletionToPager::new(twizzler_abi::pager::PagerCompletionData::EchoResp)
             }

--- a/src/kernel/src/pager/queues.rs
+++ b/src/kernel/src/pager/queues.rs
@@ -1,7 +1,7 @@
 use twizzler_abi::{
     object::ObjID,
     pager::{
-        CompletionToKernel, CompletionToPager, KernelCommand, RequestFromKernel, RequestFromPager,
+        CompletionToKernel, CompletionToPager, KernelCommand, RequestFromKernel, RequestFromPager, PagerRequest
     },
 };
 
@@ -25,7 +25,11 @@ pub(super) fn pager_request_handler_main() {
     loop {
         receiver.handle_request(|id, req| {
             logln!("kernel: got req {}:{:?} from pager", id, req);
-            CompletionToPager::new(twizzler_abi::pager::PagerCompletionData::EchoResp)
+            if req.cmd() == twizzler_abi::pager::PagerRequest::Ready {
+                return CompletionToPager::new(twizzler_abi::pager::PagerCompletionData::ReadyResp)
+            } else {
+                return CompletionToPager::new(twizzler_abi::pager::PagerCompletionData::EchoResp)
+            }
         });
     }
 }

--- a/src/lib/twizzler-abi/src/pager.rs
+++ b/src/lib/twizzler-abi/src/pager.rs
@@ -39,6 +39,7 @@ impl CompletionToKernel {
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Ord, Eq)]
 pub enum KernelCompletionData {
     EchoResp,
+    PageDataReq(PhysRange)
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Ord, Eq)]

--- a/src/lib/twizzler-abi/src/pager.rs
+++ b/src/lib/twizzler-abi/src/pager.rs
@@ -60,6 +60,7 @@ impl RequestFromPager {
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Ord, Eq)]
 pub enum PagerRequest {
     EchoReq,
+    TestReq,
     Ready,
 }
 
@@ -81,7 +82,7 @@ impl CompletionToPager {
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Ord, Eq)]
 pub enum PagerCompletionData {
     EchoResp,
-    ReadyResp,
+    TestResp,
     DramPages(PhysRange),
 }
 

--- a/src/lib/twizzler-abi/src/pager.rs
+++ b/src/lib/twizzler-abi/src/pager.rs
@@ -39,7 +39,7 @@ impl CompletionToKernel {
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Ord, Eq)]
 pub enum KernelCompletionData {
     EchoResp,
-    PageDataReq(PhysRange)
+    PageDataCompletion(PhysRange)
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Ord, Eq)]

--- a/src/lib/twizzler-abi/src/pager.rs
+++ b/src/lib/twizzler-abi/src/pager.rs
@@ -19,6 +19,7 @@ impl RequestFromKernel {
 pub enum KernelCommand {
     EchoReq,
     PageDataReq(ObjID, ObjectRange),
+    ObjectInfoReq(ObjID),
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Ord, Eq)]
@@ -39,7 +40,8 @@ impl CompletionToKernel {
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Ord, Eq)]
 pub enum KernelCompletionData {
     EchoResp,
-    PageDataCompletion(PhysRange)
+    PageDataCompletion(PhysRange),
+    ObjectInfoCompletion(ObjectInfo)
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Ord, Eq)]
@@ -89,6 +91,17 @@ pub enum PagerCompletionData {
 pub struct PageDataReq {
     objID: ObjID,
     object_range: ObjectRange
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Ord, Eq)]
+pub struct ObjectInfo {
+    pub obj_id: ObjID
+}
+
+impl ObjectInfo {
+    pub fn new(obj_id: ObjID) -> Self {
+        Self { obj_id }
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Ord, Eq)]

--- a/src/lib/twizzler-abi/src/pager.rs
+++ b/src/lib/twizzler-abi/src/pager.rs
@@ -1,3 +1,5 @@
+use twizzler_rt_abi::object::{ObjID};
+
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Ord, Eq)]
 pub struct RequestFromKernel {
     cmd: KernelCommand,
@@ -16,6 +18,7 @@ impl RequestFromKernel {
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Ord, Eq)]
 pub enum KernelCommand {
     EchoReq,
+    PageDataReq(ObjID, ObjectRange),
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Ord, Eq)]
@@ -78,4 +81,35 @@ impl CompletionToPager {
 pub enum PagerCompletionData {
     EchoResp,
     ReadyResp,
+    DramPages(PhysRange),
 }
+
+pub struct PageDataReq {
+    objID: ObjID,
+    object_range: ObjectRange
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Ord, Eq)]
+pub struct PhysRange {
+    pub start: u64,
+    pub end: u64,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Ord, Eq)]
+pub struct ObjectRange {
+    pub start: u64,
+    pub end: u64,
+}
+
+impl PhysRange {
+    pub fn new(start: u64, end: u64) -> Self {
+        Self { start, end }
+    }
+}
+
+impl ObjectRange {
+    pub fn new(start: u64, end: u64) -> Self {
+        Self { start, end }
+    }
+}
+

--- a/src/lib/twizzler-abi/src/pager.rs
+++ b/src/lib/twizzler-abi/src/pager.rs
@@ -56,6 +56,7 @@ impl RequestFromPager {
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Ord, Eq)]
 pub enum PagerRequest {
     EchoReq,
+    Ready,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Ord, Eq)]
@@ -76,4 +77,5 @@ impl CompletionToPager {
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Ord, Eq)]
 pub enum PagerCompletionData {
     EchoResp,
+    ReadyResp,
 }


### PR DESCRIPTION
Pager Features:

Pager init
Kernel <-> Pager Queues
PageDataReq, EchoReq, TestReq
limine: Loading kernel boot():/kernel.elf...
limine: Physical base: 0x7013f000
limine: Virtual base: 0xffffffff80100000
limine: Slide: 0x0
limine: ELF entry point: 0x0
limine: Base revision: 1
limine: Requests count: 8
limine: Top of HHDM: 0x100000000
limine: Entry point at 0xffffffff8038b2e0
acpi: Found RSDP at 0x7fb7e000
acpi: Found XSDP at 0x7fb7e014
limine: Loading module boot():/initrd...
[x86::apic] initializing APIC version X2Apic
[kernel] boot with cmd `'
[kernel::mm] initializing memory management
[kernel::debug] parsing kernel debug image
[kernel::cpu] enumerating secondary CPUs
remap 2 32
setting 2 32 masked=false
remap 5 37
setting 5 37 masked=false
remap 9 41
setting 9 41 masked=false
remap 10 42
setting 10 42 masked=false
remap 11 43
setting 11 43 masked=false
[kernel::initrd] loading module, 121 MB...
[kernel::initrd] loading "bootstrap" -> 10000000000000001
[kernel::initrd] loading "init" -> 10000000000000002
[kernel::initrd] loading "devmgr" -> 10000000000000003
[kernel::initrd] loading "pager" -> 10000000000000004
[kernel::initrd] loading "libtwz_rt.so" -> 10000000000000005
[kernel::initrd] loading "monitor" -> 10000000000000006
[kernel::initrd] loading "montest" -> 10000000000000007
[kernel::initrd] loading "libmontest_lib.so" -> 10000000000000008
[kernel::initrd] loading "mnemosyne" -> 10000000000000009
[kernel::initrd] loading "stdfs_demo" -> 1000000000000000a
[kernel::initrd] loading "logboi-test" -> 1000000000000000b
[kernel::initrd] loading "liblogboi_srv.so" -> 1000000000000000c
[kernel::initrd] loading "libstd.so" -> 1000000000000000d
[kernel::initrd] done, loaded 121 MB of object data
[kernel::cpu] booting secondary CPUs
[kernel::arch::tsc] tsc frequency 3072000000 (Hz), 325520 fs
[kernel::arch::x86-pit] setting up for statclock with freq 127 (7 ms)
[kernel::arch::tsc] tsc frequency 3072000000 (Hz), 325520 fs
setting 4 36 masked=false
[kernel::machine::pcie] init
[kernel::main] processor 0 entering main idle loop
1970-01-01T00:00:08.963490Z INFO bootstrap: bootstrapping runtime monitor
1970-01-01T00:00:09.798546Z INFO monitor early init completed, starting init
1970-01-01T00:00:10.182235Z INFO init: logboi ready
1970-01-01T00:00:10.184055Z INFO init: starting device manager
[devmgr] starting device manager Args { inner: ["devmgr", "18446744073709551682"] }
1970-01-01T00:00:10.390816Z DEBUG init: waiting for device manager to come up
[log:0] Hello Logboi, from devmgr!
[devmgr] scanning PCIe bus
[devmgr] 00:00.00 Bridge: Intel Corporation 82G33/G31/P35/P31 Express DRAM Controller
[devmgr] 00:02.00 Network controller: Intel Corporation 82574L Gigabit Network Connection
[devmgr] 00:03.00 Mass storage controller: Red Hat, Inc. QEMU NVM Express Controller
[devmgr] 00:1f.00 Bridge: Intel Corporation 82801IB (ICH9) LPC Interface Controller
[kernel::machine::pcie] unknown PCIe header type
[devmgr] 00:1f.02 Mass storage controller: Intel Corporation 82801IR/IO/IH (ICH9R/DO/DH) 6 port SATA Controller [AHCI mode]
[kernel::machine::pcie] unknown PCIe header type
[devmgr] 00:1f.03 Serial bus controller: Intel Corporation 82801I (ICH9 Family) SMBus Controller
[kernel::machine::pcie] unknown PCIe header type
1970-01-01T00:00:10.695086Z DEBUG init: device manager is up!
1970-01-01T00:00:10.696328Z INFO init: starting pager
[kernel-pager] registered sender pager queue: ObjID(1000000000000006b)
[kernel-pager] registered receiver pager queue: ObjID(1000000000000006c)
INFO pager::data: creating new PagerData instance
Hi, welcome to the basic twizzler test console.
If you wanted line-editing, you've come to the wrong place.
INFO pager::data: initializing PagerDataInner
To run a program, type its name.
INFO pager: Pager Attaching Queue: 18446744073709551723
INFO pager: Pager Attaching Queue: 18446744073709551724
INFO pager: pager health check start...
INFO pager: submitting request to kernel
kernel: got req 0:RequestFromPager { cmd: EchoReq } from pager
kernel: completing!! 0
INFO pager: got Ok(CompletionToPager { data: EchoResp }) in response
INFO pager: health check successful
INFO pager: init complete
INFO pager: spawning queues...
INFO pager: sending ready signal to kernel
INFO pager: submitting request RequestFromPager { cmd: Ready }
INFO pager: queue receiving...
kernel: got req 0:RequestFromPager { cmd: Ready } from pager
kernel: completing!! 0
INFO pager: received completion for ready signal: CompletionToPager { data: DramPages(PhysRange { start: 0, end: 4095999 }) }
INFO pager: initializing the pager with physical memory range: start: 0, end: 4095999
INFO pager::data: resizing resources to support 1000 pages
INFO pager::data: resizing bitvec to new size: 1000
INFO pager::data: bitvec resized to: 1000
INFO pager::data: adding 1000 capacity to hashmap
INFO pager: Performing Test...
INFO pager: submitting request RequestFromPager { cmd: TestReq }
kernel: got req 0:RequestFromPager { cmd: TestReq } from pager
kernel: submitting page data request on K2P Queue
kernel: submitting obj info request on K2P Queue
kernel: completing!! 0
INFO pager: got request: (1,RequestFromKernel { cmd: PageDataReq(ObjID(3e9), ObjectRange { start: 0, end: 4096 }) })
INFO pager: got request: (2,RequestFromKernel { cmd: ObjectInfoReq(ObjID(3e9)) })
INFO pager: Test Completed
INFO pager::request_handle: handling kernel request RequestFromKernel { cmd: PageDataReq(ObjID(3e9), ObjectRange { start: 0, end: 4096 }) }
INFO pager::request_handle: handling PageDataReq for ObjID: ObjID(3e9), Range: start = 0, end = 4096
INFO pager::data: allocating memory page for ObjID ObjID(3e9), ObjectRange ObjectRange { start: 0, end: 4096 }
INFO pager::data: attempting to get memory page
INFO pager::data: searching for next available page
INFO pager::data: next available page: 0
INFO pager::data: inserting into hashmap: key = 0, ObjID = ObjID(3e9), ObjectRange = ObjectRange { start: 0, end: 4096 }
INFO pager::data: inserted into hashmap: key = 0, ObjID = ObjID(3e9), ObjectRange = ObjectRange { start: 0, end: 4096 }
INFO pager::data: memory page allocated successfully
INFO pager: request 1 complete
got physical range PhysRange { start: 0, end: 4096 }
INFO pager::request_handle: handling kernel request RequestFromKernel { cmd: ObjectInfoReq(ObjID(3e9)) }
INFO pager::request_handle: handling ObjectInfo for ObjID: ObjID(3e9)
INFO pager: request 2 complete
got object info ObjectInfo { obj_id: ObjID(3e9) }