### PR TITLE
Pager support for filling physical memory + object store

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -387,6 +387,10 @@ name = "bitflags"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+dependencies = [
+ "compiler_builtins",
+ "rustc-std-workspace-core",
+]
 
 [[package]]
 name = "bitmaps"
@@ -816,6 +820,15 @@ name = "colorchoice"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
+
+[[package]]
+name = "compiler_builtins"
+version = "0.1.142"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78013b42e2946a76d348a858fa5a06ca7d6b5cccdfccd660ea7a0aa4a44d40ca"
+dependencies = [
+ "rustc-std-workspace-core",
+]
 
 [[package]]
 name = "concurrent-queue"
@@ -3897,6 +3910,7 @@ dependencies = [
  "twizzler-driver",
  "twizzler-object",
  "twizzler-queue",
+ "twizzler-rt-abi",
  "twizzler-runtime",
  "volatile",
 ]
@@ -4431,6 +4445,12 @@ name = "rustc-demangle"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
+
+[[package]]
+name = "rustc-std-workspace-core"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa9c45b374136f52f2d6311062c7146bff20fec063c3f5d46a410bd937746955"
 
 [[package]]
 name = "rustfix"
@@ -5486,6 +5506,8 @@ name = "twizzler-rt-abi"
 version = "0.99.0"
 dependencies = [
  "bitflags 2.6.0",
+ "compiler_builtins",
+ "rustc-std-workspace-core",
  "twizzler-types",
 ]
 
@@ -5500,6 +5522,10 @@ dependencies = [
 [[package]]
 name = "twizzler-types"
 version = "0.1.0"
+dependencies = [
+ "compiler_builtins",
+ "rustc-std-workspace-core",
+]
 
 [[package]]
 name = "twz-rt"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1421,6 +1421,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "fatfs"
+version = "0.4.0"
+source = "git+https://github.com/rafalh/rust-fatfs.git#c4bb76929eb115f228720631b4110f827b998653"
+dependencies = [
+ "bitflags 2.6.0",
+ "log",
+]
+
+[[package]]
 name = "fdt"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2974,7 +2983,7 @@ dependencies = [
  "anyhow",
  "argh",
  "clap",
- "fatfs",
+ "fatfs 0.3.6",
  "gpt",
  "locate-cargo-manifest",
 ]
@@ -3733,6 +3742,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62948e14d923ea95ea2c7c86c71013138b66525b86bdc08d2dcc262bdb497b87"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "object-store"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "fatfs 0.4.0",
+ "nvme",
+ "pci-ids",
+ "twizzler-abi",
+ "twizzler-async",
+ "twizzler-driver",
+ "twizzler-object",
+ "twizzler-queue",
+ "volatile",
+]
+
+[[package]]
+name = "object-store-test"
+version = "0.1.0"
+dependencies = [
+ "object-store",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ members = [
     "src/bin/virtio",
     "src/bin/mnemosyne",
     "src/bin/stdfs_demo",
+    "src/bin/object-store-test",
     "src/bin/virtio",
     "src/kernel",
     "src/lib/twizzler-queue-raw",
@@ -40,6 +41,7 @@ members = [
     "src/srv/logboi-srv",
     "src/bin/logboi-test",
     "src/lib/virtio-net",
+    "src/bin/object-store-test",
 ]
 
 exclude = ["toolchain/src/rust"]
@@ -71,10 +73,10 @@ initrd = [
     "crate:stdfs_demo",
     "crate:logboi-test",
     "lib:logboi-srv",
-    # "crate:random_validation",
     "crate:randtest",
     "crate:randtest",
     "crate:genrandom",
+    "crate:object-store-test",
     #"third-party:hello-world-rs"
 ]
 

--- a/src/bin/etl_twizzler/src/etl.rs
+++ b/src/bin/etl_twizzler/src/etl.rs
@@ -72,7 +72,7 @@ where
 
         self.tarchive
             .append_data(&mut header, path, &mut buf_writer)?;
-         
+
         Ok(())
     }
 
@@ -97,8 +97,7 @@ where
         let mut v = vec![];
         buf_writer.read_to_end(&mut v)?;
         {
-            self.tarchive
-                .append_data(&mut header, name, v.as_slice())?;
+            self.tarchive.append_data(&mut header, name, v.as_slice())?;
         }
         Ok(())
     }
@@ -215,10 +214,9 @@ where
                         form_persistent_vector(entry, path, bad_idea.offset)?;
                     }
                 }
-            }
-            else if let Err(E) = e {
+            } else if let Err(E) = e {
                 println!("{}", E);
-            } 
+            }
         }
 
         Ok(())

--- a/src/bin/init/src/main.rs
+++ b/src/bin/init/src/main.rs
@@ -1,6 +1,6 @@
 extern crate twizzler_runtime;
 
-fn initialize_pager() { 
+fn initialize_pager() {
     info!("starting pager");
     const DEFAULT_PAGER_QUEUE_LEN: usize = 1024;
     let queue = twizzler_queue::Queue::<RequestFromKernel, CompletionToKernel>::create(
@@ -42,7 +42,6 @@ fn initialize_pager() {
     .expect("failed to start pager");
 
     std::mem::forget(pager_comp);
-
 }
 
 fn main() {

--- a/src/bin/object-store-test/Cargo.toml
+++ b/src/bin/object-store-test/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "object-store-test"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+object-store = { version = "0.1.0", path = "object-store" }

--- a/src/bin/object-store-test/object-store/Cargo.toml
+++ b/src/bin/object-store-test/object-store/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "object-store"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+fatfs = { git = "https://github.com/rafalh/rust-fatfs.git", version = "0.4.0", features = [
+    "std",
+    "log_level_info",
+    "lfn",
+    "alloc",
+], default-features = false }
+twizzler-async = { path = "../../../lib/twizzler-async" }
+twizzler-abi = { path = "../../../lib/twizzler-abi" }
+twizzler-driver = { path = "../../../lib/twizzler-driver" }
+twizzler-object = { path = "../../../lib/twizzler-object" }
+twizzler-queue = { path = "../../../lib/twizzler-queue" }
+nvme = { path = "../../../lib/nvme-rs" }
+async-trait = "0.1.66"
+volatile = "0.5"
+pci-ids = "0.2.4"

--- a/src/bin/object-store-test/object-store/src/disk.rs
+++ b/src/bin/object-store-test/object-store/src/disk.rs
@@ -1,0 +1,156 @@
+use std::{
+    borrow::BorrowMut,
+    io::{self, Error, ErrorKind},
+    ops::Deref,
+    sync::{Arc, LazyLock, Mutex, OnceLock},
+};
+
+use fatfs::{
+    FatType, FileSystem, FormatVolumeOptions, IntoStorage, IoBase, Read, Seek, SeekFrom, Write,
+};
+use twizzler_async::block_on;
+
+use crate::nvme::{init_nvme, NvmeController};
+
+pub struct Disk {
+    ctrl: Arc<NvmeController>,
+    pub pos: usize,
+}
+
+impl Disk {
+    pub fn new() -> Result<Disk, ()> {
+        Ok(Disk {
+            ctrl: block_on(init_nvme()),
+            pos: 0,
+        })
+    }
+}
+
+static DISK: OnceLock<Disk> = OnceLock::new();
+pub static FS: LazyLock<Mutex<FileSystem<Disk>>> = LazyLock::new(|| {
+    let mut disk = Disk::new().unwrap();
+    let fs_options = fatfs::FsOptions::new().update_accessed_date(false);
+    let fs = FileSystem::new(disk, fs_options);
+    if let Ok(fs) = fs {
+        return Mutex::new(fs);
+    }
+    drop(fs);
+    let mut disk = Disk::new().unwrap();
+    format(&mut disk);
+    let fs =
+        FileSystem::new(disk, fs_options).expect("disk should be formatted now so no more errors.");
+    Mutex::new(fs)
+});
+
+// impl IntoStorage<&mut Disk> for LazyLock<Disk> {
+//     fn into_storage(mut self) -> &mut Disk {
+//         &mut self
+//     }
+// }
+// is only called if unable to open fs
+fn format(disk: &mut Disk) {
+    let options = FormatVolumeOptions::new()
+        .bytes_per_sector(SECTOR_SIZE as u16)
+        .bytes_per_cluster(PAGE_SIZE as u32)
+        .fat_type(FatType::Fat32);
+    fatfs::format_volume(disk, options).unwrap();
+}
+const DISK_SIZE: usize = 0x40000000;
+const PAGE_SIZE: usize = 4096;
+const SECTOR_SIZE: usize = 512;
+const PAGE_MASK: usize = 0xFFF;
+const LBA_COUNT: usize = DISK_SIZE / SECTOR_SIZE;
+
+impl fatfs::Read for Disk {
+    fn read(&mut self, buf: &mut [u8]) -> Result<usize, Error> {
+        let mut lba = (self.pos / PAGE_SIZE) * 8;
+        let mut bytes_written: usize = 0;
+        let mut read_buffer: [u8; PAGE_SIZE] = [0; PAGE_SIZE];
+
+        while bytes_written != buf.len() {
+            if lba >= LBA_COUNT {
+                break;
+            }
+
+            let left = self.pos % PAGE_SIZE;
+            let right = if left + buf.len() - bytes_written > PAGE_SIZE {
+                PAGE_SIZE
+            } else {
+                left + buf.len() - bytes_written
+            }; // If I want to write more than the boundary of a page
+            block_on(self.ctrl.read_page(lba as u64, &mut read_buffer, 0));
+
+            let bytes_to_read = right - left;
+            buf[bytes_written..bytes_written + bytes_to_read]
+                .copy_from_slice(&read_buffer[left..right]);
+
+            bytes_written += bytes_to_read;
+            self.pos += bytes_to_read;
+            lba += PAGE_SIZE / SECTOR_SIZE;
+        }
+
+        Ok(bytes_written)
+    }
+}
+
+impl fatfs::Write for Disk {
+    fn write(&mut self, buf: &[u8]) -> Result<usize, Error> {
+        let mut lba = (self.pos / PAGE_SIZE) * 8;
+        let mut bytes_read = 0;
+        let mut write_buffer: [u8; PAGE_SIZE] = [0; PAGE_SIZE];
+
+        while bytes_read != buf.len() {
+            if lba >= LBA_COUNT {
+                break;
+            }
+
+            let left = self.pos % PAGE_SIZE;
+            let right = if left + buf.len() - bytes_read > PAGE_SIZE {
+                PAGE_SIZE
+            } else {
+                left + buf.len() - bytes_read
+            };
+            if right - left != PAGE_SIZE {
+                let temp_pos: u64 = self.pos.try_into().unwrap();
+                self.seek(SeekFrom::Start(temp_pos & !PAGE_MASK as u64));
+                self.read_exact(&mut write_buffer)?;
+                self.seek(SeekFrom::Start(temp_pos));
+            }
+
+            write_buffer[left..right].copy_from_slice(&buf[bytes_read..bytes_read + right - left]);
+            bytes_read += right - left;
+
+            self.pos += right - left;
+
+            block_on(self.ctrl.write_page(lba as u64, &mut write_buffer, 0));
+            lba += PAGE_SIZE / SECTOR_SIZE;
+        }
+
+        Ok(bytes_read)
+    }
+
+    fn flush(&mut self) -> Result<(), Error> {
+        Ok(())
+    }
+}
+
+impl fatfs::Seek for Disk {
+    fn seek(&mut self, pos: SeekFrom) -> Result<u64, Error> {
+        let new_pos: i64 = match pos {
+            SeekFrom::Start(x) => x as i64,
+            SeekFrom::End(x) => (DISK_SIZE as i64) - x,
+            SeekFrom::Current(x) => (self.pos as i64) + x,
+        };
+        if new_pos > DISK_SIZE.try_into().unwrap() || new_pos < 0 {
+            println!("HERE!");
+            Err(Error::new(ErrorKind::AddrInUse, "oh no!"))
+        } else {
+            self.pos = new_pos as usize;
+            Ok(self.pos.try_into().unwrap())
+        }
+    }
+}
+
+impl IoBase for Disk {
+    type Error = Error;
+}

--- a/src/bin/object-store-test/object-store/src/lib.rs
+++ b/src/bin/object-store-test/object-store/src/lib.rs
@@ -1,0 +1,5 @@
+mod disk;
+mod nvme;
+mod object_store;
+
+pub use object_store::{create_object, read_exact, unlink_object, write_all};

--- a/src/bin/object-store-test/object-store/src/nvme.rs
+++ b/src/bin/object-store-test/object-store/src/nvme.rs
@@ -1,0 +1,40 @@
+use core::panic;
+use std::sync::Arc;
+
+use twizzler_abi::device::BusType;
+use twizzler_driver::{bus::pcie::PcieDeviceInfo, DeviceController};
+
+mod controller;
+mod dma;
+mod requester;
+
+pub use controller::NvmeController;
+
+pub async fn init_nvme() -> Arc<NvmeController> {
+    let device_root = twizzler_driver::get_bustree_root();
+    for device in device_root.children() {
+        if device.is_bus() && device.bus_type() == BusType::Pcie {
+            for child in device.children() {
+                let info = unsafe { child.get_info::<PcieDeviceInfo>(0).unwrap() };
+                if info.get_data().class == 1
+                    && info.get_data().subclass == 8
+                    && info.get_data().progif == 2
+                {
+                    /*println!(
+                        "found nvme controller {:x}.{:x}.{:x}",
+                        info.get_data().bus_nr,
+                        info.get_data().dev_nr,
+                        info.get_data().func_nr
+                    );*/
+
+                    let mut ctrl = Arc::new(NvmeController::new(
+                        DeviceController::new_from_device(child),
+                    ));
+                    controller::init_controller(&mut ctrl).await;
+                    return ctrl;
+                }
+            }
+        }
+    }
+    panic!("no nvme controller found");
+}

--- a/src/bin/object-store-test/object-store/src/nvme/controller.rs
+++ b/src/bin/object-store-test/object-store/src/nvme/controller.rs
@@ -1,0 +1,546 @@
+use std::{
+    mem::size_of,
+    sync::{Arc, Mutex, OnceLock, RwLock},
+};
+
+use nvme::{
+    admin::{CreateIOCompletionQueue, CreateIOSubmissionQueue},
+    ds::{
+        controller::properties::config::ControllerConfig,
+        identify::controller::IdentifyControllerDataStructure,
+        namespace::{NamespaceId, NamespaceList},
+        queue::{
+            comentry::CommonCompletion, subentry::CommonCommand, CommandId, QueueId, QueuePriority,
+        },
+    },
+    hosted::memory::{PhysicalPageCollection, PrpMode},
+    nvm::{ReadDword13, WriteDword13},
+};
+use twizzler_async::Task;
+use twizzler_driver::{
+    dma::{DmaOptions, DmaPool, DMA_PAGE_SIZE},
+    request::{Requester, SubmitRequest, SubmitSummaryWithResponses},
+    DeviceController,
+};
+use volatile::map_field;
+
+use super::{dma::NvmeDmaRegion, requester::NvmeRequester};
+use crate::nvme::dma::NvmeDmaSliceRegion;
+
+pub struct NvmeController {
+    requester: RwLock<Vec<Requester<NvmeRequester>>>,
+    admin_requester: RwLock<Option<Arc<Requester<NvmeRequester>>>>,
+    int_tasks: Mutex<Vec<Task<()>>>,
+    device_ctrl: DeviceController,
+    dma_pool: DmaPool,
+    capacity: OnceLock<usize>,
+    block_size: OnceLock<usize>,
+}
+
+pub async fn init_controller(ctrl: &mut Arc<NvmeController>) {
+    let bar = ctrl.device_ctrl.device().get_mmio(1).unwrap();
+    let mut reg = unsafe {
+        bar.get_mmio_offset_mut::<nvme::ds::controller::properties::ControllerProperties>(0)
+    };
+    let reg = reg.as_mut_ptr();
+
+    let int = ctrl.device_ctrl.allocate_interrupt().unwrap();
+    let config = ControllerConfig::new();
+    map_field!(reg.configuration).write(config);
+
+    while map_field!(reg.status).read().ready() {
+        core::hint::spin_loop();
+    }
+
+    let aqa = nvme::ds::controller::properties::aqa::AdminQueueAttributes::new()
+        .with_completion_queue_size(32 - 1)
+        .with_submission_queue_size(32 - 1);
+    map_field!(reg.admin_queue_attr).write(aqa);
+
+    let saq = ctrl
+        .dma_pool
+        .allocate_array(32, nvme::ds::queue::subentry::CommonCommand::default())
+        .unwrap();
+    let caq = ctrl
+        .dma_pool
+        .allocate_array(32, nvme::ds::queue::comentry::CommonCompletion::default())
+        .unwrap();
+
+    let mut saq = NvmeDmaSliceRegion::new(saq);
+    let mut caq = NvmeDmaSliceRegion::new(caq);
+
+    let cpin = caq.dma_region_mut().pin().unwrap();
+    let spin = saq.dma_region_mut().pin().unwrap();
+
+    assert_eq!(cpin.len(), 1);
+    assert_eq!(spin.len(), 1);
+
+    let cpin_addr = cpin[0].addr();
+    let spin_addr = spin[0].addr();
+
+    map_field!(reg.admin_comqueue_base_addr).write(cpin_addr.into());
+    map_field!(reg.admin_subqueue_base_addr).write(spin_addr.into());
+
+    //let css_nvm = reg.capabilities.get().supports_nvm_command_set();
+    //let css_more = reg.capabilities.get().supports_more_io_command_sets();
+    // TODO: check bit 7 of css.
+
+    let config = ControllerConfig::new()
+        .with_enable(true)
+        .with_io_completion_queue_entry_size(
+            size_of::<CommonCompletion>()
+                .next_power_of_two()
+                .ilog2()
+                .try_into()
+                .unwrap(),
+        )
+        .with_io_submission_queue_entry_size(
+            size_of::<CommonCommand>()
+                .next_power_of_two()
+                .ilog2()
+                .try_into()
+                .unwrap(),
+        );
+
+    map_field!(reg.configuration).write(config);
+    while !map_field!(reg.status).read().ready() {
+        core::hint::spin_loop();
+    }
+
+    let smem = unsafe {
+        core::slice::from_raw_parts_mut(
+            saq.dma_region_mut().get_mut().as_mut_ptr() as *mut u8,
+            32 * size_of::<CommonCommand>(),
+        )
+    };
+    const C_STRIDE: usize = size_of::<CommonCompletion>();
+    const S_STRIDE: usize = size_of::<CommonCommand>();
+    let sq = nvme::queue::SubmissionQueue::new(smem, 32, S_STRIDE).unwrap();
+
+    let cmem = unsafe {
+        core::slice::from_raw_parts_mut(
+            caq.dma_region_mut().get_mut().as_mut_ptr() as *mut u8,
+            32 * size_of::<CommonCompletion>(),
+        )
+    };
+    let cq = nvme::queue::CompletionQueue::new(cmem, 32, C_STRIDE).unwrap();
+
+    let mut saq_bell = unsafe { bar.get_mmio_offset::<u32>(0x1000) };
+    let mut caq_bell = unsafe {
+        bar.get_mmio_offset::<u32>(
+            0x1000 + 1 * map_field!(reg.capabilities).read().doorbell_stride_bytes(),
+        )
+    };
+
+    let req = NvmeRequester::new(
+        Mutex::new(sq),
+        Mutex::new(cq),
+        saq_bell.as_mut_ptr().as_raw_ptr().as_ptr(),
+        caq_bell.as_mut_ptr().as_raw_ptr().as_ptr(),
+        saq,
+        caq,
+    );
+    let req = Arc::new(Requester::new(req));
+
+    std::thread::spawn(|| twizzler_async::run(std::future::pending::<()>()));
+
+    let req2 = req.clone();
+    let ctrl2 = ctrl.clone();
+    twizzler_async::run(async {
+        Task::spawn(async move {
+            loop {
+                let _i = int.next().await;
+                //println!("got interrupt");
+                //println!("=== admin ===");
+                let resps = req2.driver().check_completions();
+                req2.finish(&resps);
+                for r in ctrl2.requester.read().unwrap().iter() {
+                    //println!("=== i/o ===");
+                    let c = r.driver().check_completions();
+                    r.finish(&c);
+                }
+            }
+        })
+    })
+    .detach();
+
+    //ctrl.int_tasks.lock().unwrap().push(task);
+
+    *ctrl.admin_requester.write().unwrap() = Some(req);
+
+    let cqid = 1.into();
+    let sqid = 1.into();
+
+    let req = ctrl
+        .create_queue_pair(cqid, sqid, QueuePriority::Medium, 32)
+        .await;
+
+    ctrl.requester.write().unwrap().push(req);
+}
+
+impl NvmeController {
+    pub fn new(device_ctrl: DeviceController) -> Self {
+        Self {
+            requester: Default::default(),
+            admin_requester: Default::default(),
+            int_tasks: Default::default(),
+            device_ctrl,
+            dma_pool: DmaPool::new(
+                DmaPool::default_spec(),
+                twizzler_driver::dma::Access::BiDirectional,
+                DmaOptions::empty(),
+            ),
+            capacity: OnceLock::new(),
+            block_size: OnceLock::new(),
+        }
+    }
+
+    async fn create_queue_pair(
+        &self,
+        cqid: QueueId,
+        sqid: QueueId,
+        priority: QueuePriority,
+        queue_len: usize,
+    ) -> Requester<NvmeRequester> {
+        let saq = self
+            .dma_pool
+            .allocate_array(
+                queue_len,
+                nvme::ds::queue::subentry::CommonCommand::default(),
+            )
+            .unwrap();
+
+        let caq = self
+            .dma_pool
+            .allocate_array(
+                queue_len,
+                nvme::ds::queue::comentry::CommonCompletion::default(),
+            )
+            .unwrap();
+
+        let mut saq = NvmeDmaSliceRegion::new(saq);
+        let spin = saq.dma_region_mut().pin().unwrap();
+        assert_eq!(spin.len(), 1);
+
+        let mut caq = NvmeDmaSliceRegion::new(caq);
+        let cpin = caq.dma_region_mut().pin().unwrap();
+        assert_eq!(cpin.len(), 1);
+
+        let smem = unsafe {
+            core::slice::from_raw_parts_mut(
+                saq.dma_region_mut().get_mut().as_mut_ptr() as *mut u8,
+                32 * size_of::<CommonCommand>(),
+            )
+        };
+
+        const C_STRIDE: usize = size_of::<CommonCompletion>();
+        const S_STRIDE: usize = size_of::<CommonCommand>();
+        let sq = nvme::queue::SubmissionQueue::new(smem, queue_len.try_into().unwrap(), S_STRIDE)
+            .unwrap();
+
+        let cmem = unsafe {
+            core::slice::from_raw_parts_mut(
+                caq.dma_region_mut().get_mut().as_mut_ptr() as *mut u8,
+                32 * size_of::<CommonCompletion>(),
+            )
+        };
+
+        let cq = nvme::queue::CompletionQueue::new(cmem, queue_len.try_into().unwrap(), C_STRIDE)
+            .unwrap();
+
+        {
+            // TODO: we should save these NvmeDmaRegions so they don't drop (dropping is okay, but
+            // this leaks memory )
+            let cmd = CreateIOCompletionQueue::new(
+                CommandId::new(),
+                cqid,
+                (&mut caq)
+                    .get_prp_list_or_buffer(PrpMode::Single, &self.dma_pool)
+                    .unwrap(),
+                ((queue_len - 1) as u16).into(),
+                0,
+                true,
+            );
+
+            let cmd: CommonCommand = cmd.into();
+            let responses = self
+                .admin_requester
+                .read()
+                .unwrap()
+                .as_ref()
+                .unwrap()
+                .submit_for_response(&mut [SubmitRequest::new(cmd)])
+                .await
+                .unwrap();
+
+            match responses.await {
+                SubmitSummaryWithResponses::Responses(_) => {}
+                x => eprintln!("error creating completion queue {:?}", x),
+            }
+        }
+
+        {
+            let cmd = CreateIOSubmissionQueue::new(
+                CommandId::new(),
+                sqid,
+                (&mut saq)
+                    .get_prp_list_or_buffer(PrpMode::Single, &self.dma_pool)
+                    .unwrap(),
+                ((queue_len - 1) as u16).into(),
+                cqid,
+                priority,
+            );
+            let cmd: CommonCommand = cmd.into();
+            let responses = self
+                .admin_requester
+                .read()
+                .unwrap()
+                .as_ref()
+                .unwrap()
+                .submit_for_response(&mut [SubmitRequest::new(cmd)])
+                .await
+                .unwrap();
+            match responses.await {
+                SubmitSummaryWithResponses::Responses(_) => {}
+                x => eprintln!("error creating submission queue {:?}", x),
+            }
+        }
+
+        let bar = self.device_ctrl.device().get_mmio(1).unwrap();
+        let reg = unsafe {
+            bar.get_mmio_offset::<nvme::ds::controller::properties::ControllerProperties>(0)
+        };
+        let reg = reg.into_ptr();
+        let bell_stride: usize = map_field!(reg.capabilities).read().doorbell_stride_bytes();
+        let _ = 0;
+        let mut saq_bell = unsafe {
+            bar.get_mmio_offset::<u32>(0x1000 + (u16::from(sqid) as usize) * 2 * bell_stride)
+        };
+        let mut caq_bell = unsafe {
+            bar.get_mmio_offset::<u32>(0x1000 + ((u16::from(cqid) as usize) * 2 + 1) * bell_stride)
+        };
+
+        let req = NvmeRequester::new(
+            Mutex::new(sq),
+            Mutex::new(cq),
+            saq_bell.as_mut_ptr().as_raw_ptr().as_ptr(),
+            caq_bell.as_mut_ptr().as_raw_ptr().as_ptr(),
+            saq,
+            caq,
+        );
+
+        Requester::new(req)
+    }
+
+    pub async fn identify_controller(&self) -> IdentifyControllerDataStructure {
+        let ident = self
+            .dma_pool
+            .allocate(nvme::ds::identify::controller::IdentifyControllerDataStructure::default())
+            .unwrap();
+        let mut ident = NvmeDmaRegion::new(ident);
+        let ident_cmd = nvme::admin::Identify::new(
+            CommandId::new(),
+            nvme::admin::IdentifyCNSValue::IdentifyController,
+            (&mut ident)
+                .get_dptr(
+                    nvme::hosted::memory::DptrMode::Prp(PrpMode::Single),
+                    &self.dma_pool,
+                )
+                .unwrap(),
+            None,
+        );
+        let ident_cmd: CommonCommand = ident_cmd.into();
+        let responses = self
+            .admin_requester
+            .read()
+            .unwrap()
+            .as_ref()
+            .unwrap()
+            .submit_for_response(&mut [SubmitRequest::new(ident_cmd)])
+            .await;
+        let responses = responses.unwrap().await;
+        match responses {
+            SubmitSummaryWithResponses::Responses(_resp) => {}
+            _ => panic!("got err for ident"),
+        }
+
+        ident.dma_region().with(|ident| ident.clone())
+    }
+
+    pub async fn identify_namespace(
+        &self,
+    ) -> nvme::ds::identify::namespace::IdentifyNamespaceDataStructure {
+        let nslist = self.dma_pool.allocate([0u8; 4096]).unwrap();
+        let mut nslist = NvmeDmaRegion::new(nslist);
+        let nslist_cmd = nvme::admin::Identify::new(
+            CommandId::new(),
+            nvme::admin::IdentifyCNSValue::ActiveNamespaceIdList(NamespaceId::default()),
+            (&mut nslist)
+                .get_dptr(
+                    nvme::hosted::memory::DptrMode::Prp(PrpMode::Single),
+                    &self.dma_pool,
+                )
+                .unwrap(),
+            None,
+        );
+        let nslist_cmd: CommonCommand = nslist_cmd.into();
+        let responses = self
+            .admin_requester
+            .read()
+            .unwrap()
+            .as_ref()
+            .unwrap()
+            .submit_for_response(&mut [SubmitRequest::new(nslist_cmd)])
+            .await;
+        let responses = responses.unwrap().await;
+        match responses {
+            SubmitSummaryWithResponses::Responses(_resp) => {}
+            _ => panic!("got err for ident"),
+        }
+
+        nslist.dma_region().with(|nslist| {
+            let lslist = NamespaceList::new(nslist);
+            for _id in lslist.into_iter() {
+                // TODO: do something with IDs
+            }
+        });
+
+        let ident = self
+            .dma_pool
+            .allocate(nvme::ds::identify::namespace::IdentifyNamespaceDataStructure::default())
+            .unwrap();
+        let mut ident = NvmeDmaRegion::new(ident);
+        let ident_cmd = nvme::admin::Identify::new(
+            CommandId::new(),
+            nvme::admin::IdentifyCNSValue::IdentifyNamespace(NamespaceId::new(1u32)),
+            (&mut ident)
+                .get_dptr(
+                    nvme::hosted::memory::DptrMode::Prp(PrpMode::Single),
+                    &self.dma_pool,
+                )
+                .unwrap(),
+            None,
+        );
+        let ident_cmd: CommonCommand = ident_cmd.into();
+        let responses = self
+            .admin_requester
+            .read()
+            .unwrap()
+            .as_ref()
+            .unwrap()
+            .submit_for_response(&mut [SubmitRequest::new(ident_cmd)])
+            .await;
+        let responses = responses.unwrap().await;
+        match responses {
+            SubmitSummaryWithResponses::Responses(_resp) => {}
+            _ => panic!("got err for ident"),
+        }
+
+        ident.dma_region().with(|ident| ident.clone())
+    }
+
+    pub async fn flash_len(&self) -> usize {
+        if let Some(sz) = self.capacity.get() {
+            *sz
+        } else {
+            self.identify_controller().await;
+            let ns = self.identify_namespace().await;
+            let block_size = ns.lba_formats()[ns.formatted_lba_size.index()].data_size();
+            let _ = self.capacity.set(block_size * ns.capacity as usize);
+            block_size * ns.capacity as usize
+        }
+    }
+
+    pub async fn read_page(
+        &self,
+        lba_start: u64,
+        out_buffer: &mut [u8],
+        offset: usize,
+    ) -> Result<(), ()> {
+        let nr_blocks = DMA_PAGE_SIZE / self.get_lba_size().await;
+        let buffer = self.dma_pool.allocate([0u8; DMA_PAGE_SIZE]).unwrap();
+        let mut buffer = NvmeDmaRegion::new(buffer);
+        let dptr = (&mut buffer)
+            .get_dptr(
+                nvme::hosted::memory::DptrMode::Prp(PrpMode::Double),
+                &self.dma_pool,
+            )
+            .unwrap();
+        let cmd = nvme::nvm::ReadCommand::new(
+            CommandId::new(),
+            NamespaceId::new(1u32),
+            dptr,
+            lba_start,
+            nr_blocks as u16,
+            ReadDword13::default(),
+        );
+        let cmd: CommonCommand = cmd.into();
+        let responses = self.requester.read().unwrap()[0]
+            .submit_for_response(&mut [SubmitRequest::new(cmd)])
+            .await;
+        match responses.unwrap().await {
+            SubmitSummaryWithResponses::Responses(_) => buffer.dma_region().with(|data| {
+                out_buffer.copy_from_slice(&data[offset..DMA_PAGE_SIZE]);
+                Ok(())
+            }),
+            SubmitSummaryWithResponses::Errors(_, _r) => Err(()),
+            SubmitSummaryWithResponses::Shutdown => Err(()),
+        }
+    }
+
+    pub async fn write_page(
+        &self,
+        lba_start: u64,
+        in_buffer: &[u8],
+        offset: usize,
+    ) -> Result<(), ()> {
+        let nr_blocks = DMA_PAGE_SIZE / self.get_lba_size().await;
+        let mut buffer = self.dma_pool.allocate([0u8; DMA_PAGE_SIZE]).unwrap();
+
+        let len = in_buffer.len();
+        if offset + len > DMA_PAGE_SIZE {
+            panic!("cannot write past a page");
+        }
+        if offset != 0 || len != DMA_PAGE_SIZE {
+            unsafe { self.read_page(lba_start, buffer.get_mut(), 0).await? };
+        }
+        buffer.with_mut(|data| data[offset..(offset + len)].copy_from_slice(in_buffer));
+
+        let mut buffer = NvmeDmaRegion::new(buffer);
+        let dptr = (&mut buffer)
+            .get_dptr(
+                nvme::hosted::memory::DptrMode::Prp(PrpMode::Double),
+                &self.dma_pool,
+            )
+            .unwrap();
+        let cmd = nvme::nvm::WriteCommand::new(
+            CommandId::new(),
+            NamespaceId::new(1u32),
+            dptr,
+            lba_start,
+            nr_blocks as u16,
+            WriteDword13::default(),
+        );
+        let cmd: CommonCommand = cmd.into();
+        let responses = self.requester.read().unwrap()[0]
+            .submit_for_response(&mut [SubmitRequest::new(cmd)])
+            .await;
+        match responses.unwrap().await {
+            SubmitSummaryWithResponses::Responses(_) => Ok(()),
+            SubmitSummaryWithResponses::Errors(_, _r) => Err(()),
+            SubmitSummaryWithResponses::Shutdown => Err(()),
+        }
+    }
+
+    pub async fn get_lba_size(&self) -> usize {
+        if let Some(sz) = self.block_size.get() {
+            *sz
+        } else {
+            self.identify_controller().await;
+            let ns = self.identify_namespace().await;
+            let block_size = ns.lba_formats()[ns.formatted_lba_size.index()].data_size();
+            let _ = self.block_size.set(block_size);
+            block_size
+        }
+    }
+}

--- a/src/bin/object-store-test/object-store/src/nvme/dma.rs
+++ b/src/bin/object-store-test/object-store/src/nvme/dma.rs
@@ -1,0 +1,184 @@
+use nvme::{
+    ds::cmd::PrpListOrBuffer,
+    hosted::memory::{PhysicalPageCollection, PrpMode},
+};
+use twizzler_driver::dma::{DeviceSync, DmaPin, DmaPool, DmaRegion, DmaSliceRegion, DMA_PAGE_SIZE};
+
+struct PrpMgr {
+    _list: Vec<DmaSliceRegion<u64>>,
+    mode: PrpMode,
+    buffer: bool,
+    embed: [u64; 2],
+}
+
+pub struct NvmeDmaRegion<T: DeviceSync> {
+    reg: DmaRegion<T>,
+    prp: Option<PrpMgr>,
+}
+
+impl<'a, T: DeviceSync> NvmeDmaRegion<T> {
+    pub fn new(region: DmaRegion<T>) -> Self {
+        Self {
+            reg: region,
+            prp: None,
+        }
+    }
+
+    pub fn dma_region(&self) -> &DmaRegion<T> {
+        &self.reg
+    }
+
+    pub fn dma_region_mut(&mut self) -> &mut DmaRegion<T> {
+        &mut self.reg
+    }
+}
+
+fn __get_prp_list_or_buffer(pin: DmaPin, dma: &DmaPool, mode: PrpMode) -> PrpMgr {
+    let entries_per_page = DMA_PAGE_SIZE / 8;
+    let pin_len = pin.len();
+    let mut pin_iter = pin.into_iter();
+
+    let prp = match pin_len {
+        1 => PrpMgr {
+            _list: vec![],
+            embed: [pin_iter.next().unwrap().addr().into(), 0],
+            mode,
+            buffer: true,
+        },
+        2 if mode == PrpMode::Double => PrpMgr {
+            _list: vec![],
+            embed: [
+                pin_iter.next().unwrap().addr().into(),
+                pin_iter.next().unwrap().addr().into(),
+            ],
+            mode,
+            buffer: false,
+        },
+        _ => {
+            let mut first_prp_page = dma.allocate_array(entries_per_page, 0u64).unwrap();
+            let start = first_prp_page
+                .pin()
+                .unwrap()
+                .into_iter()
+                .next()
+                .unwrap()
+                .addr()
+                .into();
+            let mut list = vec![first_prp_page];
+            let embed = [pin_iter.next().unwrap().addr().into(), start];
+            for (num, page) in pin_iter.enumerate() {
+                let index = num % entries_per_page;
+                if (num + 1) % entries_per_page == 0 && num != pin_len - 1 {
+                    // Last entry with more to record, chain.
+                    let mut next_prp_page = dma.allocate_array(entries_per_page, 0u64).unwrap();
+                    let pin = next_prp_page.pin().unwrap();
+                    assert_eq!(pin.len(), 1);
+                    let phys = pin.into_iter().next().unwrap().addr();
+                    list.last_mut()
+                        .unwrap()
+                        .with_mut(index..(index + 1), |array: &mut [u64]| {
+                            array[0] = phys.into();
+                        });
+
+                    list.push(next_prp_page);
+                }
+
+                list.last_mut()
+                    .unwrap()
+                    .with_mut(index..(index + 1), |array: &mut [u64]| {
+                        array[0] = page.addr().into();
+                    });
+            }
+            PrpMgr {
+                _list: list,
+                mode,
+                embed,
+                buffer: false,
+            }
+        }
+    };
+    prp
+}
+
+impl PrpMgr {
+    fn prp_list_or_buffer(&self) -> PrpListOrBuffer {
+        match self.mode {
+            PrpMode::Double => {
+                if self.buffer {
+                    PrpListOrBuffer::Buffer(self.embed[0])
+                } else {
+                    PrpListOrBuffer::PrpFirstAndList(self.embed[0], self.embed[1])
+                }
+            }
+            PrpMode::Single => {
+                if self.buffer {
+                    PrpListOrBuffer::Buffer(self.embed[0])
+                } else {
+                    PrpListOrBuffer::PrpList(self.embed[0])
+                }
+            }
+        }
+    }
+}
+
+impl<'a, T: DeviceSync> PhysicalPageCollection for &'a mut NvmeDmaRegion<T> {
+    fn get_prp_list_or_buffer(
+        &mut self,
+        mode: PrpMode,
+        dma: Self::DmaType,
+    ) -> Option<nvme::ds::cmd::PrpListOrBuffer> {
+        if let Some(ref prp) = self.prp {
+            if mode == prp.mode {
+                return Some(prp.prp_list_or_buffer());
+            }
+        }
+
+        let pin = self.reg.pin().unwrap();
+        self.prp = Some(__get_prp_list_or_buffer(pin, dma, mode));
+        Some(self.prp.as_ref().unwrap().prp_list_or_buffer())
+    }
+
+    type DmaType = &'a DmaPool;
+}
+
+pub struct NvmeDmaSliceRegion<T: DeviceSync> {
+    reg: DmaSliceRegion<T>,
+    prp: Option<PrpMgr>,
+}
+
+impl<'a, T: DeviceSync> NvmeDmaSliceRegion<T> {
+    pub fn new(region: DmaSliceRegion<T>) -> Self {
+        Self {
+            reg: region,
+            prp: None,
+        }
+    }
+
+    pub fn dma_region(&self) -> &DmaSliceRegion<T> {
+        &self.reg
+    }
+
+    pub fn dma_region_mut(&mut self) -> &mut DmaSliceRegion<T> {
+        &mut self.reg
+    }
+}
+
+impl<'a, T: DeviceSync> PhysicalPageCollection for &'a mut NvmeDmaSliceRegion<T> {
+    fn get_prp_list_or_buffer(
+        &mut self,
+        mode: PrpMode,
+        dma: Self::DmaType,
+    ) -> Option<nvme::ds::cmd::PrpListOrBuffer> {
+        if let Some(ref prp) = self.prp {
+            if mode == prp.mode {
+                return Some(prp.prp_list_or_buffer());
+            }
+        }
+
+        let pin = self.reg.pin().unwrap();
+        self.prp = Some(__get_prp_list_or_buffer(pin, dma, mode));
+        Some(self.prp.as_ref().unwrap().prp_list_or_buffer())
+    }
+
+    type DmaType = &'a DmaPool;
+}

--- a/src/bin/object-store-test/object-store/src/nvme/requester.rs
+++ b/src/bin/object-store-test/object-store/src/nvme/requester.rs
@@ -1,0 +1,106 @@
+use std::{ptr::NonNull, sync::Mutex};
+
+use nvme::{
+    ds::queue::{comentry::CommonCompletion, subentry::CommonCommand},
+    queue::{CompletionQueue, SubmissionQueue},
+};
+use twizzler_driver::request::{RequestDriver, ResponseInfo, SubmitRequest};
+use volatile::VolatilePtr;
+
+use super::dma::NvmeDmaSliceRegion;
+
+pub struct NvmeRequester {
+    subq: Mutex<SubmissionQueue>,
+    comq: Mutex<CompletionQueue>,
+    sub_bell: *mut u32,
+    com_bell: *mut u32,
+    _sub_dma: NvmeDmaSliceRegion<CommonCommand>,
+    _com_dma: NvmeDmaSliceRegion<CommonCompletion>,
+}
+
+unsafe impl Send for NvmeRequester {}
+unsafe impl Sync for NvmeRequester {}
+
+impl NvmeRequester {
+    pub fn new(
+        subq: Mutex<SubmissionQueue>,
+        comq: Mutex<CompletionQueue>,
+        sub_bell: *mut u32,
+        com_bell: *mut u32,
+        sub_dma: NvmeDmaSliceRegion<CommonCommand>,
+        com_dma: NvmeDmaSliceRegion<CommonCompletion>,
+    ) -> Self {
+        Self {
+            subq,
+            comq,
+            sub_bell,
+            com_bell,
+            _sub_dma: sub_dma,
+            _com_dma: com_dma,
+        }
+    }
+
+    #[inline]
+    fn sub_bell(&self) -> VolatilePtr<'_, u32> {
+        unsafe { VolatilePtr::new(NonNull::new(self.sub_bell).unwrap()) }
+    }
+
+    #[inline]
+    fn com_bell(&self) -> VolatilePtr<'_, u32> {
+        unsafe { VolatilePtr::new(NonNull::new(self.com_bell).unwrap()) }
+    }
+
+    pub fn check_completions(&self) -> Vec<ResponseInfo<CommonCompletion>> {
+        let mut comq = self.comq.lock().unwrap();
+        let mut resps = Vec::new();
+        let mut new_head = None;
+        let mut new_bell = None;
+        while let Some((bell, resp)) = comq.get_completion::<CommonCompletion>() {
+            let id: u16 = resp.command_id().into();
+            resps.push(ResponseInfo::new(resp, id as u64, resp.status().is_error()));
+            new_head = Some(resp.new_sq_head());
+            new_bell = Some(bell);
+        }
+
+        if let Some(head) = new_head {
+            self.subq.lock().unwrap().update_head(head);
+        }
+
+        if let Some(bell) = new_bell {
+            self.com_bell().write(bell as u32)
+        }
+
+        resps
+    }
+}
+
+#[async_trait::async_trait]
+impl RequestDriver for NvmeRequester {
+    type Request = CommonCommand;
+
+    type Response = CommonCompletion;
+
+    type SubmitError = ();
+
+    async fn submit(
+        &self,
+        reqs: &mut [SubmitRequest<Self::Request>],
+    ) -> Result<(), Self::SubmitError> {
+        let mut sq = self.subq.lock().unwrap();
+        let mut tail = None;
+        for sr in reqs.iter_mut() {
+            let cid = (sr.id() as u16).into();
+            sr.data_mut().set_cid(cid);
+            tail = sq.submit(sr.data());
+            assert!(tail.is_some());
+        }
+        if let Some(tail) = tail {
+            self.sub_bell().write(tail as u32);
+        }
+        Ok(())
+    }
+
+    fn flush(&self) {}
+
+    const NUM_IDS: usize = 32;
+}

--- a/src/bin/object-store-test/object-store/src/object_store.rs
+++ b/src/bin/object-store-test/object-store/src/object_store.rs
@@ -1,0 +1,67 @@
+use std::io::{Error, Read, Write};
+
+use fatfs::{DefaultTimeProvider, Dir, LossyOemCpConverter, Seek};
+
+use crate::disk::{Disk, FS};
+fn get_dir_path<'a>(
+    fs: &'a mut fatfs::FileSystem<Disk>,
+    encoded_obj_id: &EncodedObjectId,
+) -> Result<Dir<'a, Disk, DefaultTimeProvider, LossyOemCpConverter>, Error> {
+    let subdir = fs
+        .root_dir()
+        .create_dir("ids")?
+        .create_dir(&encoded_obj_id[0..1])?;
+    Ok(subdir)
+}
+
+type EncodedObjectId = String;
+
+fn encode_obj_id(obj_id: u128) -> EncodedObjectId {
+    format!("{:0>32x}", obj_id)
+}
+
+pub fn unlink_object(obj_id: u128) -> Result<(), Error> {
+    let b64 = encode_obj_id(obj_id);
+    let mut fs = FS.lock().unwrap();
+    let subdir = get_dir_path(&mut fs, &b64)?;
+    subdir.remove(&b64)?;
+    Ok(())
+}
+
+/// Returns true if file was created and false if the file already existed.
+pub fn create_object(obj_id: u128) -> Result<bool, Error> {
+    let b64 = encode_obj_id(obj_id);
+    let mut fs = FS.lock().unwrap();
+    let subdir = get_dir_path(&mut fs, &b64)?;
+    // try to open it to check if it exists.
+    let res = subdir.open_file(&b64);
+    match res {
+        Ok(_) => Ok(false),
+        Err(e) => match e {
+            fatfs::Error::NotFound => {
+                subdir.create_file(&b64);
+                Ok(true)
+            }
+            _ => Err(e.into()),
+        },
+    }
+}
+pub fn read_exact(obj_id: u128, buf: &mut [u8], off: u64) -> Result<(), Error> {
+    let b64 = encode_obj_id(obj_id);
+    let mut fs = FS.lock().unwrap();
+    let subdir = get_dir_path(&mut fs, &b64)?;
+    let mut file = subdir.open_file(&b64)?;
+    file.seek(fatfs::SeekFrom::Start(off))?;
+    file.read_exact(buf)?;
+    Ok(())
+}
+
+pub fn write_all(obj_id: u128, buf: &[u8], off: u64) -> Result<(), Error> {
+    let b64 = encode_obj_id(obj_id);
+    let mut fs = FS.lock().unwrap();
+    let subdir = get_dir_path(&mut fs, &b64)?;
+    let mut file = subdir.open_file(&b64)?;
+    file.seek(fatfs::SeekFrom::Start(off))?;
+    file.write_all(buf)?;
+    Ok(())
+}

--- a/src/bin/object-store-test/src/main.rs
+++ b/src/bin/object-store-test/src/main.rs
@@ -1,0 +1,34 @@
+#![feature(random)]
+use std::{io::Error, random::random};
+
+use object_store::*;
+
+fn make_and_check_file(buf1: &mut [u8], buf2: &mut [u8]) -> (Vec<u8>, u128) {
+    let id: u128 = random();
+
+    create_object(id).unwrap();
+    buf1.fill_with(|| random());
+    write_all(id, buf1, 0).unwrap();
+    read_exact(id, buf2, 0).unwrap();
+    assert!(buf1 == buf2);
+    (buf2.into(), id)
+}
+
+fn main() {
+    let mut working_bufs = (vec![0; 600], vec![0; 600]);
+    let out = (0..20).map(|i| {
+        println!("{}", i);
+        make_and_check_file(&mut working_bufs.0, &mut working_bufs.1)
+    });
+    for (value, id) in out {
+        // make sure buf == read
+        let mut buf = vec![0; 600];
+        read_exact(id, &mut buf, 0).unwrap();
+        assert!(value == buf);
+        // unlink
+        unlink_object(id).unwrap();
+        // make sure object is unlinked
+        let v = read_exact(id, &mut buf, 0).expect_err("should be error");
+        assert!(v.kind() == std::io::ErrorKind::NotFound);
+    }
+}

--- a/src/bin/pager/Cargo.toml
+++ b/src/bin/pager/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 
 [dependencies]
 twizzler-abi = { path = "../../lib/twizzler-abi" }
+twizzler-rt-abi = { path = "../../abi/rt-abi" }
 twizzler-object = { path = "../../lib/twizzler-object" }
 twizzler-queue = { path = "../../lib/twizzler-queue" }
 #twizzler-async = { path = "../../lib/twizzler-async" }

--- a/src/bin/pager/src/data.rs
+++ b/src/bin/pager/src/data.rs
@@ -1,9 +1,11 @@
-use std::collections::HashMap;
-use std::sync::{Arc, Mutex};
+use std::{
+    collections::{HashMap, VecDeque},
+    sync::{Arc, Mutex},
+};
+
 use bitvec::prelude::*;
 use twizzler_abi::pager::{ObjectRange, PhysRange};
 use twizzler_object::{ObjID, Object, ObjectInitFlags, Protections};
-use std::collections::VecDeque;
 
 use crate::helpers::{page_in, page_to_physrange};
 
@@ -16,7 +18,7 @@ pub struct PagerDataInner {
     pub bitvec: BitVec,
     pub hashmap: HashMap<u64, (ObjID, ObjectRange)>,
     pub lru_queue: VecDeque<u64>,
-    pub mem_range_start: u64 
+    pub mem_range_start: u64,
 }
 
 impl PagerDataInner {
@@ -28,7 +30,7 @@ impl PagerDataInner {
             bitvec: BitVec::new(),
             hashmap: HashMap::with_capacity(0),
             lru_queue: VecDeque::new(),
-            mem_range_start: 0
+            mem_range_start: 0,
         }
     }
 
@@ -87,7 +89,10 @@ impl PagerDataInner {
             self.lru_queue.retain(|&p| p != page_number as u64);
             tracing::info!("page {} removed from bitvec", page_number);
         } else {
-            tracing::info!("page {} is out of bounds and cannot be removed", page_number);
+            tracing::info!(
+                "page {} is out of bounds and cannot be removed",
+                page_number
+            );
         }
     }
 
@@ -114,12 +119,16 @@ impl PagerDataInner {
     pub fn insert_into_map(&mut self, key: u64, obj_id: ObjID, range: ObjectRange) {
         tracing::info!(
             "inserting into hashmap: key = {}, ObjID = {:?}, ObjectRange = {:?}",
-            key, obj_id, range
+            key,
+            obj_id,
+            range
         );
         self.hashmap.insert(key, (obj_id.clone(), range.clone()));
         tracing::info!(
             "inserted into hashmap: key = {}, ObjID = {:?}, ObjectRange = {:?}",
-            key, obj_id, range
+            key,
+            obj_id,
+            range
         );
     }
 
@@ -187,7 +196,11 @@ impl PagerData {
     /// Page in the data from disk
     /// Returns the physical range corresponding to the allocated page.
     pub fn fill_mem_page(&self, id: ObjID, obj_range: ObjectRange) -> PhysRange {
-        tracing::info!("allocating memory page for ObjID {:?}, ObjectRange {:?}", id, obj_range);
+        tracing::info!(
+            "allocating memory page for ObjID {:?}, ObjectRange {:?}",
+            id,
+            obj_range
+        );
         let mut inner = self.inner.lock().unwrap();
         let page = inner.get_mem_page();
         inner.insert_into_map(page.try_into().unwrap(), id, obj_range);
@@ -197,4 +210,3 @@ impl PagerData {
         return phys_range;
     }
 }
-

--- a/src/bin/pager/src/helpers.rs
+++ b/src/bin/pager/src/helpers.rs
@@ -1,12 +1,8 @@
-use twizzler_abi::pager::{
-    PhysRange, ObjectRange
-};
-
+use twizzler_abi::pager::{ObjectRange, PhysRange};
 use twizzler_object::{ObjID, Object, ObjectInitFlags, Protections};
 
 /// A constant representing the page size (4096 bytes per page).
 pub const PAGE: u64 = 4096;
-
 
 /// Converts a `PhysRange` into the number of pages (4096 bytes per page).
 /// Returns a `u64` representing the total number of pages in the range.
@@ -24,8 +20,7 @@ pub fn page_to_physrange(page_num: usize, range_start: u64) -> PhysRange {
     let start = ((page_num as u64) * PAGE) + range_start;
     let end = start + PAGE;
 
-    return PhysRange { start: start, end: end }
-
+    return PhysRange { start, end };
 }
 
 /// Converts an `ObjectRange` representing a single page into the page number.
@@ -38,7 +33,6 @@ pub fn objectrange_to_page_number(object_range: &ObjectRange) -> Option<u64> {
     Some(object_range.start / PAGE)
 }
 
-
 pub fn page_in(obj_id: ObjID, obj_range: ObjectRange, phys_range: PhysRange) {
     //Read from Disk -> Memory for Page, how??
 }
@@ -49,32 +43,52 @@ mod tests {
 
     #[test]
     fn test_physrange_to_pages() {
-        let range = PhysRange { start: 0, end: 8192 };
+        let range = PhysRange {
+            start: 0,
+            end: 8192,
+        };
         assert_eq!(physrange_to_pages(&range), 2);
 
-        let range = PhysRange { start: 0, end: 4095 };
+        let range = PhysRange {
+            start: 0,
+            end: 4095,
+        };
         assert_eq!(physrange_to_pages(&range), 1);
 
         let range = PhysRange { start: 0, end: 0 };
         assert_eq!(physrange_to_pages(&range), 0);
 
-        let range = PhysRange { start: 4096, end: 8192 };
+        let range = PhysRange {
+            start: 4096,
+            end: 8192,
+        };
         assert_eq!(physrange_to_pages(&range), 2);
     }
 
     #[test]
     fn test_objectrange_to_page_number() {
-        let range = ObjectRange { start: 0, end: 4096 };
+        let range = ObjectRange {
+            start: 0,
+            end: 4096,
+        };
         assert_eq!(objectrange_to_page_number(&range), Some(0));
 
-        let range = ObjectRange { start: 4096, end: 8192 };
+        let range = ObjectRange {
+            start: 4096,
+            end: 8192,
+        };
         assert_eq!(objectrange_to_page_number(&range), Some(1));
 
-        let range = ObjectRange { start: 0, end: 8192 }; // Invalid range for one page
+        let range = ObjectRange {
+            start: 0,
+            end: 8192,
+        }; // Invalid range for one page
         assert_eq!(objectrange_to_page_number(&range), None);
 
-        let range = ObjectRange { start: 8192, end: 12288 };
+        let range = ObjectRange {
+            start: 8192,
+            end: 12288,
+        };
         assert_eq!(objectrange_to_page_number(&range), Some(2));
     }
 }
-

--- a/src/bin/pager/src/main.rs
+++ b/src/bin/pager/src/main.rs
@@ -1,66 +1,70 @@
-use std::{collections::BTreeMap, sync::OnceLock, time::Duration, sync::{Arc, Mutex}};
+use std::{
+    collections::BTreeMap,
+    error::Error,
+    sync::{Arc, Mutex, OnceLock},
+    time::Duration,
+};
 
 use async_executor::{Executor, Task};
 use async_io::Timer;
 use futures::executor::block_on;
 use tickv::{success_codes::SuccessCode, ErrorCode};
-
 use tracing::{debug, info, warn, Level};
 use tracing_subscriber::FmtSubscriber;
-
 use twizzler_abi::pager::{
-    CompletionToKernel, CompletionToPager, KernelCompletionData, RequestFromKernel, KernelCommand,
-    RequestFromPager, PagerCompletionData, PhysRange, ObjectRange
+    CompletionToKernel, CompletionToPager, KernelCommand, KernelCompletionData, ObjectRange,
+    PagerCompletionData, PhysRange, RequestFromKernel, RequestFromPager,
 };
 use twizzler_object::{ObjID, Object, ObjectInitFlags, Protections};
 
-use crate::store::{Key, KeyValueStore};
+use crate::{
+    data::PagerData,
+    helpers::{physrange_to_pages, PAGE},
+    request_handle::handle_kernel_request,
+    store::{Key, KeyValueStore},
+};
 
-use std::error::Error;
-use crate::data::PagerData;
-use crate::helpers::{physrange_to_pages, PAGE};
-use crate::request_handle::{handle_kernel_request};
-
-mod request_handle;
 mod data;
 mod helpers;
 mod nvme;
+mod physrw;
+mod request_handle;
 mod store;
 
 pub static EXECUTOR: OnceLock<Executor> = OnceLock::new();
 
 /***
  * Tracing Init
- ***/
+ */
 fn tracing_init() {
     tracing::subscriber::set_global_default(
         tracing_subscriber::fmt()
             .with_max_level(tracing::Level::INFO)
             .without_time()
             .finish(),
-    ).unwrap();
+    )
+    .unwrap();
 }
 
 /***
  * Pager Data Structures Initialization
- ***/
+ */
 fn data_structure_init() -> PagerData {
-    let pager_data = PagerData::new(); 
-    
+    let pager_data = PagerData::new();
+
     return pager_data;
 }
 
-
 /***
  * Setup data structures and physical memory for use by pager
- ***/
+ */
 fn memory_init(data: PagerData, range: PhysRange) {
     data.init_range(range);
     let pages = physrange_to_pages(&range) as usize;
     data.resize(pages);
 }
 
-/*** 
+/***
  * Queue Initializing
  */
 fn attach_queue<T: std::marker::Copy, U: std::marker::Copy, Q>(
@@ -77,11 +81,12 @@ fn attach_queue<T: std::marker::Copy, U: std::marker::Copy, Q>(
         obj_id,
         Protections::READ | Protections::WRITE,
         ObjectInitFlags::empty(),
-    ).unwrap();
+    )
+    .unwrap();
 
     // Ensure the object is cast or transformed to match the expected `Queue` type
     let queue: twizzler_queue::Queue<T, U> = twizzler_queue::Queue::from(object);
-    
+
     Ok(queue_constructor(queue))
 }
 
@@ -90,20 +95,27 @@ fn queue_args(i: usize) -> String {
 }
 
 fn queue_init() -> (
-    twizzler_queue::CallbackQueueReceiver<RequestFromKernel, CompletionToKernel>, 
-    twizzler_queue::QueueSender<RequestFromPager, CompletionToPager>
-    ) {
-
-    let rq = attach_queue::<RequestFromKernel, CompletionToKernel, _>(&queue_args(1), twizzler_queue::CallbackQueueReceiver::new).unwrap();
-    let sq = attach_queue::<RequestFromPager, CompletionToPager, _>(&queue_args(2), twizzler_queue::QueueSender::new).unwrap();
+    twizzler_queue::CallbackQueueReceiver<RequestFromKernel, CompletionToKernel>,
+    twizzler_queue::QueueSender<RequestFromPager, CompletionToPager>,
+) {
+    let rq = attach_queue::<RequestFromKernel, CompletionToKernel, _>(
+        &queue_args(1),
+        twizzler_queue::CallbackQueueReceiver::new,
+    )
+    .unwrap();
+    let sq = attach_queue::<RequestFromPager, CompletionToPager, _>(
+        &queue_args(2),
+        twizzler_queue::QueueSender::new,
+    )
+    .unwrap();
 
     return (rq, sq);
 }
 
-/*** 
+/***
  * Async Runtime Initialization
  * Creating n threads
- ***/
+ */
 fn async_runtime_init(n: i32) -> &'static Executor<'static> {
     let ex = EXECUTOR.get_or_init(|| Executor::new());
 
@@ -116,27 +128,26 @@ fn async_runtime_init(n: i32) -> &'static Executor<'static> {
 
 /***
  * Health Check
- ***/
+ */
 fn health_check(
-    _rq: &twizzler_queue::CallbackQueueReceiver<RequestFromKernel, CompletionToKernel>, 
+    _rq: &twizzler_queue::CallbackQueueReceiver<RequestFromKernel, CompletionToKernel>,
     sq: &twizzler_queue::QueueSender<RequestFromPager, CompletionToPager>,
     ex: &'static Executor<'static>,
-    timeout_ms: Option<u64>
-    ) -> Result<(), String> {
+    timeout_ms: Option<u64>,
+) -> Result<(), String> {
     let timeout_duration = Duration::from_millis(timeout_ms.unwrap_or(1000) as u64);
 
     tracing::info!("pager health check start...");
-    block_on(ex.run(
-            async move{
-                let timeout = Timer::after(timeout_duration);
-                tracing::info!("submitting request to kernel");
-                
-                let res = sq.submit_and_wait(RequestFromPager::new(
-                        twizzler_abi::pager::PagerRequest::EchoReq,
-                        ));
-                let x = res.await;
-                tracing::info!(" got {:?} in response", x);
-                timeout.await;
+    block_on(ex.run(async move {
+        let timeout = Timer::after(timeout_duration);
+        tracing::info!("submitting request to kernel");
+
+        let res = sq.submit_and_wait(RequestFromPager::new(
+            twizzler_abi::pager::PagerRequest::EchoReq,
+        ));
+        let x = res.await;
+        tracing::info!(" got {:?} in response", x);
+        timeout.await;
     }));
 
     Ok(())
@@ -145,20 +156,19 @@ fn health_check(
 fn verify_health(health: Result<(), String>) {
     match health {
         Ok(()) => tracing::info!("health check successful"),
-        Err(_) => tracing::info!("gealth check failed")
+        Err(_) => tracing::info!("gealth check failed"),
     }
 }
 
 /***
- * Pager Initialization generic function which calls specific initialization functions 
- ***/
+ * Pager Initialization generic function which calls specific initialization functions
+ */
 fn pager_init() -> (
-    twizzler_queue::CallbackQueueReceiver<RequestFromKernel, CompletionToKernel>, 
+    twizzler_queue::CallbackQueueReceiver<RequestFromKernel, CompletionToKernel>,
     twizzler_queue::QueueSender<RequestFromPager, CompletionToPager>,
     PagerData,
-    &'static Executor<'static>
-    ) {
-    
+    &'static Executor<'static>,
+) {
     tracing::info!("init start");
     tracing_init();
     let data = data_structure_init();
@@ -173,48 +183,47 @@ fn pager_init() -> (
     return (rq, sq, data, ex);
 }
 
-
 fn spawn_queues(
-    rq: twizzler_queue::CallbackQueueReceiver<RequestFromKernel, CompletionToKernel>, 
+    rq: twizzler_queue::CallbackQueueReceiver<RequestFromKernel, CompletionToKernel>,
     data: PagerData,
-    ex: &'static Executor<'static>
+    ex: &'static Executor<'static>,
 ) {
     tracing::info!("spawning queues...");
-    ex.spawn(listen_queue(rq, data, handle_kernel_request, ex)).detach();
+    ex.spawn(listen_queue(rq, data, handle_kernel_request, ex))
+        .detach();
 }
 
 async fn listen_queue<R, C, F>(
     q: twizzler_queue::CallbackQueueReceiver<R, C>,
     data: PagerData,
     handler: impl Fn(R, Arc<PagerData>) -> F + Copy + Send + Sync + 'static,
-    ex: &'static Executor<'static>
-    ) 
-    where 
+    ex: &'static Executor<'static>,
+) where
     F: std::future::Future<Output = Option<C>> + Send + 'static,
     R: std::fmt::Debug + Copy + Send + Sync + 'static,
-    C: std::fmt::Debug + Copy + Send + Sync + 'static
-    {
-        tracing::info!("queue receiving...");
-        let q = Arc::new(q);
-        let data = Arc::new(data);
-        loop {
-            let (id, request) = q.receive().await.unwrap(); 
-            tracing::info!("got request: ({},{:?})", id, request);
+    C: std::fmt::Debug + Copy + Send + Sync + 'static,
+{
+    tracing::info!("queue receiving...");
+    let q = Arc::new(q);
+    let data = Arc::new(data);
+    loop {
+        let (id, request) = q.receive().await.unwrap();
+        tracing::info!("got request: ({},{:?})", id, request);
 
-            let qc = Arc::clone(&q);
-            let datac = Arc::clone(&data);
-            ex.spawn(
-                async move {
-                    let comp = handler(request, datac).await;
-                    notify(qc, id, comp).await;
-                }).detach();
-        }
+        let qc = Arc::clone(&q);
+        let datac = Arc::clone(&data);
+        ex.spawn(async move {
+            let comp = handler(request, datac).await;
+            notify(&qc, id, comp).await;
+        })
+        .detach();
+    }
 }
 
-async fn notify<R, C>(q: Arc<twizzler_queue::CallbackQueueReceiver<R, C>>, id: u32, res: Option<C>)
-    where
+async fn notify<R, C>(q: &Arc<twizzler_queue::CallbackQueueReceiver<R, C>>, id: u32, res: Option<C>)
+where
     R: std::fmt::Debug + Copy + Send + Sync,
-    C: std::fmt::Debug + Copy + Send + Sync + 'static
+    C: std::fmt::Debug + Copy + Send + Sync + 'static,
 {
     if let Some(res) = res {
         q.complete(id, res).await.unwrap();
@@ -222,34 +231,38 @@ async fn notify<R, C>(q: Arc<twizzler_queue::CallbackQueueReceiver<R, C>>, id: u
     tracing::info!("request {} complete", id);
 }
 
-async fn send_request<R, C>(q: Arc<twizzler_queue::QueueSender<R, C>>, request: R) -> Result<C, Box<dyn std::error::Error>>
-    where
+async fn send_request<R, C>(
+    q: &Arc<twizzler_queue::QueueSender<R, C>>,
+    request: R,
+) -> Result<C, Box<dyn std::error::Error>>
+where
     R: std::fmt::Debug + Copy + Send + Sync,
-    C: std::fmt::Debug + Copy + Send + Sync + 'static
-
+    C: std::fmt::Debug + Copy + Send + Sync + 'static,
 {
     tracing::info!("submitting request {:?}", request);
-    return q.submit_and_wait(request).await.map_err(|e| Box::new(e) as Box<dyn std::error::Error>);
+    return q
+        .submit_and_wait(request)
+        .await
+        .map_err(|e| Box::new(e) as Box<dyn std::error::Error>);
 }
 
 async fn report_ready(
-    q: Arc<twizzler_queue::QueueSender<RequestFromPager, CompletionToPager>>,
+    q: &Arc<twizzler_queue::QueueSender<RequestFromPager, CompletionToPager>>,
     ex: &'static Executor<'static>,
-) -> Option<PagerCompletionData>{
+) -> Option<PagerCompletionData> {
     tracing::info!("sending ready signal to kernel");
     let request = RequestFromPager::new(twizzler_abi::pager::PagerRequest::Ready);
 
     match send_request(q, request).await {
         Ok(completion) => {
             tracing::info!("received completion for ready signal: {:?}", completion);
-            return Some(completion.data()); 
+            return Some(completion.data());
         }
         Err(e) => {
             tracing::debug!("error from ready signal {:?}", e);
             return None;
         }
     }
-
 }
 
 fn main() {
@@ -259,7 +272,7 @@ fn main() {
     let sqc = Arc::clone(&sq);
 
     let phys_range: Option<PhysRange> = block_on(async move {
-        let res = report_ready(sqc, ex).await;
+        let res = report_ready(&sq, ex).await;
         match res {
             Some(PagerCompletionData::DramPages(range)) => {
                 Some(range) // Return the range
@@ -272,19 +285,55 @@ fn main() {
     });
 
     if let Some(range) = phys_range {
-        tracing::info!("initializing the pager with physical memory range: start: {}, end: {}", range.start, range.end);
+        tracing::info!(
+            "initializing the pager with physical memory range: start: {}, end: {}",
+            range.start,
+            range.end
+        );
         memory_init(data, range);
     } else {
         tracing::info!("cannot complete pager initialization with no physical memory");
     }
 
-
     tracing::info!("Performing Test...");
-    let sqc = Arc::clone(&sq);
+    let sqc2 = sqc.clone();
     block_on(async move {
         let request = RequestFromPager::new(twizzler_abi::pager::PagerRequest::TestReq);
-        let _ = send_request(sqc, request).await.ok();
+        let _ = send_request(&sqc, request).await.ok();
     });
+
+    if let Some(phys_range) = phys_range {
+        std::thread::sleep(Duration::from_secs(3));
+        block_on(async move {
+            let mut buf = vec![0u8; 4096];
+            for (i, b) in (&mut buf).iter_mut().enumerate() {
+                *b = i as u8;
+            }
+            let mut buf2 = vec![0u8; 4096];
+            tracing::info!("testing physrw: {:?}", &buf[0..10]);
+            assert_ne!(buf, buf2);
+            let start = phys_range.start;
+            let phys = PhysRange {
+                start,
+                end: start + buf.len() as u64,
+            };
+            tracing::info!("filling physical pages: {:?} from {:p}", phys, buf.as_ptr());
+            physrw::fill_physical_pages(&sqc2, buf.as_slice(), phys)
+                .await
+                .unwrap();
+
+            tracing::info!(
+                "reading physical pages: {:?} into {:p}",
+                phys,
+                buf2.as_ptr()
+            );
+            physrw::read_physical_pages(&sqc2, buf2.as_mut_slice(), phys)
+                .await
+                .unwrap();
+
+            assert_eq!(buf, buf2);
+        });
+    }
 
     tracing::info!("Test Completed");
     //Done

--- a/src/bin/pager/src/main.rs
+++ b/src/bin/pager/src/main.rs
@@ -1,3 +1,5 @@
+#![feature(ptr_sub_ptr)]
+
 use std::{
     collections::BTreeMap,
     error::Error,

--- a/src/bin/pager/src/physrw.rs
+++ b/src/bin/pager/src/physrw.rs
@@ -1,0 +1,65 @@
+use std::sync::{Arc, OnceLock};
+
+use twizzler_abi::pager::{CompletionToPager, PagerRequest, PhysRange, RequestFromPager};
+use twizzler_object::ObjID;
+use twizzler_queue::QueueSender;
+
+use crate::send_request;
+
+type Queue = QueueSender<RequestFromPager, CompletionToPager>;
+type QueueRef = Arc<Queue>;
+
+static SCTX_ID: OnceLock<ObjID> = OnceLock::new();
+
+fn get_sctx_id() -> ObjID {
+    *SCTX_ID.get_or_init(|| twizzler_abi::syscall::sys_thread_active_sctx_id())
+}
+
+fn get_object(ptr: *const u8) -> (ObjID, usize) {
+    todo!()
+}
+
+async fn do_physrw_request(
+    queue: &QueueRef,
+    target_object: ObjID,
+    offset: usize,
+    len: usize,
+    phys: PhysRange,
+    write_phys: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let request = RequestFromPager::new(PagerRequest::CopyUserPhys {
+        target_object,
+        offset,
+        len,
+        phys,
+        write_phys,
+    });
+    let comp = send_request(queue, request).await?;
+    match comp.data() {
+        twizzler_abi::pager::PagerCompletionData::Okay => Ok(()),
+        _ => Err("invalid pager completion".to_owned().into()),
+    }
+}
+
+/// Writes buf.len() bytes from the buffer into physical addresses specified in phys. If the
+/// supplied physical range is shorter than the buffer, then the remaining bytes in the buffer are
+/// filled with 0.
+pub async fn fill_physical_pages(
+    queue: &QueueRef,
+    buf: &[u8],
+    phys: PhysRange,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let obj = get_object(buf.as_ptr());
+    do_physrw_request(queue, obj.0, obj.1, buf.len(), phys, true).await
+}
+
+/// Reads buf.len() bytes from physical addresses in phys into the buffer. If the supplied physical
+/// range is shorter than the buffer, then the remaining bytes in the buffer are filled with 0.
+pub async fn read_physical_pages(
+    queue: &QueueRef,
+    buf: &mut [u8],
+    phys: PhysRange,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let obj = get_object(buf.as_ptr());
+    do_physrw_request(queue, obj.0, obj.1, buf.len(), phys, false).await
+}

--- a/src/bin/pager/src/physrw.rs
+++ b/src/bin/pager/src/physrw.rs
@@ -1,4 +1,4 @@
-use std::sync::{Arc, OnceLock};
+use std::sync::Arc;
 
 use twizzler_abi::pager::{CompletionToPager, PagerRequest, PhysRange, RequestFromPager};
 use twizzler_object::ObjID;
@@ -9,14 +9,9 @@ use crate::send_request;
 type Queue = QueueSender<RequestFromPager, CompletionToPager>;
 type QueueRef = Arc<Queue>;
 
-static SCTX_ID: OnceLock<ObjID> = OnceLock::new();
-
-fn get_sctx_id() -> ObjID {
-    *SCTX_ID.get_or_init(|| twizzler_abi::syscall::sys_thread_active_sctx_id())
-}
-
 fn get_object(ptr: *const u8) -> (ObjID, usize) {
-    todo!()
+    let handle = twizzler_rt_abi::object::twz_rt_get_object_handle(ptr).unwrap();
+    (handle.id(), unsafe { ptr.sub_ptr(handle.start()) })
 }
 
 async fn do_physrw_request(

--- a/src/bin/pager/src/physrw.rs
+++ b/src/bin/pager/src/physrw.rs
@@ -41,9 +41,9 @@ async fn do_physrw_request(
     }
 }
 
-/// Writes buf.len() bytes from the buffer into physical addresses specified in phys. If the
-/// supplied physical range is shorter than the buffer, then the remaining bytes in the buffer are
-/// filled with 0.
+/// Writes phys.len() bytes from the buffer into physical addresses specified in phys. If the
+/// supplied buffer is shorter than the physical range, then the remaining bytes in the physical
+/// memory are filled with 0.
 pub async fn fill_physical_pages(
     queue: &QueueRef,
     buf: &[u8],

--- a/src/kernel/src/interrupt.rs
+++ b/src/kernel/src/interrupt.rs
@@ -146,8 +146,7 @@ pub fn set_userspace_interrupt_wakeup(number: u32, wi: WakeInfo) {
 pub fn handle_interrupt(number: u32) {
     let gi = get_global_interrupts();
     gi.ints[number as usize].raise();
-    if number != 43 {
-    }
+    if number != 43 {}
 }
 
 const INTQUEUE_LEN: usize = 128;

--- a/src/kernel/src/memory/frame.rs
+++ b/src/kernel/src/memory/frame.rs
@@ -45,6 +45,7 @@ use super::{MemoryRegion, MemoryRegionKind, PhysAddr};
 use crate::{
     arch::memory::{frame::FRAME_SIZE, phys_to_virt},
     once::Once,
+    pager::pager_select_memory_regions,
     spinlock::Spinlock,
 };
 
@@ -519,7 +520,8 @@ static FI: Once<Vec<FrameIndexer>> = Once::new();
 /// # Arguments
 ///  * `regions`: An array of memory regions passed from the boot info system.
 pub fn init(regions: &[MemoryRegion]) {
-    let pfa = PhysicalFrameAllocator::new(regions);
+    let regions = pager_select_memory_regions(regions);
+    let pfa = PhysicalFrameAllocator::new(&regions);
     FI.call_once(|| pfa.regions.iter().map(|r| r.indexer.clone()).collect());
     PFA.call_once(|| Spinlock::new(pfa));
 }

--- a/src/kernel/src/memory/mod.rs
+++ b/src/kernel/src/memory/mod.rs
@@ -18,6 +18,7 @@ pub enum MemoryRegionKind {
     BootloaderReserved,
 }
 
+#[derive(Debug, Clone, Copy)]
 pub struct MemoryRegion {
     pub start: PhysAddr,
     pub length: usize,

--- a/src/kernel/src/pager/queues.rs
+++ b/src/kernel/src/pager/queues.rs
@@ -1,17 +1,25 @@
 use twizzler_abi::{
-    object::ObjID,
+    device::CacheType,
+    object::{ObjID, Protections},
     pager::{
-        CompletionToKernel, CompletionToPager, KernelCommand, RequestFromKernel, RequestFromPager, PagerRequest, PhysRange, ObjectRange
+        CompletionToKernel, CompletionToPager, KernelCommand, ObjectRange, PagerCompletionData,
+        PagerRequest, PhysRange, RequestFromKernel, RequestFromPager,
     },
 };
 
 use super::request::ReqKind;
 use crate::{
+    arch::{PhysAddr, VirtAddr},
     idcounter::{IdCounter, SimpleId},
+    memory::context::{kernel_context, KernelMemoryContext, ObjectContextInfo},
     obj::{lookup_object, LookupFlags},
     once::Once,
+    pager::PAGER_MEMORY,
     queue::{ManagedQueueReceiver, ManagedQueueSender, QueueObject},
-    thread::{entry::start_new_kernel, priority::Priority},
+    syscall::object::sys_sctx_attach,
+    thread::{
+        current_memory_context, current_thread_ref, entry::start_new_kernel, priority::Priority,
+    },
 };
 
 static SENDER: Once<(
@@ -20,33 +28,96 @@ static SENDER: Once<(
 )> = Once::new();
 static RECEIVER: Once<ManagedQueueReceiver<RequestFromPager, CompletionToPager>> = Once::new();
 
+fn pager_request_copy_user_phys(
+    target_object: ObjID,
+    offset: usize,
+    len: usize,
+    phys: PhysRange,
+    write_phys: bool,
+) -> CompletionToPager {
+    let Ok(phys_start) = PhysAddr::new(phys.start) else {
+        return CompletionToPager::new(PagerCompletionData::Error);
+    };
+
+    logln!("lookup {}", target_object);
+    let Ok(object) = lookup_object(target_object, LookupFlags::empty()).ok_or(()) else {
+        return CompletionToPager::new(PagerCompletionData::Error);
+    };
+    logln!("found object! {}", object.id());
+    let ko = kernel_context().insert_kernel_object::<()>(ObjectContextInfo::new(
+        object,
+        Protections::READ | Protections::WRITE,
+        CacheType::WriteBack,
+    ));
+    let Ok(vaddr) = ko.start_addr().offset(offset) else {
+        return CompletionToPager::new(PagerCompletionData::Error);
+    };
+
+    let vphys = phys_start.kernel_vaddr();
+    let user_slice = unsafe { core::slice::from_raw_parts_mut(vaddr.as_mut_ptr(), len) };
+    let phys_slice =
+        unsafe { core::slice::from_raw_parts_mut(vphys.as_mut_ptr::<u8>(), phys.len()) };
+
+    let copy_len = core::cmp::min(user_slice.len(), phys_slice.len());
+    let (target_slice, source_slice) = if write_phys {
+        (phys_slice, user_slice)
+    } else {
+        (user_slice, phys_slice)
+    };
+    target_slice[0..copy_len].copy_from_slice(&source_slice[0..copy_len]);
+    target_slice[copy_len..].fill(0);
+
+    CompletionToPager::new(PagerCompletionData::Okay)
+}
+
+fn pager_test_request() -> CompletionToPager {
+    let sender = SENDER.wait();
+    let obj_id = ObjID::new(1001);
+    logln!("kernel: submitting page data request on K2P Queue");
+    let item = RequestFromKernel::new(twizzler_abi::pager::KernelCommand::PageDataReq(
+        obj_id,
+        ObjectRange {
+            start: 0,
+            end: 4096,
+        },
+    ));
+    let id = sender.0.next_simple().value() as u32;
+    let res = SENDER.wait().1.submit(item, id);
+
+    logln!("kernel: submitting obj info request on K2P Queue");
+    let item = RequestFromKernel::new(twizzler_abi::pager::KernelCommand::ObjectInfoReq(obj_id));
+    let id = sender.0.next_simple().value() as u32;
+    let res = SENDER.wait().1.submit(item, id);
+
+    return CompletionToPager::new(twizzler_abi::pager::PagerCompletionData::TestResp);
+}
+
 pub(super) fn pager_request_handler_main() {
     let receiver = RECEIVER.wait();
     loop {
         receiver.handle_request(|id, req| {
             logln!("kernel: got req {}:{:?} from pager", id, req);
-            if req.cmd() == twizzler_abi::pager::PagerRequest::Ready {
-                return CompletionToPager::new(twizzler_abi::pager::PagerCompletionData::DramPages(PhysRange::new(0x0000, 0x3E7FFF)))
-            } else if req.cmd() == twizzler_abi::pager::PagerRequest::TestReq {
-                let sender = SENDER.wait();
-                let obj_id = ObjID::new(1001);
-                logln!("kernel: submitting page data request on K2P Queue");
-                let item = RequestFromKernel::new(
-                    twizzler_abi::pager::KernelCommand::PageDataReq(obj_id, ObjectRange{ start: 0, end: 4096}),
-                );
-                let id = sender.0.next_simple().value() as u32;
-                let res = SENDER.wait().1.submit(item, id);
-
-                logln!("kernel: submitting obj info request on K2P Queue");
-                let item = RequestFromKernel::new(
-                    twizzler_abi::pager::KernelCommand::ObjectInfoReq(obj_id),
-                );
-                let id = sender.0.next_simple().value() as u32;
-                let res = SENDER.wait().1.submit(item, id);
- 
-                return CompletionToPager::new(twizzler_abi::pager::PagerCompletionData::TestResp)
-            } else {
-                return CompletionToPager::new(twizzler_abi::pager::PagerCompletionData::EchoResp)
+            match req.cmd() {
+                PagerRequest::EchoReq => {
+                    CompletionToPager::new(twizzler_abi::pager::PagerCompletionData::EchoResp)
+                }
+                PagerRequest::TestReq => pager_test_request(),
+                PagerRequest::Ready => {
+                    let reg = PAGER_MEMORY
+                        .poll()
+                        .map(|pm| (pm.start.raw(), pm.length))
+                        .unwrap_or((0, 0));
+                    CompletionToPager::new(twizzler_abi::pager::PagerCompletionData::DramPages(
+                        PhysRange::new(reg.0, reg.0 + reg.1 as u64),
+                    ))
+                }
+                PagerRequest::CopyUserPhys {
+                    target_object,
+                    offset,
+                    len,
+                    phys,
+                    write_phys,
+                } => pager_request_copy_user_phys(target_object, offset, len, phys, write_phys),
             }
         });
     }

--- a/src/kernel/src/pager/queues.rs
+++ b/src/kernel/src/pager/queues.rs
@@ -39,11 +39,9 @@ fn pager_request_copy_user_phys(
         return CompletionToPager::new(PagerCompletionData::Error);
     };
 
-    logln!("lookup {}", target_object);
     let Ok(object) = lookup_object(target_object, LookupFlags::empty()).ok_or(()) else {
         return CompletionToPager::new(PagerCompletionData::Error);
     };
-    logln!("found object! {}", object.id());
     let ko = kernel_context().insert_kernel_object::<()>(ObjectContextInfo::new(
         object,
         Protections::READ | Protections::WRITE,

--- a/src/kernel/src/random/cpu_trng/mod.rs
+++ b/src/kernel/src/random/cpu_trng/mod.rs
@@ -5,6 +5,7 @@ use rdrand::RdSeed;
 mod rndrs;
 #[cfg(any(target_arch = "aarch64", target_arch = "arm"))]
 use rand_core::RngCore;
+
 #[cfg(any(target_arch = "aarch64", target_arch = "arm"))]
 use self::rndrs::Rndrs;
 use super::{register_entropy_source, EntropySource};

--- a/src/lib/twizzler-abi/src/pager.rs
+++ b/src/lib/twizzler-abi/src/pager.rs
@@ -1,4 +1,4 @@
-use twizzler_rt_abi::object::{ObjID};
+use twizzler_rt_abi::object::ObjID;
 
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Ord, Eq)]
 pub struct RequestFromKernel {
@@ -41,7 +41,7 @@ impl CompletionToKernel {
 pub enum KernelCompletionData {
     EchoResp,
     PageDataCompletion(PhysRange),
-    ObjectInfoCompletion(ObjectInfo)
+    ObjectInfoCompletion(ObjectInfo),
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Ord, Eq)]
@@ -64,6 +64,13 @@ pub enum PagerRequest {
     EchoReq,
     TestReq,
     Ready,
+    CopyUserPhys {
+        target_object: ObjID,
+        offset: usize,
+        len: usize,
+        phys: PhysRange,
+        write_phys: bool,
+    },
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Ord, Eq)]
@@ -83,6 +90,8 @@ impl CompletionToPager {
 
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Ord, Eq)]
 pub enum PagerCompletionData {
+    Okay,
+    Error,
     EchoResp,
     TestResp,
     DramPages(PhysRange),
@@ -90,12 +99,12 @@ pub enum PagerCompletionData {
 
 pub struct PageDataReq {
     objID: ObjID,
-    object_range: ObjectRange
+    object_range: ObjectRange,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Ord, Eq)]
 pub struct ObjectInfo {
-    pub obj_id: ObjID
+    pub obj_id: ObjID,
 }
 
 impl ObjectInfo {
@@ -120,6 +129,10 @@ impl PhysRange {
     pub fn new(start: u64, end: u64) -> Self {
         Self { start, end }
     }
+
+    pub fn len(&self) -> usize {
+        (self.end - self.start) as usize
+    }
 }
 
 impl ObjectRange {
@@ -127,4 +140,3 @@ impl ObjectRange {
         Self { start, end }
     }
 }
-

--- a/src/lib/twizzler-driver/src/bus/pcie.rs
+++ b/src/lib/twizzler-driver/src/bus/pcie.rs
@@ -75,7 +75,8 @@ pub enum PcieCapability<'a> {
     Unknown(u8),
     Msi(VolatileRef<'a, MsiCapability>),
     MsiX(VolatileRef<'a, MsixCapability>),
-    VendorSpecific(usize), //Offset to the capability, as vendor specific capabilities do not have a consistent definition.
+    VendorSpecific(usize), /* Offset to the capability, as vendor specific capabilities do not
+                            * have a consistent definition. */
 }
 
 impl<'a> Iterator for PcieCapabilityIterator<'a> {
@@ -111,7 +112,10 @@ fn calc_msg_info(vec: InterruptVector, level: bool) -> (u64, u32) {
 }
 
 impl Device {
-    pub fn pcie_capabilities<'a>(&'a self, mm: &'a MmioObject) -> Option<PcieCapabilityIterator<'a>> {
+    pub fn pcie_capabilities<'a>(
+        &'a self,
+        mm: &'a MmioObject,
+    ) -> Option<PcieCapabilityIterator<'a>> {
         let cfg = unsafe { mm.get_mmio_offset::<PcieDeviceHeader>(0) };
         let cfg = cfg.as_ptr();
         let ptr = map_field!(cfg.cap_ptr).read() & 0xfc;

--- a/src/lib/virtio-net/src/hal.rs
+++ b/src/lib/virtio-net/src/hal.rs
@@ -128,7 +128,7 @@ unsafe impl Hal for TestHal {
         assert!(buf_len <= DMA_PAGE_SIZE, "Hal::Share(): Buffer too large");
         let (phys, virt) = TestHal::dma_alloc(1, direction);
         let slice = remove_alloced(phys).unwrap().into_inner();
-        
+
         let buf_casted = buffer.cast::<u8>();
         let buf = buf_casted.as_ptr();
         let dma_buf = virt.as_ptr();

--- a/src/rt/minimal/src/runtime/syms.rs
+++ b/src/rt/minimal/src/runtime/syms.rs
@@ -536,7 +536,6 @@ pub unsafe extern "C-unwind" fn twz_rt_get_random(
     len: usize,
     flags: get_random_flags,
 ) -> usize {
-
     OUR_RUNTIME.get_random(
         unsafe { core::slice::from_raw_parts_mut(buf.cast(), len) },
         flags.into(),

--- a/src/rt/reference/src/runtime/alloc.rs
+++ b/src/rt/reference/src/runtime/alloc.rs
@@ -62,6 +62,21 @@ pub struct LocalAllocator {
     bootstrap_alloc_slot: AtomicUsize,
 }
 
+impl LocalAllocator {
+    pub fn get_id_from_ptr(&self, ptr: *const u8) -> Option<ObjID> {
+        let slot = ptr as usize / MAX_SIZE;
+        let inner = self.inner.lock().ok()?;
+        let inner = inner.as_ref()?;
+        inner.talc.oom_handler.objects.iter().find_map(|info| {
+            if info.0 == slot {
+                Some(info.1)
+            } else {
+                None
+            }
+        })
+    }
+}
+
 struct LocalAllocatorInner {
     talc: Talc<RuntimeOom>,
 }

--- a/src/rt/reference/src/runtime/object/handlecache.rs
+++ b/src/rt/reference/src/runtime/object/handlecache.rs
@@ -58,6 +58,7 @@ impl HandleCache {
     /// Activate, using a slot as key.
     pub fn activate_from_ptr(&mut self, ptr: *const u8) -> Option<object_handle> {
         let slot = (ptr as usize) / MAX_SIZE;
+        trace!("activate-from-ptr: {:p} (slot = {})", ptr, slot);
         let map = self.slotmap.get(&slot)?;
         self.activate(*map)
     }

--- a/tools/xtask/src/qemu.rs
+++ b/tools/xtask/src/qemu.rs
@@ -67,7 +67,9 @@ impl QemuCommand {
             .arg("nvme,serial=deadbeef,drive=nvme");
 
         self.cmd.arg("-device").arg("virtio-net-pci,netdev=net0");
-        self.cmd.arg("-netdev").arg("user,id=net0,hostfwd=tcp::5555-:5555");
+        self.cmd
+            .arg("-netdev")
+            .arg("user,id=net0,hostfwd=tcp::5555-:5555");
 
         self.cmd
             .arg("--no-reboot") // exit instead of rebooting


### PR DESCRIPTION
This PR:

- Adds support for the kernel to fill pages at the pager's request (this is for testing purposes, and will be replaced)
- Adds object store (from @zphrs)
- Runs cargo-fmt

