### PR TITLE
Generate object IDs using entropy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3624,7 +3624,6 @@ dependencies = [
 name = "naming-srv"
 version = "0.1.0"
 dependencies = [
- "arrayvec",
  "lazy_static",
  "secgate",
  "twizzler-abi",

--- a/src/kernel/src/device.rs
+++ b/src/kernel/src/device.rs
@@ -61,7 +61,7 @@ static KSO_MANAGER: Once<KsoManager> = Once::new();
 
 fn get_kso_manager() -> &'static KsoManager {
     KSO_MANAGER.call_once(|| {
-        let root = Arc::new(crate::obj::Object::new());
+        let root = Arc::new(crate::obj::Object::new_kernel());
         crate::obj::register_object(root.clone());
         KsoManager {
             root,
@@ -171,7 +171,7 @@ pub fn create_busroot(
     bt: BusType,
     kaction: fn(DeviceRef, cmd: u32, arg: u64, arg2: u64) -> Result<KactionValue, KactionError>,
 ) -> DeviceRef {
-    let obj = Arc::new(crate::obj::Object::new());
+    let obj = Arc::new(crate::obj::Object::new_kernel());
     crate::obj::register_object(obj.clone());
     let device = Arc::new(Device {
         inner: Mutex::new(DeviceInner {
@@ -199,7 +199,7 @@ pub fn create_device(
     id: DeviceId,
     kaction: fn(DeviceRef, cmd: u32, arg: u64, arg: u64) -> Result<KactionValue, KactionError>,
 ) -> DeviceRef {
-    let obj = Arc::new(crate::obj::Object::new());
+    let obj = Arc::new(crate::obj::Object::new_kernel());
     crate::obj::register_object(obj.clone());
     let device = Arc::new(Device {
         inner: Mutex::new(DeviceInner {
@@ -236,7 +236,7 @@ impl Device {
     }
 
     pub fn add_info<T>(&self, info: &T) {
-        let obj = Arc::new(crate::obj::Object::new());
+        let obj = Arc::new(crate::obj::Object::new_kernel());
         obj.write_base(info);
         crate::obj::register_object(obj.clone());
         self.inner
@@ -246,7 +246,7 @@ impl Device {
     }
 
     pub fn add_mmio(&self, start: PhysAddr, end: PhysAddr, ct: CacheType, info: u64) {
-        let obj = Arc::new(crate::obj::Object::new());
+        let obj = Arc::new(crate::obj::Object::new_kernel());
         obj.map_phys(start, end, ct);
         let mmio_info = MmioInfo {
             length: (end - start) as u64,

--- a/src/kernel/src/initrd.rs
+++ b/src/kernel/src/initrd.rs
@@ -43,7 +43,7 @@ pub fn init(modules: &[BootModule]) {
         );
         let mut total_alloc = 0;
         for e in tar.entries() {
-            let obj = obj::Object::new();
+            let obj = obj::Object::new_kernel();
             logln!(
                 "[kernel::initrd]  loading {:?} -> {:x}",
                 e.filename(),

--- a/src/kernel/src/memory/context/virtmem.rs
+++ b/src/kernel/src/memory/context/virtmem.rs
@@ -809,7 +809,7 @@ mod test {
 
     #[kernel_test]
     fn test_kernel_object() {
-        let obj = crate::obj::Object::new();
+        let obj = crate::obj::Object::new_kernel();
         let obj = Arc::new(obj);
         crate::obj::register_object(obj.clone());
 

--- a/src/kernel/src/random/mod.rs
+++ b/src/kernel/src/random/mod.rs
@@ -12,7 +12,6 @@ use jitter::maybe_add_jitter_entropy_source;
 use crate::{
     mutex::{LockGuard, Mutex},
     once::Once,
-    syscall::sync::sys_thread_sync,
     thread::{entry::run_closure_in_new_thread, priority::Priority},
 };
 
@@ -31,14 +30,12 @@ struct EntropySources {
 
 impl EntropySources {
     pub fn new() -> Self {
-        logln!("Created new entropy sources list");
         Self {
             sources: Vec::new(),
         }
     }
 
     pub fn has_sources(&self) -> bool {
-        logln!("source count: {}", self.source_count());
         self.source_count() != 0
     }
 
@@ -49,9 +46,7 @@ impl EntropySources {
         &mut self,
     ) -> Result<(), ()> {
         let source = Source::try_new()?;
-        logln!("pushing source!");
         self.sources.push((Box::new(source), Contributor::new()));
-        logln!("Sources count: {}", self.source_count());
         Ok(())
     }
 
@@ -70,7 +65,6 @@ impl EntropySources {
                 }
             }
         }
-        // logln!("contributed entropy to pool");
     }
 }
 
@@ -78,7 +72,7 @@ static ACCUMULATOR: Once<Mutex<Accumulator>> = Once::new();
 static ENTROPY_SOURCES: Once<Mutex<EntropySources>> = Once::new();
 
 /// Generates randomness and fills the out buffer with entropy.
-///  
+///
 /// Will optionally block while waiting for entropy events.
 ///
 /// Returns whether or not it successfully filled the out buffer with entropy
@@ -91,14 +85,12 @@ pub fn getrandom(out: &mut [u8], nonblocking: bool) -> bool {
     if let Ok(()) = res {
         return true;
     }
-    logln!("need to seed accumulator");
     // try_fill_random_data only fails if unseeded
     // so the rest is trying to seed it/wait for it to be seeded
     let mut entropy_sources = ENTROPY_SOURCES
         .call_once(|| Mutex::new(EntropySources::new()))
         .lock();
     if entropy_sources.has_sources() {
-        logln!("has sources");
         entropy_sources.contribute_entropy(acc.borrow_mut());
         acc.try_fill_random_data(out)
             .expect("Should be seeded now & therefore shouldn't return an error");
@@ -110,12 +102,12 @@ pub fn getrandom(out: &mut [u8], nonblocking: bool) -> bool {
         // doesn't block, returns false instead
         false
     } else {
+        // TODO: block on a condvar or something.
         // otherwise schedule and recurse in again after this thread gets picked up again
         // this way it allows other work to get done, work that might result in entropy events
 
         // block for 2 seconds and hope for other entropy-generating work to get done in the
         // meantime
-        logln!("recursing");
         // sys_thread_sync(&mut [], Some(&mut Duration::from_secs(2))).expect(
         //     "shouldn't panic because sys_thread_sync doesn't panic if no ops are passed in",
         // );
@@ -184,13 +176,8 @@ mod test {
     #[kernel_test]
     fn test_rand_gen() {
         let registered_jitter_entropy = maybe_add_jitter_entropy_source();
-        let mut into = [0u8; 1024];
         logln!("jitter entropy registered: {}", registered_jitter_entropy);
-
-        getrandom(&mut into, false);
-        for byte in into {
-            logln!("{}", byte);
-        }
-        // logln!("Into: {:?}", into)
+        let mut into = [0u8; 1024];
+        assert_eq!(getrandom(&mut into, false), true);
     }
 }

--- a/src/kernel/src/time.rs
+++ b/src/kernel/src/time.rs
@@ -4,6 +4,7 @@ use twizzler_abi::syscall::{ClockInfo, FemtoSeconds};
 
 use crate::spinlock::Spinlock;
 
+#[derive(Default, Debug, Clone, Copy)]
 pub struct Ticks {
     pub value: u64,
     pub rate: FemtoSeconds,

--- a/src/kernel/src/userinit.rs
+++ b/src/kernel/src/userinit.rs
@@ -16,7 +16,7 @@ use crate::{
 };
 
 pub fn create_blank_object() -> ObjectRef {
-    let obj = crate::obj::Object::new();
+    let obj = crate::obj::Object::new_kernel();
     let obj = Arc::new(obj);
     crate::obj::register_object(obj.clone());
     obj

--- a/src/lib/twizzler-abi/src/meta.rs
+++ b/src/lib/twizzler-abi/src/meta.rs
@@ -6,12 +6,12 @@ use crate::{
 };
 
 /// Flags for objects.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Ord, Eq, Hash, Default)]
 #[repr(transparent)]
 pub struct MetaFlags(u32);
 
 /// A nonce for avoiding object ID collision.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Ord, Eq, Hash, Default)]
 #[repr(transparent)]
 pub struct Nonce(u128);
 

--- a/src/lib/twizzler-abi/src/syscall/create.rs
+++ b/src/lib/twizzler-abi/src/syscall/create.rs
@@ -83,10 +83,10 @@ bitflags! {
 #[repr(C)]
 /// Full object creation specification, minus ties.
 pub struct ObjectCreate {
-    kuid: ObjID,
-    bt: BackingType,
-    lt: LifetimeType,
-    flags: ObjectCreateFlags,
+    pub kuid: ObjID,
+    pub bt: BackingType,
+    pub lt: LifetimeType,
+    pub flags: ObjectCreateFlags,
 }
 impl ObjectCreate {
     /// Build a new object create specification.
@@ -110,8 +110,8 @@ impl ObjectCreate {
 /// A specification of ties to create.
 /// (see [the book](https://twizzler-operating-system.github.io/nightly/book/object_lifetime.html) for more information on ties).
 pub struct CreateTieSpec {
-    id: ObjID,
-    flags: CreateTieFlags,
+    pub id: ObjID,
+    pub flags: CreateTieFlags,
 }
 
 impl CreateTieSpec {

--- a/src/lib/twizzler-abi/src/syscall/time/units.rs
+++ b/src/lib/twizzler-abi/src/syscall/time/units.rs
@@ -48,7 +48,7 @@ pub struct NanoSeconds(pub u64);
 #[repr(transparent)]
 pub struct PicoSeconds(pub u64);
 
-#[derive(Clone, Copy, Debug, PartialEq)]
+#[derive(Clone, Copy, Debug, PartialEq, Default)]
 #[repr(transparent)]
 pub struct FemtoSeconds(pub u64);
 


### PR DESCRIPTION
This PR sets the object ID generation method to be the intended Twizzler method (hash of object metadata, some metadata derived from entropy). It also removes a number of logging messages and fixes a couple panics.