### PR TITLE
Twizzler crate: fill out the easy stuff, add handle caching.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -404,6 +404,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f421f1bcb30aa9d851a03c2920ab5d96ca920d5786645a597b5fc37922f8b89e"
 
 [[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1492,6 +1504,12 @@ name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
@@ -3868,9 +3886,13 @@ dependencies = [
  "async-executor",
  "async-io",
  "async-trait",
+ "bitvec",
  "futures",
  "nvme",
+ "polling",
  "tickv",
+ "tracing",
+ "tracing-subscriber",
  "twizzler-abi",
  "twizzler-driver",
  "twizzler-object",
@@ -4172,6 +4194,12 @@ checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
@@ -4932,6 +4960,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
 name = "tar"
 version = "0.4.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5450,7 +5484,6 @@ dependencies = [
 [[package]]
 name = "twizzler-rt-abi"
 version = "0.99.0"
-source = "git+https://github.com/twizzler-operating-system/abi#83c1f3573d535975c461d41a51c136bba625fdb0"
 dependencies = [
  "bitflags 2.6.0",
  "twizzler-types",
@@ -5467,7 +5500,6 @@ dependencies = [
 [[package]]
 name = "twizzler-types"
 version = "0.1.0"
-source = "git+https://github.com/twizzler-operating-system/abi#83c1f3573d535975c461d41a51c136bba625fdb0"
 
 [[package]]
 name = "twz-rt"
@@ -6008,6 +6040,15 @@ name = "writeable"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
+
+[[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]
 
 [[package]]
 name = "x86"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
     "src/bin/init",
     "src/bin/bootstrap",
     "src/bin/devmgr",
-    "src/bin/etl_twizzler",  
+    "src/bin/etl_twizzler",
     "src/bin/pager",
     "src/bin/mnemosyne",
     "src/bin/random_validation",
@@ -95,7 +95,7 @@ async-io = { git = "https://github.com/twizzler-operating-system/async-io.git", 
 async-executor = { git = "https://github.com/twizzler-operating-system/async-executor.git", branch = "twizzler" }
 twizzler-futures = { path = "src/lib/twizzler-futures" }
 twizzler-abi = { path = "src/lib/twizzler-abi" }
-twizzler-rt-abi = { git = "https://github.com/twizzler-operating-system/abi" }
+twizzler-rt-abi = { path = "src/abi/rt-abi" }
 parking_lot = { git = "https://github.com/twizzler-operating-system/parking_lot.git", branch = "twizzler" }
 # lock_api comes from the parking_lot repo
 lock_api = { git = "https://github.com/twizzler-operating-system/parking_lot.git", branch = "twizzler" }

--- a/src/lib/twizzler-abi/src/syscall/create.rs
+++ b/src/lib/twizzler-abi/src/syscall/create.rs
@@ -131,6 +131,7 @@ impl CreateTieSpec {
     Eq,
     IntoPrimitive,
     FromPrimitive,
+    Hash,
     thiserror::Error,
 )]
 #[repr(u64)]

--- a/src/lib/twizzler/src/alloc.rs
+++ b/src/lib/twizzler/src/alloc.rs
@@ -1,11 +1,6 @@
-use std::{
-    alloc::{AllocError, Layout},
-    mem::MaybeUninit,
-};
+use std::alloc::{AllocError, Layout};
 
-use invbox::InvBox;
-
-use crate::{marker::Invariant, ptr::GlobalPtr, tx::TxHandle};
+use crate::{ptr::GlobalPtr, tx::TxHandle};
 
 pub mod arena;
 mod global;

--- a/src/lib/twizzler/src/alloc/arena.rs
+++ b/src/lib/twizzler/src/alloc/arena.rs
@@ -1,10 +1,10 @@
 use std::mem::MaybeUninit;
 
-use super::{Allocator, OwnedGlobalPtr};
+use super::{Allocator, OwnedGlobalPtr, SingleObjectAllocator};
 use crate::{
     object::Object,
     ptr::{GlobalPtr, Ref},
-    tx::TxRef,
+    tx::{TxObject, TxRef},
 };
 
 pub struct ArenaObject {
@@ -16,11 +16,15 @@ impl ArenaObject {
         todo!()
     }
 
+    pub fn tx(self) -> crate::tx::Result<TxObject<ArenaBase>> {
+        self.obj.tx()
+    }
+
     pub fn allocator(&self) -> ArenaAllocator {
         todo!()
     }
 
-    pub fn alloc<T>(&self, value: T) -> OwnedGlobalPtr<T, ArenaAllocator> {
+    pub fn alloc<T>(&self, value: T) -> crate::tx::Result<OwnedGlobalPtr<T, ArenaAllocator>> {
         todo!()
     }
 
@@ -46,6 +50,8 @@ impl ArenaAllocator {
     }
 }
 
+impl SingleObjectAllocator for ArenaAllocator {}
+
 #[repr(C)]
 pub struct ArenaBase {}
 
@@ -58,6 +64,12 @@ impl Allocator for ArenaAllocator {
     }
 
     unsafe fn dealloc(&self, ptr: GlobalPtr<u8>, layout: std::alloc::Layout) {
+        todo!()
+    }
+}
+
+impl TxObject<ArenaBase> {
+    pub fn alloc<T>(&self, val: T) -> crate::tx::Result<OwnedGlobalPtr<T, ArenaAllocator>> {
         todo!()
     }
 }

--- a/src/lib/twizzler/src/alloc/global.rs
+++ b/src/lib/twizzler/src/alloc/global.rs
@@ -1,3 +1,5 @@
+use std::alloc::Layout;
+
 use super::Allocator;
 use crate::ptr::{GlobalPtr, Ref};
 
@@ -8,7 +10,8 @@ pub struct OwnedGlobalPtr<T, A: Allocator> {
 
 impl<T, A: Allocator> Drop for OwnedGlobalPtr<T, A> {
     fn drop(&mut self) {
-        todo!()
+        let layout = Layout::new::<T>();
+        unsafe { self.alloc.dealloc(self.global().cast(), layout) };
     }
 }
 
@@ -21,7 +24,7 @@ impl<T, A: Allocator> OwnedGlobalPtr<T, A> {
         Self { global, alloc }
     }
 
-    pub fn resolve(&self) -> Ref<'_, T> {
+    pub fn resolve<'a>(&self) -> Ref<'a, T> {
         todo!()
     }
 }

--- a/src/lib/twizzler/src/alloc/invbox.rs
+++ b/src/lib/twizzler/src/alloc/invbox.rs
@@ -52,10 +52,10 @@ mod tests {
 
     fn box_simple() {
         let alloc = ArenaObject::new().unwrap();
-        let foo = alloc
-            .alloc_inplace(|tx| {
-                let x = InvBox::new(tx.tx(), alloc.alloc(3).unwrap());
-                tx.write(Foo { x })
+        let arena = alloc.tx().unwrap();
+        let foo = arena
+            .alloc(Foo {
+                x: InvBox::new(&arena, arena.alloc(3).unwrap()),
             })
             .unwrap();
 

--- a/src/lib/twizzler/src/alloc/invbox.rs
+++ b/src/lib/twizzler/src/alloc/invbox.rs
@@ -51,7 +51,7 @@ mod tests {
     impl BaseType for Foo {}
 
     fn box_simple() {
-        let alloc = ArenaObject::new();
+        let alloc = ArenaObject::new().unwrap();
         let foo = alloc
             .alloc_inplace(|tx| {
                 let x = InvBox::new(tx.tx(), alloc.alloc(3).unwrap());
@@ -65,7 +65,7 @@ mod tests {
 
     fn box_simple_builder() {
         let builder = ObjectBuilder::<Foo>::default();
-        let alloc = ArenaObject::new();
+        let alloc = ArenaObject::new().unwrap();
         let obj = builder
             .build_inplace(|tx| {
                 let x = InvBox::new(&tx, alloc.alloc(3).unwrap());

--- a/src/lib/twizzler/src/alloc/invbox.rs
+++ b/src/lib/twizzler/src/alloc/invbox.rs
@@ -14,7 +14,7 @@ pub struct InvBox<T: Invariant, Alloc: Allocator> {
 
 impl<T: Invariant, Alloc: Allocator> InvBox<T, Alloc> {
     pub unsafe fn from_invptr(raw: InvPtr<T>, alloc: Alloc) -> Self {
-        todo!()
+        Self { raw, alloc }
     }
 
     pub fn new<B>(tx: &TxObject<B>, ogp: OwnedGlobalPtr<T, Alloc>) -> Self {
@@ -22,11 +22,11 @@ impl<T: Invariant, Alloc: Allocator> InvBox<T, Alloc> {
     }
 
     pub fn resolve(&self) -> Ref<'_, T> {
-        todo!()
+        unsafe { self.raw.resolve() }
     }
 
     pub fn global(&self) -> GlobalPtr<T> {
-        todo!()
+        self.raw.global()
     }
 
     pub fn as_ptr(&self) -> &InvPtr<T> {
@@ -54,7 +54,7 @@ mod tests {
         let alloc = ArenaObject::new();
         let foo = alloc
             .alloc_inplace(|tx| {
-                let x = InvBox::new(tx.tx(), alloc.alloc(3));
+                let x = InvBox::new(tx.tx(), alloc.alloc(3).unwrap());
                 tx.write(Foo { x })
             })
             .unwrap();
@@ -68,7 +68,7 @@ mod tests {
         let alloc = ArenaObject::new();
         let obj = builder
             .build_inplace(|tx| {
-                let x = InvBox::new(&tx, alloc.alloc(3));
+                let x = InvBox::new(&tx, alloc.alloc(3).unwrap());
                 tx.write(Foo { x })
             })
             .unwrap();

--- a/src/lib/twizzler/src/collections/list.rs
+++ b/src/lib/twizzler/src/collections/list.rs
@@ -39,7 +39,7 @@ mod tests {
 
     #[test]
     fn simple() {
-        let arena = ArenaObject::new();
+        let arena = ArenaObject::new().unwrap();
         let alloc = arena.allocator();
         let tx = arena.tx().unwrap();
         let node0 = tx
@@ -77,7 +77,7 @@ mod tests {
         // This would come from derive(Invariant)
         unsafe impl Invariant for Node {}
 
-        let arena = ArenaObject::new();
+        let arena = ArenaObject::new().unwrap();
         let alloc = arena.allocator();
         let data0 = arena.alloc(3);
         let tx = arena.tx().unwrap();

--- a/src/lib/twizzler/src/collections/list.rs
+++ b/src/lib/twizzler/src/collections/list.rs
@@ -37,6 +37,7 @@ mod tests {
         object::{ObjectBuilder, TypedObject},
     };
 
+    #[test]
     fn simple() {
         let arena = ArenaObject::new();
         let alloc = arena.allocator();
@@ -58,6 +59,7 @@ mod tests {
         assert_eq!(rnode0.value, 3);
     }
 
+    #[test]
     fn with_boxes() {
         struct Node {
             data: InvBox<u32, ArenaAllocator>,

--- a/src/lib/twizzler/src/marker.rs
+++ b/src/lib/twizzler/src/marker.rs
@@ -57,6 +57,7 @@ pub trait BaseType {
     }
 }
 
+impl BaseType for () {}
 impl BaseType for u8 {}
 impl BaseType for u16 {}
 impl BaseType for u32 {}

--- a/src/lib/twizzler/src/object.rs
+++ b/src/lib/twizzler/src/object.rs
@@ -162,12 +162,3 @@ impl<Base: BaseType> TypedObject for Object<Base> {
         unsafe { Ref::from_raw_parts(base, self.handle()) }
     }
 }
-
-impl<B: BaseType> From<Object<B>> for Object<()> {
-    fn from(value: Object<B>) -> Self {
-        Self {
-            handle: value.into_handle(),
-            _pd: PhantomData,
-        }
-    }
-}

--- a/src/lib/twizzler/src/object.rs
+++ b/src/lib/twizzler/src/object.rs
@@ -3,7 +3,7 @@
 use std::marker::PhantomData;
 
 use twizzler_abi::object::{ObjID, MAX_SIZE, NULLPAGE_SIZE};
-use twizzler_rt_abi::object::ObjectHandle;
+use twizzler_rt_abi::object::{MapError, MapFlags, ObjectHandle};
 
 use crate::{marker::BaseType, ptr::Ref, tx::TxObject};
 
@@ -102,13 +102,32 @@ pub struct Object<Base> {
 
 impl<B> Clone for Object<B> {
     fn clone(&self) -> Self {
-        todo!()
+        Self {
+            handle: self.handle.clone(),
+            _pd: PhantomData,
+        }
     }
 }
 
 impl<Base> Object<Base> {
     pub fn tx(self) -> crate::tx::Result<TxObject<Base>> {
-        todo!()
+        TxObject::new(self)
+    }
+
+    pub unsafe fn from_handle_unchecked(handle: ObjectHandle) -> Self {
+        Self {
+            handle,
+            _pd: PhantomData,
+        }
+    }
+
+    pub fn from_handle(handle: ObjectHandle) -> Result<Self, MapError> {
+        // TODO: check base fingerprint
+        unsafe { Ok(Self::from_handle_unchecked(handle)) }
+    }
+
+    pub fn into_handle(self) -> ObjectHandle {
+        self.handle
     }
 
     pub unsafe fn cast<U>(self) -> Object<U> {
@@ -116,6 +135,16 @@ impl<Base> Object<Base> {
             handle: self.handle,
             _pd: PhantomData,
         }
+    }
+
+    pub fn map(id: ObjID, flags: MapFlags) -> Result<Self, MapError> {
+        let handle = twizzler_rt_abi::object::twz_rt_map_object(id, flags)?;
+        Self::from_handle(handle)
+    }
+
+    pub unsafe fn map_unchecked(id: ObjID, flags: MapFlags) -> Result<Self, MapError> {
+        let handle = twizzler_rt_abi::object::twz_rt_map_object(id, flags)?;
+        unsafe { Ok(Self::from_handle_unchecked(handle)) }
     }
 }
 
@@ -129,12 +158,16 @@ impl<Base: BaseType> TypedObject for Object<Base> {
     type Base = Base;
 
     fn base(&self) -> Ref<'_, Self::Base> {
-        todo!()
+        let base = self.base_ptr();
+        unsafe { Ref::from_raw_parts(base, self.handle()) }
     }
 }
 
 impl<B: BaseType> From<Object<B>> for Object<()> {
     fn from(value: Object<B>) -> Self {
-        todo!()
+        Self {
+            handle: value.into_handle(),
+            _pd: PhantomData,
+        }
     }
 }

--- a/src/lib/twizzler/src/ptr/global.rs
+++ b/src/lib/twizzler/src/ptr/global.rs
@@ -2,17 +2,41 @@ use std::marker::PhantomData;
 
 use twizzler_abi::object::ObjID;
 
+use super::Ref;
+
 #[derive(Debug, Default, PartialEq, PartialOrd, Ord, Eq, Hash)]
 /// A global pointer, containing a fully qualified object ID and offset.
 pub struct GlobalPtr<T> {
     id: ObjID,
-    offset: usize,
+    offset: u64,
     _pd: PhantomData<*const T>,
+}
+
+impl<T> GlobalPtr<T> {
+    pub fn new(id: ObjID, offset: u64) -> Self {
+        Self {
+            id,
+            offset,
+            _pd: PhantomData,
+        }
+    }
+
+    pub fn cast<U>(self) -> GlobalPtr<U> {
+        GlobalPtr::new(self.id, self.offset)
+    }
+
+    pub unsafe fn resolve(&self) -> Ref<'_, T> {
+        todo!()
+    }
 }
 
 impl<T> Clone for GlobalPtr<T> {
     fn clone(&self) -> Self {
-        todo!()
+        Self {
+            id: self.id,
+            offset: self.offset,
+            _pd: PhantomData,
+        }
     }
 }
 

--- a/src/lib/twizzler/src/ptr/invariant.rs
+++ b/src/lib/twizzler/src/ptr/invariant.rs
@@ -15,7 +15,11 @@ pub struct InvPtr<T: Invariant> {
 }
 
 impl<T: Invariant> InvPtr<T> {
-    pub unsafe fn resolve<'a>(&self) -> Ref<'a, T> {
+    pub fn global(&self) -> GlobalPtr<T> {
+        todo!()
+    }
+
+    pub unsafe fn resolve(&self) -> Ref<'_, T> {
         todo!()
     }
 

--- a/src/lib/twizzler/src/ptr/resolved.rs
+++ b/src/lib/twizzler/src/ptr/resolved.rs
@@ -18,6 +18,10 @@ impl<'obj, T> Ref<'obj, T> {
         self.ptr
     }
 
+    pub unsafe fn from_raw_parts(ptr: *const T, handle: *const ObjectHandle) -> Self {
+        todo!()
+    }
+
     pub unsafe fn cast<U>(self) -> Ref<'obj, U> {
         todo!()
     }

--- a/src/lib/twizzler/src/ptr/resolved.rs
+++ b/src/lib/twizzler/src/ptr/resolved.rs
@@ -46,6 +46,10 @@ impl<'obj, T> Ref<'obj, T> {
     pub unsafe fn mutable(self) -> RefMut<'obj, T> {
         RefMut::from_raw_parts(self.ptr as *mut T, self.handle)
     }
+
+    pub fn global(&self) -> GlobalPtr<T> {
+        GlobalPtr::new(self.handle().id(), self.offset())
+    }
 }
 
 impl<'obj, T> Deref for Ref<'obj, T> {
@@ -95,6 +99,10 @@ impl<'obj, T> RefMut<'obj, T> {
 
     pub fn offset(&self) -> u64 {
         self.handle().ptr_local(self.ptr.cast()).unwrap() as u64
+    }
+
+    pub fn global(&self) -> GlobalPtr<T> {
+        GlobalPtr::new(self.handle().id(), self.offset())
     }
 }
 

--- a/src/lib/twizzler/src/tx.rs
+++ b/src/lib/twizzler/src/tx.rs
@@ -13,6 +13,7 @@ pub use unsafetx::*;
 use crate::{
     alloc::{invbox::InvBox, Allocator},
     marker::Invariant,
+    object::CreateError,
 };
 
 /// A trait for implementing per-object transaction handles.
@@ -45,7 +46,7 @@ pub trait TxHandle {
 
 pub type Result<T> = std::result::Result<T, TxError>;
 
-#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, thiserror::Error)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq, thiserror::Error)]
 /// Transaction errors, with user-definable abort type.
 pub enum TxError {
     /// Resources exhausted.
@@ -57,6 +58,9 @@ pub enum TxError {
     /// Invalid argument.
     #[error("invalid argument")]
     InvalidArgument,
+    /// Create error
+    #[error("create error")]
+    CreateError(#[from] CreateError),
 }
 
 #[derive(Copy, Clone, Debug, PartialEq, PartialOrd, Ord, Eq, Hash)]

--- a/src/lib/twizzler/src/tx/object.rs
+++ b/src/lib/twizzler/src/tx/object.rs
@@ -18,19 +18,26 @@ pub struct TxObject<T = ()> {
 
 impl<T> TxObject<T> {
     pub fn new(object: Object<T>) -> Result<Self> {
-        todo!()
+        // TODO: start tx
+        Ok(Self {
+            handle: object.into_handle(),
+            _pd: PhantomData,
+        })
     }
 
     pub fn commit(self) -> Result<Object<T>> {
-        todo!()
+        // TODO: commit tx
+        Ok(unsafe { Object::from_handle_unchecked(self.handle) })
     }
 
     pub fn abort(self) -> Object<T> {
-        todo!()
+        // TODO: abort tx
+        unsafe { Object::from_handle_unchecked(self.handle) }
     }
 
     pub fn base_mut(&mut self) -> RefMut<'_, T> {
-        todo!()
+        // TODO: track base in tx
+        unsafe { RefMut::from_raw_parts(self.base_mut_ptr(), self.handle()) }
     }
 
     pub fn insert_fot(&mut self, fot: FotEntry) -> crate::tx::Result<u64> {
@@ -39,14 +46,17 @@ impl<T> TxObject<T> {
 }
 
 impl<B> TxObject<MaybeUninit<B>> {
-    pub fn write(self, base: B) -> crate::tx::Result<TxObject<B>> {
-        todo!()
+    pub fn write(self, baseval: B) -> crate::tx::Result<TxObject<B>> {
+        let base = unsafe { self.base_mut_ptr::<MaybeUninit<B>>().as_mut().unwrap() };
+        base.write(baseval);
+        TxObject::new(unsafe { Object::from_handle_unchecked(self.handle) })
     }
 }
 
 impl<B> TxHandle for TxObject<B> {
     fn tx_mut(&self, data: *const u8, len: usize) -> super::Result<*mut u8> {
-        todo!()
+        // TODO
+        Ok(data as *mut u8)
     }
 }
 
@@ -60,7 +70,7 @@ impl<B: BaseType> TypedObject for TxObject<B> {
     type Base = B;
 
     fn base(&self) -> crate::ptr::Ref<'_, Self::Base> {
-        todo!()
+        unsafe { crate::ptr::Ref::from_raw_parts(self.base_ptr(), self.handle()) }
     }
 }
 

--- a/src/lib/twizzler/src/tx/object.rs
+++ b/src/lib/twizzler/src/tx/object.rs
@@ -13,6 +13,10 @@ pub struct TxObject<T> {
 }
 
 impl<T> TxObject<T> {
+    pub fn new(object: Object<T>) -> Result<Self> {
+        todo!()
+    }
+
     pub fn commit(self) -> Result<Object<T>> {
         todo!()
     }

--- a/src/lib/twizzler/src/tx/reference.rs
+++ b/src/lib/twizzler/src/tx/reference.rs
@@ -1,26 +1,39 @@
-use std::{cell::RefMut, mem::MaybeUninit, ops::Deref};
+use std::{
+    any::TypeId,
+    mem::{ManuallyDrop, MaybeUninit},
+    ops::Deref,
+};
 
 use super::TxObject;
+use crate::{marker::BaseType, object::RawObject, ptr::RefMut};
 
 pub struct TxRef<T> {
-    ptr: *const T,
-    tx: TxObject<()>,
-    panic_on_drop: bool,
+    ptr: *mut T,
+    tx: Option<TxObject<()>>,
 }
 
 impl<T> TxRef<T> {
     pub fn as_mut(&mut self) -> RefMut<'_, T> {
-        todo!()
+        let handle = self.tx.as_ref().unwrap().handle().handle();
+        unsafe { RefMut::from_raw_parts(self.ptr, handle) }
+    }
+
+    pub unsafe fn new(tx: TxObject<()>, ptr: *mut T) -> Self {
+        Self { ptr, tx: Some(tx) }
     }
 
     pub fn tx(&self) -> &TxObject<()> {
-        todo!()
+        self.tx.as_ref().unwrap()
     }
 }
 
 impl<T> TxRef<MaybeUninit<T>> {
-    pub fn write(self, val: T) -> crate::tx::Result<TxRef<T>> {
-        todo!()
+    pub fn write(mut self, val: T) -> crate::tx::Result<TxRef<T>> {
+        unsafe {
+            let ptr = self.ptr.as_mut().unwrap_unchecked();
+            let tx = self.tx.take().unwrap();
+            Ok(TxRef::<T>::new(tx, ptr.write(val)))
+        }
     }
 }
 
@@ -33,6 +46,7 @@ impl<T> Deref for TxRef<T> {
 }
 
 impl<T> Drop for TxRef<T> {
+    #[track_caller]
     fn drop(&mut self) {
         todo!()
     }

--- a/src/lib/twizzler/src/tx/unsafetx.rs
+++ b/src/lib/twizzler/src/tx/unsafetx.rs
@@ -9,7 +9,7 @@ impl UnsafeTxHandle {
 }
 
 impl TxHandle for UnsafeTxHandle {
-    fn tx_mut(&self, data: *const u8, len: usize) -> super::Result<*mut u8> {
-        todo!()
+    fn tx_mut(&self, data: *const u8, _len: usize) -> super::Result<*mut u8> {
+        Ok(data as *mut u8)
     }
 }

--- a/src/rt/reference/src/runtime.rs
+++ b/src/rt/reference/src/runtime.rs
@@ -1,9 +1,6 @@
 //! Top level runtime module, managing the basic presentation of the runtime.
 
-use std::sync::{
-    atomic::{AtomicU32, Ordering},
-    Mutex,
-};
+use std::sync::atomic::{AtomicU32, Ordering};
 
 mod alloc;
 mod core;
@@ -16,6 +13,7 @@ mod thread;
 mod time;
 pub(crate) mod upcall;
 
+use twizzler_abi::simple_mutex::Mutex;
 pub use upcall::set_upcall_handler;
 
 use self::object::ObjectHandleManager;

--- a/src/rt/reference/src/runtime/object/handlecache.rs
+++ b/src/rt/reference/src/runtime/object/handlecache.rs
@@ -1,0 +1,103 @@
+use std::collections::BTreeMap;
+
+use tracing::trace;
+use twizzler_abi::object::MAX_SIZE;
+use twizzler_rt_abi::bindings::object_handle;
+
+use super::free_runtime_info;
+use crate::runtime::object::ObjectMapKey;
+
+type Mapping = super::ObjectMapKey;
+
+const QUEUE_LEN: usize = 32;
+
+#[derive(Default, Debug, Clone)]
+pub struct HandleCache {
+    active: BTreeMap<Mapping, object_handle>,
+    queued: Vec<(Mapping, object_handle)>,
+    slotmap: BTreeMap<usize, Mapping>,
+}
+
+// Safety: this is needed because of the raw pointers in object_handle, but that's okay here
+// because those pointers are not used within the handle cache.
+unsafe impl Send for HandleCache {}
+
+fn do_unmap(handle: &object_handle) {
+    let map = Mapping::from_raw_handle(handle);
+    // No one else has a reference outside of the runtime, and we are being called by the handle
+    // cache after it has bumped us from the queue. Thus, the internal refs had to be zero (to
+    // be on the queue) and never incremented.
+    free_runtime_info(handle.runtime_info.cast());
+    monitor_api::monitor_rt_object_unmap(map.0, map.1).unwrap();
+}
+
+impl HandleCache {
+    pub const fn new() -> Self {
+        Self {
+            active: BTreeMap::new(),
+            queued: Vec::new(),
+            slotmap: BTreeMap::new(),
+        }
+    }
+
+    /// If map is present in either the active or the inactive lists, return a mutable reference to
+    /// it. If the handle was inactive, move it to the active list.
+    pub fn activate(&mut self, map: Mapping) -> Option<object_handle> {
+        let idx = self.queued.iter().position(|item| item.0 == map);
+        if let Some(idx) = idx {
+            trace!("activate {:?} from queue pos {}", map, idx);
+            let (_, handle) = self.queued.remove(idx);
+            self.insert(handle);
+        } else {
+            trace!("activate {:?}", map);
+        }
+
+        self.active.get_mut(&map).map(|item| *item)
+    }
+
+    /// Activate, using a slot as key.
+    pub fn activate_from_ptr(&mut self, ptr: *const u8) -> Option<object_handle> {
+        let slot = (ptr as usize) / MAX_SIZE;
+        let map = self.slotmap.get(&slot)?;
+        self.activate(*map)
+    }
+
+    /// Insert a handle into the active list. Item must not be already mapped.
+    pub fn insert(&mut self, handle: object_handle) {
+        let slot = (handle.start as usize) / MAX_SIZE;
+        let map = ObjectMapKey::from_raw_handle(&handle);
+        trace!("insert {:?}", map);
+        let _r = self.active.insert(map, handle);
+        debug_assert!(_r.is_none());
+        self.slotmap.insert(slot, map);
+    }
+
+    fn do_remove(&mut self, item: object_handle) {
+        let slot = (item.start as usize) / MAX_SIZE;
+        do_unmap(&item);
+        self.slotmap.remove(&slot);
+    }
+
+    /// Release a handle. Must only be called from runtime handle release (internal_refs == 0).
+    pub fn release(&mut self, handle: &object_handle) {
+        let map = ObjectMapKey::from_raw_handle(handle);
+        trace!("release {:?}", map);
+        if let Some(handle) = self.active.remove(&map) {
+            // If queue is full, evict.
+            if self.queued.len() >= QUEUE_LEN {
+                let (oldmap, old) = self.queued.remove(0);
+                trace!("evict {:?}", oldmap);
+                self.do_remove(old);
+            }
+            self.queued.push((map, handle));
+        }
+    }
+
+    /// Flush all items in the inactive queue.
+    pub fn flush(&mut self) {
+        let to_remove = self.queued.drain(..).collect::<Vec<_>>();
+        for item in to_remove {
+            self.do_remove(item.1);
+        }
+    }
+}

--- a/src/rt/reference/src/syms.rs
+++ b/src/rt/reference/src/syms.rs
@@ -479,6 +479,14 @@ pub unsafe extern "C-unwind" fn twz_rt_release_handle(handle: *mut object_handle
 check_ffi_type!(twz_rt_release_handle, _);
 
 #[no_mangle]
+pub unsafe extern "C-unwind" fn twz_rt_get_object_handle(ptr: *mut c_void) -> object_handle {
+    OUR_RUNTIME
+        .get_object_handle_from_ptr(ptr.cast())
+        .unwrap_or(object_handle::default())
+}
+check_ffi_type!(twz_rt_get_object_handle, _);
+
+#[no_mangle]
 pub unsafe extern "C-unwind" fn __twz_rt_map_two_objects(
     id_1: rt_objid,
     flags_1: map_flags,

--- a/tools/xtask/src/build.rs
+++ b/tools/xtask/src/build.rs
@@ -296,7 +296,7 @@ fn maybe_build_tests_dynamic<'a>(
                 "twizzler-futures" => None,
                 "twizzler-async" => None,
                 // for now -- tests aren't ready in this crate to run. Too many todo!()'s still.
-                "twizzler" => None,
+                //"twizzler" => None,
                 _ => Some(p.name().to_string()),
             })
             .collect(),


### PR DESCRIPTION
This PR implements many of the 1-2 liners that were stubbed out in the previous PRs. We also add in the handle caching so we can lookup objects by pointer, which is needed for the pager.