### PR TITLE
Add dynamic gates for pager in runtime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3263,7 +3263,6 @@ dependencies = [
  "async-io",
  "futures",
  "monitor-api",
- "pager",
  "polling",
  "rprompt",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3891,6 +3891,7 @@ version = "0.1.0"
 dependencies = [
  "ctor",
  "monitor",
+ "monitor-api",
  "montest-lib",
  "secgate",
  "tracing",

--- a/src/bin/init/Cargo.toml
+++ b/src/bin/init/Cargo.toml
@@ -19,4 +19,3 @@ polling = "3.6.0"
 futures = "*"
 twizzler-futures = { path = "../../lib/twizzler-futures" }
 monitor-api = { path = "../../rt/monitor-api" }
-pager = { path = "../../lib/pager" }

--- a/src/bin/init/src/main.rs
+++ b/src/bin/init/src/main.rs
@@ -29,7 +29,22 @@ fn initialize_pager() {
     )
     .unwrap();
 
-    pager::pager_start(queue.object().id(), queue2.object().id());
+    let pager_comp: CompartmentHandle = monitor_api::CompartmentLoader::new(
+        "pager-srv",
+        "libpager_srv.so",
+        monitor_api::NewCompartmentFlags::EXPORT_GATES,
+    )
+    .args(["pager-srv"])
+    .load()
+    .expect("failed to start pager");
+
+    let pager_start = unsafe {
+        pager_comp
+            .dynamic_gate::<(ObjID, ObjID), ()>("pager_start")
+            .unwrap()
+    };
+    pager_start(queue.object().id(), queue2.object().id());
+    std::mem::forget(pager_comp);
 }
 
 fn main() {

--- a/src/kernel/src/main.rs
+++ b/src/kernel/src/main.rs
@@ -174,6 +174,9 @@ pub fn idle_main() -> ! {
         current_processor().id
     );
     loop {
+        {
+            current_processor().cleanup_exited();
+        }
         sched::schedule(true);
         arch::processor::halt_and_wait();
     }

--- a/src/kernel/src/sched.rs
+++ b/src/kernel/src/sched.rs
@@ -486,7 +486,7 @@ pub fn schedule_stattick(dt: Nanoseconds) {
     let cp = current_processor();
     let cur = current_thread_ref();
     if let Some(ref cur) = cur {
-        if !cur.is_critical() && (cur.is_in_user() || cur.is_idle_thread()) {
+        if !cur.is_critical() && cur.is_in_user() {
             cp.cleanup_exited();
         }
         if cur.is_idle_thread() {

--- a/src/lib/secgate/src/lib.rs
+++ b/src/lib/secgate/src/lib.rs
@@ -297,6 +297,26 @@ pub struct DynamicSecGate<'comp, A, R> {
     _pd: PhantomData<&'comp (A, R)>,
 }
 
+impl<'a, A: Tuple + Crossing + Copy, R: Crossing + Copy> Fn<A> for DynamicSecGate<'a, A, R> {
+    extern "rust-call" fn call(&self, args: A) -> Self::Output {
+        unsafe { dynamic_gate_call(*self, args) }
+    }
+}
+
+impl<'a, A: Tuple + Crossing + Copy, R: Crossing + Copy> FnMut<A> for DynamicSecGate<'a, A, R> {
+    extern "rust-call" fn call_mut(&mut self, args: A) -> Self::Output {
+        unsafe { dynamic_gate_call(*self, args) }
+    }
+}
+
+impl<'a, A: Tuple + Crossing + Copy, R: Crossing + Copy> FnOnce<A> for DynamicSecGate<'a, A, R> {
+    type Output = SecGateReturn<R>;
+
+    extern "rust-call" fn call_once(self, args: A) -> Self::Output {
+        unsafe { dynamic_gate_call(self, args) }
+    }
+}
+
 impl<'a, A, R> Debug for DynamicSecGate<'a, A, R> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(

--- a/src/lib/secgate/src/lib.rs
+++ b/src/lib/secgate/src/lib.rs
@@ -8,7 +8,11 @@
 #![feature(maybe_uninit_as_bytes)]
 
 use core::ffi::CStr;
-use std::{cell::UnsafeCell, marker::Tuple, mem::MaybeUninit};
+use std::{
+    cell::UnsafeCell,
+    marker::{PhantomData, Tuple},
+    mem::MaybeUninit,
+};
 
 pub use secgate_macros::*;
 use twizzler_abi::object::ObjID;
@@ -284,4 +288,44 @@ pub fn restore_frame(frame: SecFrame) {
     if frame.tp != 0 {
         twizzler_abi::syscall::sys_thread_settls(frame.tp as u64);
     }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub struct DynamicSecGate<'comp, A, R> {
+    address: usize,
+    _pd: PhantomData<&'comp (A, R)>,
+}
+
+impl<'comp, A, R> DynamicSecGate<'comp, A, R> {
+    pub unsafe fn new(address: usize) -> Self {
+        Self {
+            address,
+            _pd: PhantomData,
+        }
+    }
+}
+
+pub unsafe fn dynamic_gate_call<A: Tuple + Crossing + Copy, R: Crossing + Copy>(
+    target: DynamicSecGate<A, R>,
+    args: A,
+) -> SecGateReturn<R> {
+    let frame = frame();
+    // Allocate stack space for args + ret. Args::with_alloca also inits the memory.
+    let ret = GateCallInfo::with_alloca(get_thread_id(), get_sctx_id(), |info| {
+        Arguments::<A>::with_alloca(args, |args| {
+            Return::<R>::with_alloca(|ret| {
+                // Call the trampoline in the mod.
+                unsafe {
+                        //#mod_name::#trampoline_name_without_prefix(info as *const _, args as *const _, ret as *mut _);
+                        #[cfg(target_arch = "x86_64")]
+                        core::arch::asm!("jmp {target}", target = in(reg) target.address, in("rdx") info as *const _, in("rcx") args as *const _, in("rdi") ret as *mut _);
+                        #[cfg(not(target_arch = "x86_64"))]
+                        todo!()
+                    }
+                ret.into_inner()
+            })
+        })
+    });
+    restore_frame(frame);
+    ret
 }

--- a/src/rt/monitor-api/src/lib.rs
+++ b/src/rt/monitor-api/src/lib.rs
@@ -478,6 +478,18 @@ impl CompartmentHandle {
         Self { desc: None }
     }
 
+    /// Lookup a compartment by name.
+    pub fn lookup(name: impl AsRef<str>) -> Option<Self> {
+        let name_len = lazy_sb::write_bytes_to_sb(name.as_ref().as_bytes());
+        Some(Self {
+            desc: Some(
+                gates::monitor_rt_lookup_compartment(name_len)
+                    .ok()
+                    .flatten()?,
+            ),
+        })
+    }
+
     /// Get an iterator over this compartment's dependencies.
     pub fn deps(&self) -> CompartmentDepsIter {
         CompartmentDepsIter::new(self)

--- a/src/rt/monitor/secapi/gates.rs
+++ b/src/rt/monitor/secapi/gates.rs
@@ -164,6 +164,20 @@ pub fn monitor_rt_get_compartment_deps(
     monitor.get_compartment_deps(caller, desc, dep_n)
 }
 
+#[cfg_attr(feature = "secgate-impl", secgate::secure_gate(options(info)))]
+#[cfg_attr(
+    not(feature = "secgate-impl"),
+    secgate::secure_gate(options(info, api))
+)]
+pub fn monitor_rt_lookup_compartment(
+    info: &secgate::GateCallInfo,
+    name_len: usize,
+) -> Option<Descriptor> {
+    let monitor = crate::mon::get_monitor();
+    let caller = info.source_context().unwrap_or(MONITOR_INSTANCE_ID);
+    monitor.lookup_compartment(caller, info.thread_id(), name_len)
+}
+
 // Safety: the broken part is just DlPhdrInfo. We ensure that any pointers in there are
 // intra-compartment.
 unsafe impl Crossing for LibraryInfo {}

--- a/src/rt/monitor/secapi/gates.rs
+++ b/src/rt/monitor/secapi/gates.rs
@@ -139,6 +139,21 @@ pub fn monitor_rt_get_compartment_info(
     not(feature = "secgate-impl"),
     secgate::secure_gate(options(info, api))
 )]
+pub fn monitor_rt_compartment_dynamic_gate(
+    info: &secgate::GateCallInfo,
+    desc: Option<Descriptor>,
+    name_len: usize,
+) -> Option<usize> {
+    let monitor = crate::mon::get_monitor();
+    let caller = info.source_context().unwrap_or(MONITOR_INSTANCE_ID);
+    monitor.get_compartment_gate_address(caller, info.thread_id(), desc, name_len)
+}
+
+#[cfg_attr(feature = "secgate-impl", secgate::secure_gate(options(info)))]
+#[cfg_attr(
+    not(feature = "secgate-impl"),
+    secgate::secure_gate(options(info, api))
+)]
 pub fn monitor_rt_get_compartment_deps(
     info: &secgate::GateCallInfo,
     desc: Option<Descriptor>,

--- a/src/rt/monitor/src/main.rs
+++ b/src/rt/monitor/src/main.rs
@@ -112,19 +112,8 @@ fn monitor_init() -> miette::Result<()> {
             tracing::error!("failed to start monitor tests: {}", ki_name.name());
         }
     }
-    info!("monitor early init completed, starting pager");
 
-    let pager_comp = monitor_api::CompartmentLoader::new(
-        "pager-srv",
-        "libpager_srv.so",
-        monitor_api::NewCompartmentFlags::EXPORT_GATES,
-    )
-    .args(["pager-srv"])
-    .load()
-    .expect("failed to start pager");
-    std::mem::forget(pager_comp);
-
-    info!("starting init");
+    info!("monitor early init completed, starting init");
     let comp: CompartmentHandle =
         CompartmentLoader::new("init", "init", NewCompartmentFlags::empty())
             .args(&["init"])

--- a/src/rt/monitor/src/main.rs
+++ b/src/rt/monitor/src/main.rs
@@ -101,7 +101,7 @@ fn monitor_init() -> miette::Result<()> {
             // Load and wait for tests to complete
             let comp: CompartmentHandle =
                 CompartmentLoader::new("montest", test_name, NewCompartmentFlags::empty())
-                    .args(&["montest"])
+                    .args(&["montest", "--test-threads=1"])
                     .load()
                     .into_diagnostic()?;
             let mut flags = comp.info().flags;

--- a/src/rt/monitor/src/mon/mod.rs
+++ b/src/rt/monitor/src/mon/mod.rs
@@ -9,7 +9,7 @@ use happylock::{LockCollection, RwLock, ThreadKey};
 use monitor_api::{RuntimeThreadControl, SharedCompConfig, TlsTemplateInfo, MONITOR_INSTANCE_ID};
 use secgate::util::HandleMgr;
 use thread::DEFAULT_STACK_SIZE;
-use twizzler_abi::{syscall::sys_thread_exit, upcall::UpcallFrame};
+use twizzler_abi::{klog_println, syscall::sys_thread_exit, upcall::UpcallFrame};
 use twizzler_rt_abi::{
     object::{MapError, MapFlags, ObjID},
     thread::{SpawnError, ThreadSpawnArgs},

--- a/src/rt/monitor/tests/montest-lib/src/lib.rs
+++ b/src/rt/monitor/tests/montest-lib/src/lib.rs
@@ -35,6 +35,11 @@ pub fn test_was_ctor_run() -> bool {
     WAS_CTOR_RUN.load(Ordering::SeqCst)
 }
 
+#[secgate::secure_gate]
+pub fn dynamic_test(x: u32) -> u32 {
+    42 + x
+}
+
 static WAS_CTOR_RUN: AtomicBool = AtomicBool::new(false);
 
 #[used]

--- a/src/rt/monitor/tests/montest/Cargo.toml
+++ b/src/rt/monitor/tests/montest/Cargo.toml
@@ -10,6 +10,7 @@ twizzler-runtime = { path = "../../.." }
 secgate = { path = "../../../../lib/secgate" }
 montest-lib = { path = "../montest-lib" }
 monitor = { path = "../../../monitor" }
+monitor-api = { path = "../../../monitor-api" }
 ctor = "*"
 tracing = "0.1"
 tracing-subscriber = "0.3"

--- a/src/rt/monitor/tests/montest/src/main.rs
+++ b/src/rt/monitor/tests/montest/src/main.rs
@@ -94,9 +94,11 @@ mod tests {
 
     #[test]
     fn test_dynamic_secgate() {
-        let comp = CompartmentHandle::current();
+        let current = CompartmentHandle::current();
+        let name = format!("{}::libmontest_lib.so", current.info().name);
+        let comp = CompartmentHandle::lookup(&name)
+            .expect(&format!("failed to open compartment: {}", &name));
         let gate = unsafe { comp.dynamic_gate::<(u32,), u32>("dynamic_test") }.unwrap();
-        klog_println!("found: {:?}", gate);
         let ret = unsafe { secgate::dynamic_gate_call(gate, (3,)).ok().unwrap() };
         assert_eq!(ret, 45);
     }

--- a/src/rt/monitor/tests/montest/src/main.rs
+++ b/src/rt/monitor/tests/montest/src/main.rs
@@ -32,6 +32,9 @@ fn setup_logging() {
 mod tests {
     use std::sync::atomic::Ordering;
 
+    use monitor_api::CompartmentHandle;
+    use twizzler_abi::klog_println;
+
     use crate::montest_lib;
     extern crate secgate;
 
@@ -87,6 +90,15 @@ mod tests {
     fn test_bin_ctors() {
         setup_logging();
         assert_eq!(true, WAS_CTOR_RUN.load(Ordering::SeqCst))
+    }
+
+    #[test]
+    fn test_dynamic_secgate() {
+        let comp = CompartmentHandle::current();
+        let gate = unsafe { comp.dynamic_gate::<(u32,), u32>("dynamic_test") }.unwrap();
+        klog_println!("found: {:?}", gate);
+        let ret = unsafe { secgate::dynamic_gate_call(gate, (3,)).ok().unwrap() };
+        assert_eq!(ret, 45);
     }
 }
 

--- a/src/rt/reference/src/lib.rs
+++ b/src/rt/reference/src/lib.rs
@@ -27,3 +27,5 @@ pub mod preinit;
 
 #[allow(non_snake_case)]
 pub mod syms;
+
+pub mod pager;

--- a/src/rt/reference/src/pager.rs
+++ b/src/rt/reference/src/pager.rs
@@ -1,0 +1,33 @@
+use std::sync::OnceLock;
+
+use monitor_api::CompartmentHandle;
+use secgate::DynamicSecGate;
+use twizzler_abi::object::ObjID;
+
+struct PagerAPI {
+    _handle: &'static CompartmentHandle,
+    full_sync_call: DynamicSecGate<'static, (ObjID,), ()>,
+}
+
+static PAGER_API: OnceLock<PagerAPI> = OnceLock::new();
+
+fn pager_api() -> &'static PagerAPI {
+    PAGER_API.get_or_init(|| {
+        let handle = Box::leak(Box::new(
+            CompartmentHandle::lookup("pager-srv").expect("failed to open pager compartment"),
+        ));
+        let full_sync_call = unsafe {
+            handle
+                .dynamic_gate::<(ObjID,), ()>("full_object_sync")
+                .expect("failed to find full object sync gate call")
+        };
+        PagerAPI {
+            _handle: handle,
+            full_sync_call,
+        }
+    })
+}
+
+pub fn sync_object(id: ObjID) {
+    (pager_api().full_sync_call)(id).unwrap()
+}


### PR DESCRIPTION
This PR builds off #250 to make the pager startup function dynamic loaded by init after loading the pager compartment. It also fixes some things and adds examples to the runtime for dynamic access to a gate for the pager, which will be used later by the runtime to interact with the pager. Finally, this PR adds a full object sync secure gate call to the pager.