### PR TITLE
Cleanup pass

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -356,15 +356,14 @@ dependencies = [
 
 [[package]]
 name = "backtracer_core"
-version = "0.0.5"
-source = "git+https://github.com/twizzler-operating-system/backtracer?branch=twizzler#a84f7f986bbdf5ffa172364ba6b1b3deac51b4b0"
+version = "0.0.7"
 dependencies = [
  "addr2line 0.16.0",
  "cfg-if 0.1.10",
  "gimli 0.25.0",
  "log",
  "stable_deref_trait",
- "x86 0.51.0",
+ "x86",
 ]
 
 [[package]]
@@ -6154,7 +6153,7 @@ dependencies = [
  "twizzler-rt-abi",
  "uart_16550",
  "volatile",
- "x86 0.52.0",
+ "x86",
  "xmas-elf",
 ]
 
@@ -6284,7 +6283,7 @@ checksum = "e492212ac378a5e00da953718dafb1340d9fbaf4f27d6f3c5cab03d931d1c049"
 dependencies = [
  "bitflags 2.8.0",
  "rustversion",
- "x86 0.52.0",
+ "x86",
 ]
 
 [[package]]
@@ -6826,17 +6825,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
-]
-
-[[package]]
-name = "x86"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7477e4af519a58818c1f0ab4b149d0ce3304e625be8fe56c8484cac50b0532"
-dependencies = [
- "bit_field",
- "bitflags 1.3.2",
- "raw-cpuid",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1552,7 +1552,6 @@ dependencies = [
  "bincode",
  "clap",
  "lazy_static",
- "naming",
  "serde",
  "tar 0.4.43 (git+https://github.com/CPTforever/tar-rs.git?branch=twizzler)",
  "twizzler-abi",
@@ -3913,8 +3912,22 @@ name = "naming"
 version = "0.1.0"
 dependencies = [
  "arrayvec",
+ "monitor-api",
+ "naming-core",
  "naming-srv",
  "secgate",
+ "twizzler",
+ "twizzler-rt-abi",
+]
+
+[[package]]
+name = "naming-core"
+version = "0.1.0"
+dependencies = [
+ "arrayvec",
+ "monitor-api",
+ "secgate",
+ "twizzler",
  "twizzler-rt-abi",
 ]
 
@@ -3924,6 +3937,7 @@ version = "0.1.0"
 dependencies = [
  "arrayvec",
  "lazy_static",
+ "naming-core",
  "secgate",
  "twizzler",
  "twizzler-abi",
@@ -6160,6 +6174,7 @@ dependencies = [
  "num_enum",
  "paste",
  "printf-compat",
+ "spin 0.5.2",
  "stable-vec",
  "static_assertions",
  "talc",
@@ -6235,6 +6250,7 @@ dependencies = [
  "lazy_static",
  "lru",
  "monitor-api",
+ "naming-core",
  "paste",
  "printf-compat",
  "secgate",

--- a/src/bin/bootstrap/src/main.rs
+++ b/src/bin/bootstrap/src/main.rs
@@ -132,6 +132,7 @@ extern crate twizzler_minruntime;
 fn main() {
     let subscriber = FmtSubscriber::builder()
         .with_max_level(Level::INFO)
+        .without_time()
         .finish();
 
     tracing::subscriber::set_global_default(subscriber).expect("setting default subscriber failed");

--- a/src/bin/devmgr/src/main.rs
+++ b/src/bin/devmgr/src/main.rs
@@ -108,10 +108,9 @@ fn start_pcie(seg: Device) {
 
 extern crate twizzler_runtime;
 fn main() {
-    println!("[devmgr] starting device manager {:?}", args());
     logboi::LogHandle::new()
         .unwrap()
-        .log("Hello Logboi, from devmgr!".as_bytes());
+        .log("[devmgr] starting device manager".as_bytes());
     let id = args().into_iter().nth(1).unwrap().parse::<u128>().unwrap();
     let obj = Object::<std::sync::atomic::AtomicU64>::init_id(
         ObjID::new(id),

--- a/src/bin/etl_twizzler/src/etl.rs
+++ b/src/bin/etl_twizzler/src/etl.rs
@@ -2,22 +2,17 @@ use std::{
     fs::File,
     io::{self, BufRead, BufReader, Read, Seek, SeekFrom},
     path::PathBuf,
-    sync::Mutex,
 };
 
-use lazy_static::lazy_static;
 use serde::{Deserialize, Serialize};
 use tar::Header;
 #[cfg(target_os = "twizzler")]
 use twizzler_abi::{
     object::{MAX_SIZE, NULLPAGE_SIZE},
-    syscall::{
-        sys_thread_sync, BackingType, LifetimeType, ObjectCreate, ObjectCreateFlags, ThreadSync,
-        ThreadSyncFlags, ThreadSyncReference, ThreadSyncWake,
-    },
+    syscall::{BackingType, LifetimeType, ObjectCreate, ObjectCreateFlags},
 };
 #[cfg(target_os = "twizzler")]
-use twizzler_object::{ObjID, Object, ObjectInitFlags, Protections};
+use twizzler_object::Protections;
 
 // This type indicates what type of object you want to create, with the name inside
 #[derive(Serialize, Deserialize, PartialEq, Debug, Clone, Copy)]
@@ -111,8 +106,8 @@ where
 
 #[cfg(target_os = "twizzler")]
 pub fn form_twizzler_object<R: std::io::Read>(
-    mut stream: R,
-    name: String,
+    stream: R,
+    _name: String,
     offset: u64,
 ) -> std::io::Result<twizzler_object::ObjID> {
     let create = ObjectCreate::new(
@@ -132,7 +127,7 @@ pub fn form_twizzler_object<R: std::io::Read>(
     let slice =
         unsafe { std::slice::from_raw_parts_mut(handle_data_ptr, MAX_SIZE - offset as usize) };
 
-    stream.read(slice);
+    stream.read(slice)?;
 
     Ok(twzid)
 }
@@ -154,7 +149,7 @@ pub fn form_persistent_vector<R: std::io::Read>(
 ) -> std::io::Result<()> {
     let mut writer = File::create(name)?;
     writer.seek(SeekFrom::Start(offset))?;
-    let stream: Vec<String> = BufReader::new(stream)
+    let _stream: Vec<String> = BufReader::new(stream)
         .split(b'\n')
         .filter_map(|result| result.ok())
         .filter_map(|line| String::from_utf8(line).ok())
@@ -198,7 +193,7 @@ where
                     }
                     PackType::TwzObj => {
                         #[cfg(target_os = "twizzler")]
-                        form_twizzler_object(entry, path, bad_idea.offset);
+                        form_twizzler_object(entry, path, bad_idea.offset)?;
                         #[cfg(not(target_os = "twizzler"))]
                         form_fs_file(entry, path, bad_idea.offset)?;
                     }
@@ -206,8 +201,8 @@ where
                         form_persistent_vector(entry, path, bad_idea.offset)?;
                     }
                 }
-            } else if let Err(E) = e {
-                println!("{}", E);
+            } else if let Err(e) = e {
+                println!("{}", e);
             }
         }
 

--- a/src/bin/etl_twizzler/src/main.rs
+++ b/src/bin/etl_twizzler/src/main.rs
@@ -1,19 +1,6 @@
 use clap::{Parser, Subcommand};
 use etl_twizzler::etl::{Pack, PackType, Unpack};
 
-#[cfg(target_os = "twizzler")]
-use std::sync::atomic::{AtomicU64, Ordering};
-#[cfg(target_os = "twizzler")]
-use twizzler_abi::{
-    object::{MAX_SIZE, NULLPAGE_SIZE},
-    syscall::{
-        sys_thread_sync, BackingType, LifetimeType, ObjectCreate, ObjectCreateFlags, ThreadSync,
-        ThreadSyncFlags, ThreadSyncReference, ThreadSyncWake,
-    },
-};
-#[cfg(target_os = "twizzler")]
-use twizzler_object::{ObjID, Object, ObjectInitFlags, Protections};
-
 #[derive(Parser, Debug)]
 #[command(author, version, about, long_about = None)]
 struct Cli {

--- a/src/bin/genrandom/src/main.rs
+++ b/src/bin/genrandom/src/main.rs
@@ -1,33 +1,20 @@
-#![feature(new_uninit)]
-
 extern crate twizzler_runtime;
 
 use std::{
-    fs::DirBuilder,
-    future,
-    mem::{size_of, zeroed, MaybeUninit},
-    sync::{
-        atomic::{AtomicBool, Ordering},
-        mpsc::{self, channel},
-        Arc, Mutex, RwLock,
-    },
+    sync::mpsc::{self},
     thread,
-    time::{Duration, Instant},
+    time::Instant,
 };
 
-use getrandom::{getrandom, getrandom_uninit};
-use layout::{io::SeekFrom, Read, Seek, Write};
-use lethe_gadget_fat::filesystem::FileSystem;
-use twizzler_async::{block_on, Task, Timer};
+use getrandom::getrandom_uninit;
+use layout::{io::SeekFrom, Seek, Write};
 
-use crate::nvme::{init_nvme, NvmeController};
 mod disk;
 mod nvme;
 
 use disk::Disk;
 
 pub fn main() {
-    let id = 20;
     println!("Running genrandom");
 
     let mut d = Disk::new().unwrap();
@@ -43,9 +30,9 @@ pub fn main() {
     // fs.create_object(id, 1500);
     d.seek(SeekFrom::Current(START_OFFSET as i64)).unwrap();
     println!("seeked forward");
-    let mut buf = vec![0u8; BUF_SIZE_USIZE];
+    let _buf = vec![0u8; BUF_SIZE_USIZE];
     let (tx, rx) = mpsc::sync_channel(1);
-    let gen_thread = thread::spawn(move || {
+    let _gen_thread = thread::spawn(move || {
         for i in OFFSET_ITER..ITER_CT {
             let mut buf = Box::new_uninit_slice(BUF_SIZE_USIZE);
             let start = Instant::now();
@@ -61,11 +48,11 @@ pub fn main() {
         }
     });
     let program_start = Instant::now();
-    let write_thread = thread::spawn(move || {
+    let _write_thread = thread::spawn(move || {
         let mut iter_ct = OFFSET_ITER;
         for buf in rx {
             let start = Instant::now();
-            d.write(&buf);
+            d.write(&buf).unwrap();
             let end = Instant::now();
             let curr_dur = end - program_start;
             let iters_passed = iter_ct - OFFSET_ITER + 1;

--- a/src/bin/genrandom/src/nvme/controller.rs
+++ b/src/bin/genrandom/src/nvme/controller.rs
@@ -27,6 +27,7 @@ use volatile::map_field;
 use super::{dma::NvmeDmaRegion, requester::NvmeRequester};
 use crate::nvme::dma::NvmeDmaSliceRegion;
 
+#[allow(dead_code)]
 pub struct NvmeController {
     requester: RwLock<Vec<Requester<NvmeRequester>>>,
     admin_requester: RwLock<Option<Arc<Requester<NvmeRequester>>>>,
@@ -146,7 +147,7 @@ pub async fn init_controller(ctrl: &mut Arc<NvmeController>) {
 
     let req2 = req.clone();
     let ctrl2 = ctrl.clone();
-    let task = twizzler_async::run(async {
+    let _task = twizzler_async::run(async {
         Task::spawn(async move {
             loop {
                 let _i = int.next().await;
@@ -439,7 +440,7 @@ impl NvmeController {
         ident.dma_region().with(|ident| ident.clone())
     }
 
-    pub async fn flash_len(&self) -> usize {
+    pub async fn _flash_len(&self) -> usize {
         if let Some(sz) = self.capacity.get() {
             *sz
         } else {

--- a/src/bin/init/src/main.rs
+++ b/src/bin/init/src/main.rs
@@ -184,7 +184,7 @@ fn run_tests(test_list_name: &str, benches: bool) {
         };
         let bytes = &bytes[0..bytes.iter().position(|r| *r == 0).unwrap_or(0)];
         let str = String::from_utf8(bytes.to_vec()).unwrap();
-        let mut test_failed = false;
+        let test_failed = false;
         for line in str.split("\n").filter(|l| !l.is_empty()) {
             println!("STARTING TEST {}", line);
             let test_comp = monitor_api::CompartmentLoader::new(
@@ -209,33 +209,15 @@ fn run_tests(test_list_name: &str, benches: bool) {
     }
 }
 
-/*
-#[naked]
-#[no_mangle]
-extern "C" fn _start() -> ! {
-    unsafe { asm!("call std_runtime_start", options(noreturn)) }
-}
-*/
-
-use std::{
-    sync::{atomic::AtomicU64, Arc, Mutex},
-    time::Duration,
-};
-
 use monitor_api::{CompartmentFlags, CompartmentHandle, CompartmentLoader, NewCompartmentFlags};
 use tracing::{debug, info, warn};
 use twizzler_abi::{
     aux::KernelInitInfo,
-    device::SubObjectType,
-    kso::{KactionCmd, KactionFlags, KactionGenericCmd, KactionValue},
     object::{ObjID, Protections, MAX_SIZE, NULLPAGE_SIZE},
     pager::{CompletionToKernel, RequestFromKernel},
     syscall::{
-        sys_kaction, sys_new_handle, sys_object_create, sys_thread_sync, BackingType, LifetimeType,
-        NewHandleFlags, ObjectControlCmd, ObjectCreate, ObjectCreateFlags, ThreadSync,
-        ThreadSyncFlags, ThreadSyncOp, ThreadSyncReference, ThreadSyncSleep, ThreadSyncWake,
+        sys_new_handle, BackingType, LifetimeType, NewHandleFlags, ObjectCreate, ObjectCreateFlags,
+        ThreadSync, ThreadSyncFlags, ThreadSyncOp, ThreadSyncReference, ThreadSyncSleep,
     },
-    thread::{ExecutionState, ThreadRepr},
 };
 use twizzler_object::{CreateSpec, Object, ObjectInitFlags};
-use twizzler_rt_abi::object::{MapFlags, ObjectHandle};

--- a/src/bin/init/src/main.rs
+++ b/src/bin/init/src/main.rs
@@ -50,7 +50,8 @@ fn initialize_pager() {
 fn main() {
     tracing::subscriber::set_global_default(
         tracing_subscriber::fmt()
-            .with_max_level(tracing::Level::DEBUG)
+            .with_max_level(tracing::Level::INFO)
+            .without_time()
             .finish(),
     )
     .unwrap();

--- a/src/bin/mnemosyne/fat/src/filesystem.rs
+++ b/src/bin/mnemosyne/fat/src/filesystem.rs
@@ -82,7 +82,7 @@ impl<S: Read + Write + Seek + IO> FileSystem<S> {
         Ok(free_head)
     }
 
-    pub(crate) fn free_block(&mut self, block: u64) -> Result<(), FSError<S::Error>> {
+    pub(crate) fn _free_block(&mut self, block: u64) -> Result<(), FSError<S::Error>> {
         let mut frame = self.frame()?;
         let mut fat = frame.fat()?;
 

--- a/src/bin/mnemosyne/src/disk.rs
+++ b/src/bin/mnemosyne/src/disk.rs
@@ -80,7 +80,7 @@ impl Read for Disk {
             } else {
                 left + buf.len() - bytes_written
             }; // If I want to write more than the boundary of a page
-            block_on(self.ctrl.read_page(lba as u64, &mut read_buffer, 0));
+            block_on(self.ctrl.read_page(lba as u64, &mut read_buffer, 0)).unwrap();
 
             let bytes_to_read = right - left;
             buf[bytes_written..bytes_written + bytes_to_read]
@@ -95,7 +95,7 @@ impl Read for Disk {
     }
 
     fn read_exact(&mut self, buf: &mut [u8]) -> Result<(), Self::Error> {
-        self.read(buf);
+        self.read(buf)?;
         Ok(())
     }
 }
@@ -119,9 +119,9 @@ impl Write for Disk {
             };
             if right - left != PAGE_SIZE {
                 let temp_pos: u64 = self.pos.try_into().unwrap();
-                self.seek(SeekFrom::Start(temp_pos & !PAGE_MASK as u64));
+                self.seek(SeekFrom::Start(temp_pos & !PAGE_MASK as u64))?;
                 self.read_exact(&mut write_buffer)?;
-                self.seek(SeekFrom::Start(temp_pos));
+                self.seek(SeekFrom::Start(temp_pos))?;
             }
 
             write_buffer[left..right].copy_from_slice(&buf[bytes_read..bytes_read + right - left]);
@@ -129,7 +129,7 @@ impl Write for Disk {
 
             self.pos += right - left;
 
-            block_on(self.ctrl.write_page(lba as u64, &mut write_buffer, 0));
+            block_on(self.ctrl.write_page(lba as u64, &mut write_buffer, 0)).unwrap();
             lba += PAGE_SIZE / SECTOR_SIZE;
         }
 
@@ -137,7 +137,7 @@ impl Write for Disk {
     }
 
     fn write_all(&mut self, buf: &[u8]) -> Result<(), Self::Error> {
-        self.write(buf);
+        self.write(buf)?;
 
         Ok(())
     }

--- a/src/bin/mnemosyne/src/nvme/controller.rs
+++ b/src/bin/mnemosyne/src/nvme/controller.rs
@@ -27,6 +27,7 @@ use volatile::map_field;
 use super::{dma::NvmeDmaRegion, requester::NvmeRequester};
 use crate::nvme::dma::NvmeDmaSliceRegion;
 
+#[allow(dead_code)]
 pub struct NvmeController {
     requester: RwLock<Vec<Requester<NvmeRequester>>>,
     admin_requester: RwLock<Option<Arc<Requester<NvmeRequester>>>>,
@@ -439,7 +440,7 @@ impl NvmeController {
         ident.dma_region().with(|ident| ident.clone())
     }
 
-    pub async fn flash_len(&self) -> usize {
+    pub async fn _flash_len(&self) -> usize {
         if let Some(sz) = self.capacity.get() {
             *sz
         } else {

--- a/src/bin/naming-test/src/main.rs
+++ b/src/bin/naming-test/src/main.rs
@@ -1,6 +1,4 @@
-use std::fs::File;
-
-use naming::{dynamic_naming_factory, static_naming_factory};
+use naming::dynamic_naming_factory;
 
 fn main() {
     let mut handle = dynamic_naming_factory().unwrap();

--- a/src/bin/random_validation/src/diehardest/mod.rs
+++ b/src/bin/random_validation/src/diehardest/mod.rs
@@ -8,9 +8,9 @@ pub trait Random {
 }
 
 /// 13 tests in total implemented
-const TOTAL_TESTS: u32 = 13;
-pub const EXPECTED_SCORE: u32 = TOTAL_TESTS * 1024;
-pub fn crush<R: Random + Clone>(rand: R) -> u32 {
+pub const _TOTAL_TESTS: u32 = 13;
+pub const _EXPECTED_SCORE: u32 = _TOTAL_TESTS * 1024;
+pub fn _crush<R: Random + Clone>(rand: R) -> u32 {
     analysis::Report::new(rand.clone()).get_score().total() as u32
         + analysis::Report::new(transform::SkipOne(rand.clone()))
             .get_score()

--- a/src/bin/random_validation/src/main.rs
+++ b/src/bin/random_validation/src/main.rs
@@ -1,10 +1,9 @@
 extern crate twizzler_runtime;
-use std::mem::MaybeUninit;
 mod diehardest;
 
 use getrandom::getrandom;
 
-use crate::diehardest::{analysis::Report, crush};
+use crate::diehardest::analysis::Report;
 
 #[derive(Clone)]
 struct Rng;
@@ -12,7 +11,7 @@ struct Rng;
 impl diehardest::Random for Rng {
     fn get_random(&mut self) -> u64 {
         let mut into = [0u8; 8];
-        getrandom(&mut into);
+        getrandom(&mut into).unwrap();
         u64::from_ne_bytes(into)
     }
 }
@@ -22,7 +21,6 @@ impl diehardest::Random for Rng {
 // Alternatively find a way to compile dieharder, a C library, in twizzler.
 // debian package source: https://salsa.debian.org/edd/dieharder
 fn main() {
-    let mut into: [u8; 32] = Default::default();
     let report = Report::new(Rng);
     let score = report.get_score();
 

--- a/src/bin/randtest/src/main.rs
+++ b/src/bin/randtest/src/main.rs
@@ -16,7 +16,7 @@ fn main() {
         *b = random();
     }
     let mut into2: [u8; 32] = Default::default();
-    getrandom(&mut into2);
+    getrandom(&mut into2).unwrap();
 
     println!("bytes: {:?}, {:?}", into1, into2);
 }

--- a/src/bin/test-tiny-http/src/main.rs
+++ b/src/bin/test-tiny-http/src/main.rs
@@ -1,9 +1,11 @@
 // extern crate twizzler_abi;
-use tiny_http::shim::SmolTcpListener as TcpListener;
+use std::{
+    io::{Read, Write},
+    sync::Arc,
+    thread,
+};
+
 use tiny_http::{shim::SmolTcpStream as TcpStream, Response, Server};
-use std::{io::{Read, Write},
-        sync::{Arc},
-        thread,};
 
 // hello world made single threaded : TINY_HTTP
 fn main() {
@@ -18,7 +20,7 @@ fn main() {
                 request.url(),
                 request.headers()
             );
-    
+
             let response = Response::from_string("hello world");
             request.respond(response).expect("Responded");
         }
@@ -38,8 +40,9 @@ fn std_client(port: u16) -> std::io::Result<()> {
     let msg = b"GET /notes HTTP/1.1\r\n\r\n";
     let _result = client.write(msg)?;
     println!("{}", client.read(&mut rx_buffer)?);
-    println!("{}", String::from_utf8((&rx_buffer[0..2048]).to_vec()).unwrap());
+    println!(
+        "{}",
+        String::from_utf8((&rx_buffer[0..2048]).to_vec()).unwrap()
+    );
     Ok(())
 }
-
-

--- a/src/bin/virtio/src/main.rs
+++ b/src/bin/virtio/src/main.rs
@@ -1,14 +1,14 @@
-use core::{cell::RefCell, str::FromStr};
-use std::{borrow::ToOwned, rc::Rc, vec, vec::Vec};
+use core::str::FromStr;
+use std::{borrow::ToOwned, vec, vec::Vec};
 
 use smoltcp::{
     iface::{Config, Interface, SocketSet},
-    phy::{Device, DeviceCapabilities, Medium},
+    phy::{Device, Medium},
     socket::tcp,
     time::Instant,
-    wire::{EthernetAddress, HardwareAddress, IpAddress, IpCidr, Ipv4Address},
+    wire::{HardwareAddress, IpAddress, IpCidr, Ipv4Address},
 };
-use virtio_net::{get_device, DeviceWrapper};
+use virtio_net::get_device;
 
 const IP: &str = "10.0.2.15"; // QEMU user networking default IP
 const GATEWAY: &str = "10.0.2.2"; // QEMU user networking gateway

--- a/src/kernel/Cargo.toml
+++ b/src/kernel/Cargo.toml
@@ -27,7 +27,8 @@ object = { version = "0.32.1", default-features = false, features = ["read"] }
 addr2line = { version = "0.16.0", default-features = false, features = [
     "rustc-demangle",
 ] }
-backtracer_core = { git = "https://github.com/twizzler-operating-system/backtracer", branch = "twizzler" }
+#backtracer_core = { git = "https://github.com/twizzler-operating-system/backtracer", branch = "twizzler" }
+backtracer_core = { path = "../../backtracer" }
 limine = "0.2.0"
 twizzler-queue-raw = { version = "*", path = "../lib/twizzler-queue-raw", default-features = false }
 #syscall_encode = { version = "0.1.2" }

--- a/src/kernel/macros/src/lib.rs
+++ b/src/kernel/macros/src/lib.rs
@@ -32,7 +32,7 @@ pub fn kernel_test(_attr: TokenStream, items: TokenStream) -> TokenStream {
     let name = name.unwrap_or("unknown".to_string());
     // Write the test caller and the name into a test_case tuple
     let mut code: TokenStream = format!(
-        "#[test_case] const __X__{}: (&'static str, &'static dyn Fn()) = (\"{}\", &|| {{ {}(); }});",
+        "#[test_case] const __X_{}: (&'static str, &'static dyn Fn()) = (\"{}\", &|| {{ {}(); }});",
         name.to_uppercase(),
         name,
         name

--- a/src/kernel/src/arch/amd64/apic/ipi.rs
+++ b/src/kernel/src/arch/amd64/apic/ipi.rs
@@ -1,4 +1,4 @@
-use super::local::{get_lapic, LAPIC_ICRHI, LAPIC_ICRLO, LAPIC_ICRLO_STATUS_PEND};
+use super::local::{get_lapic, LAPIC_ICRLO, LAPIC_ICRLO_STATUS_PEND};
 use crate::{interrupt::Destination, processor};
 
 const DEST_SHORT_NONE: u32 = 0;

--- a/src/kernel/src/arch/amd64/ioapic.rs
+++ b/src/kernel/src/arch/amd64/ioapic.rs
@@ -97,7 +97,6 @@ pub(super) fn set_interrupt(
     for ioapic in &*ioapics {
         if let Some(reg) = ioapic.gsi_to_reg(gsi) {
             unsafe {
-                logln!("setting {} {} masked={}", gsi, vector, masked);
                 ioapic.write_vector_data(
                     reg,
                     construct_interrupt_data(vector, masked, trigger, polarity, destination),
@@ -166,11 +165,6 @@ pub fn init() {
             acpi::platform::interrupt::Polarity::ActiveLow => PinPolarity::ActiveLow,
         };
 
-        logln!(
-            "remap {} {}",
-            iso.global_system_interrupt,
-            iso.isa_source + 32
-        );
         set_interrupt(
             iso.global_system_interrupt,
             iso.isa_source as u32 + 32,

--- a/src/kernel/src/arch/amd64/start.rs
+++ b/src/kernel/src/arch/amd64/start.rs
@@ -97,12 +97,10 @@ extern "C" fn limine_entry() -> ! {
     }
 
     let mut boot_info = LimineBootInfo {
-        kernel: unsafe {
-            LIMINE_KERNEL
-                .get_response()
-                .expect("no kernel info specified for kernel")
-                .file()
-        },
+        kernel: LIMINE_KERNEL
+            .get_response()
+            .expect("no kernel info specified for kernel")
+            .file(),
         maps: alloc::vec![],
         modules: alloc::vec![],
         rsdp: LIMINE_TABLE.get_response().map(

--- a/src/kernel/src/condvar.rs
+++ b/src/kernel/src/condvar.rs
@@ -1,7 +1,7 @@
 use alloc::vec::Vec;
 
 use intrusive_collections::{intrusive_adapter, KeyAdapter, RBTree};
-use twizzler_abi::{object::ObjID, thread::ExecutionState};
+use twizzler_abi::object::ObjID;
 
 use crate::{
     sched::schedule_thread,

--- a/src/kernel/src/crypto.rs
+++ b/src/kernel/src/crypto.rs
@@ -2,14 +2,7 @@ use p256::ecdsa::{
     signature::{self, Signer, Verifier},
     Signature, SigningKey, VerifyingKey,
 };
-use sha2::{
-    digest::{
-        consts::{B0, B1},
-        generic_array::GenericArray,
-        typenum::{UInt, UTerm},
-    },
-    Digest, Sha256,
-};
+use sha2::{Digest, Sha256};
 
 pub fn sha256(input: impl AsRef<[u8]>) -> [u8; 32] {
     let mut hasher = Sha256::new();

--- a/src/kernel/src/initrd.rs
+++ b/src/kernel/src/initrd.rs
@@ -1,7 +1,5 @@
 use alloc::{borrow::ToOwned, collections::BTreeMap, string::String, sync::Arc};
 
-use object::ReadRef;
-
 use crate::{
     memory::VirtAddr,
     obj::{self, pages::Page, ObjectRef},

--- a/src/kernel/src/machine/pc/pcie.rs
+++ b/src/kernel/src/machine/pc/pcie.rs
@@ -149,7 +149,7 @@ fn register_device(
             }
         }
         _ => {
-            logln!("[kernel::machine::pcie] unknown PCIe header type");
+            // do nothing -- don't know how to get BARs.
         }
     }
     let info = PcieDeviceInfo {

--- a/src/kernel/src/memory/allocator.rs
+++ b/src/kernel/src/memory/allocator.rs
@@ -42,7 +42,12 @@ impl<Ctx: KernelMemoryContext + 'static> KernelAllocator<Ctx> {
         if start + layout.size() >= EARLY_ALLOCATION_SIZE {
             panic!("out of early memory");
         }
-        unsafe { EARLY_ALLOCATION_AREA.as_mut_ptr().add(start) as *mut u8 }
+        // Safety: this is safe because we are only ever handing out unique slices of this region,
+        // and this is then used as allocated memory. Also, at this point, there is only 1 thread.
+        #[allow(static_mut_refs)]
+        unsafe {
+            EARLY_ALLOCATION_AREA.as_mut_ptr().add(start) as *mut u8
+        }
     }
 }
 

--- a/src/kernel/src/memory/context.rs
+++ b/src/kernel/src/memory/context.rs
@@ -14,9 +14,7 @@ use twizzler_abi::{
 };
 
 use self::virtmem::KernelObjectVirtHandle;
-use super::{PhysAddr, VirtAddr};
 use crate::{
-    memory::pagetables::{ContiguousProvider, MappingFlags, MappingSettings},
     obj::{InvalidateMode, ObjectRef, PageNumber},
     syscall::object::ObjectHandle,
 };

--- a/src/kernel/src/obj/control.rs
+++ b/src/kernel/src/obj/control.rs
@@ -13,7 +13,7 @@ use crate::{
             kernel_context, KernelMemoryContext, KernelObject, KernelObjectHandle,
             ObjectContextInfo,
         },
-        frame::{alloc_frame, free_frame, FrameRef, PhysicalFrameFlags},
+        frame::{alloc_frame, FrameRef, PhysicalFrameFlags},
     },
     obj::{pages::Page, ObjectRef, PageNumber},
     userinit::create_blank_object,

--- a/src/kernel/src/pager.rs
+++ b/src/kernel/src/pager.rs
@@ -7,7 +7,7 @@ use twizzler_abi::object::ObjID;
 use crate::{
     memory::{MemoryRegion, MemoryRegionKind},
     mutex::Mutex,
-    obj::{lookup_object, LookupFlags, ObjectRef, PageNumber},
+    obj::{LookupFlags, ObjectRef, PageNumber},
     once::Once,
     syscall::sync::finish_blocking,
     thread::current_thread_ref,
@@ -28,7 +28,6 @@ pub fn pager_select_memory_regions(regions: &[MemoryRegion]) -> Vec<MemoryRegion
         if matches!(reg.kind, MemoryRegionKind::UsableRam) {
             // TODO: don't just pick one, and don't just pick the first one.
             if PAGER_MEMORY.poll().is_none() {
-                logln!("selecting pager region {:?}", reg);
                 PAGER_MEMORY.call_once(|| *reg);
             } else {
                 fa_regions.push(*reg);

--- a/src/kernel/src/pager/queues.rs
+++ b/src/kernel/src/pager/queues.rs
@@ -164,7 +164,7 @@ pub fn init_pager_queue(id: ObjID, outgoing: bool) {
         _ => panic!("pager queue not found"),
     };
     logln!(
-        "[kernel-pager] registered {} pager queue: {}",
+        "[kernel::pager] registered {} pager queue: {}",
         if outgoing { "sender" } else { "receiver" },
         id
     );

--- a/src/kernel/src/processor.rs
+++ b/src/kernel/src/processor.rs
@@ -535,14 +535,13 @@ mod test {
 
     use twizzler_kernel_macros::kernel_test;
 
-    use super::ALL_PROCESSORS;
     use crate::interrupt::Destination;
 
     const NR_IPI_TEST_ITERS: usize = 1000;
     #[kernel_test]
     fn ipi_test() {
         for _ in 0..NR_IPI_TEST_ITERS {
-            let nr_cpus = unsafe { &ALL_PROCESSORS }.iter().flatten().count();
+            let nr_cpus = super::all_processors().iter().flatten().count();
             let counter = Arc::new(AtomicUsize::new(0));
             let counter2 = counter.clone();
             super::ipi_exec(

--- a/src/kernel/src/random/mod.rs
+++ b/src/kernel/src/random/mod.rs
@@ -57,7 +57,7 @@ impl EntropySources {
             // add two events per source to each of the pools
             // Two events because fortuna::MIN_POOL_SIZE is 64 bytes and each event
             // is restricted to be 32 bytes at most
-            for i in 0..fortuna::POOL_COUNT * 2 {
+            for _ in 0..fortuna::POOL_COUNT * 2 {
                 if let Ok(_) = source.0.try_fill_entropy(&mut buf) {
                     accumulator
                         .add_random_event(&mut source.1, &buf)

--- a/src/kernel/src/syscall/object.rs
+++ b/src/kernel/src/syscall/object.rs
@@ -79,7 +79,7 @@ pub fn sys_object_map(
 }
 
 pub fn sys_object_readmap(handle: ObjID, slot: usize) -> Result<MapInfo, ObjectReadMapError> {
-    let vm = if handle.as_u128() == 0 {
+    let vm = if handle.raw() == 0 {
         current_memory_context().unwrap()
     } else {
         get_vmcontext_from_handle(handle).ok_or(ObjectReadMapError::InvalidArgument)?

--- a/src/kernel/src/syscall/sync.rs
+++ b/src/kernel/src/syscall/sync.rs
@@ -22,14 +22,12 @@ struct Requeue {
 }
 
 /* TODO: make this thread-local */
-static mut REQUEUE: Once<Requeue> = Once::new();
+static REQUEUE: Once<Requeue> = Once::new();
 
 fn get_requeue_list() -> &'static Requeue {
-    unsafe {
-        REQUEUE.call_once(|| Requeue {
-            list: Spinlock::new(BTreeMap::new()),
-        })
-    }
+    REQUEUE.call_once(|| Requeue {
+        list: Spinlock::new(BTreeMap::new()),
+    })
 }
 
 pub fn requeue_all() {

--- a/src/kernel/src/syscall/thread.rs
+++ b/src/kernel/src/syscall/thread.rs
@@ -10,18 +10,18 @@ pub fn sys_spawn(args: &ThreadSpawnArgs) -> Result<ObjID, ThreadSpawnError> {
     crate::thread::entry::start_new_user(*args)
 }
 
-pub fn thread_ctrl(cmd: ThreadControl, arg: u64) -> (u64, u64) {
+pub fn thread_ctrl(cmd: ThreadControl, arg: u64) -> [u64; 2] {
     match cmd {
         ThreadControl::SetUpcall => {
             let Some(data) = (unsafe { (arg as usize as *const UpcallTarget).as_ref() }) else {
-                return (1, 1);
+                return [1, 1];
             };
             // TODO: verify args, check perms.
             *current_thread_ref().unwrap().upcall_target.lock() = Some(*data);
         }
         ThreadControl::ResumeFromUpcall => {
             let Some(data) = (unsafe { (arg as usize as *const UpcallFrame).as_ref() }) else {
-                return (1, 1);
+                return [1, 1];
             };
             // TODO: verify args, check perms.
 
@@ -37,11 +37,11 @@ pub fn thread_ctrl(cmd: ThreadControl, arg: u64) -> (u64, u64) {
             // TODO: maybe give a priority drop?
             crate::sched::schedule(true);
         }
-        ThreadControl::GetSelfId => return current_thread_ref().unwrap().objid().split(),
+        ThreadControl::GetSelfId => return current_thread_ref().unwrap().objid().parts(),
         ThreadControl::GetActiveSctxId => {
-            return current_thread_ref().unwrap().secctx.active_id().split()
+            return current_thread_ref().unwrap().secctx.active_id().parts()
         }
         _ => todo!(),
     }
-    (0, 0)
+    [0, 0]
 }

--- a/src/kernel/src/thread.rs
+++ b/src/kernel/src/thread.rs
@@ -6,7 +6,6 @@ use core::{
 };
 
 use intrusive_collections::{linked_list::AtomicLink, offset_of, RBTreeAtomicLink};
-use object::xcoff::C_NULL;
 use twizzler_abi::{
     object::{ObjID, NULLPAGE_SIZE},
     syscall::ThreadSpawnArgs,
@@ -76,8 +75,11 @@ pub type ThreadRef = Arc<Thread>;
 static CURRENT_THREAD: RefCell<Option<ThreadRef>> = RefCell::new(None);
 
 pub fn current_thread_ref() -> Option<ThreadRef> {
-    if core::intrinsics::unlikely(!crate::processor::tls_ready()) {
-        return None;
+    #[allow(unused_unsafe)]
+    unsafe {
+        if core::intrinsics::unlikely(!crate::processor::tls_ready()) {
+            return None;
+        }
     }
     interrupt::with_disabled(|| CURRENT_THREAD.borrow().clone())
 }

--- a/src/kernel/src/thread/entry.rs
+++ b/src/kernel/src/thread/entry.rs
@@ -182,7 +182,7 @@ where
 mod test {
     use twizzler_kernel_macros::kernel_test;
 
-    use crate::thread::{current_thread_ref, Priority};
+    use crate::thread::Priority;
 
     #[kernel_test]
     fn test_closure() {

--- a/src/kernel/src/thread/entry.rs
+++ b/src/kernel/src/thread/entry.rs
@@ -106,7 +106,6 @@ impl<F, R> KthreadClosure<F, R> {
     /// Wait for the other thread to finish and provide the result.
     #[track_caller]
     pub fn wait(self: Arc<Self>) -> R {
-        let caller = core::panic::Location::caller();
         loop {
             current_processor().cleanup_exited();
             let guard = self.result.lock();

--- a/src/kernel/src/time.rs
+++ b/src/kernel/src/time.rs
@@ -34,6 +34,7 @@ where
     // best real-time or monotonic clock and then
     // TICK_SOURCES to read the data. References with Arc around
     // them still point to the same memory location.
+    #[allow(unused_unsafe)]
     if unsafe { core::intrinsics::unlikely(clk_id == 0) } {
         // reserve space for the real-time clock
         clock_list.push(clk.clone());

--- a/src/lib/naming/naming-core/src/api.rs
+++ b/src/lib/naming/naming-core/src/api.rs
@@ -1,11 +1,5 @@
-use monitor_api::CompartmentHandle;
-use secgate::{
-    util::{Descriptor, Handle, SimpleBuffer},
-    DynamicSecGate, SecGateReturn,
-};
+use secgate::{util::Descriptor, SecGateReturn};
 use twizzler_rt_abi::object::ObjID;
-
-use crate::NamingHandle;
 
 pub trait NamerAPI {
     fn put(&self, desc: Descriptor) -> SecGateReturn<()>;

--- a/src/lib/naming/naming-core/src/dynamic.rs
+++ b/src/lib/naming/naming-core/src/dynamic.rs
@@ -1,10 +1,7 @@
 use std::sync::OnceLock;
 
 use monitor_api::CompartmentHandle;
-use secgate::{
-    util::{Descriptor, Handle, SimpleBuffer},
-    DynamicSecGate, SecGateReturn,
-};
+use secgate::{util::Descriptor, DynamicSecGate, SecGateReturn};
 use twizzler_rt_abi::object::ObjID;
 
 use crate::{api::NamerAPI, NamingHandle};

--- a/src/lib/naming/naming-core/src/handle.rs
+++ b/src/lib/naming/naming-core/src/handle.rs
@@ -1,9 +1,6 @@
 use arrayvec::ArrayString;
-use secgate::{
-    util::{Descriptor, Handle, SimpleBuffer},
-    SecGateReturn,
-};
-use twizzler_rt_abi::object::{MapFlags, ObjID};
+use secgate::util::{Handle, SimpleBuffer};
+use twizzler_rt_abi::object::MapFlags;
 
 use crate::{api::NamerAPI, definitions::Schema};
 pub struct NamingHandle<'a, API: NamerAPI> {
@@ -26,7 +23,7 @@ impl<'a, API: NamerAPI> NamingHandle<'a, API> {
 
     pub fn put(&mut self, key: &str, val: u128) {
         // I should write directly to the simple buffer
-        let mut s = Schema {
+        let s = Schema {
             key: ArrayString::from(key).unwrap(),
             val,
         };
@@ -35,31 +32,31 @@ impl<'a, API: NamerAPI> NamingHandle<'a, API> {
         let bytes =
             unsafe { std::mem::transmute::<Schema, [u8; std::mem::size_of::<Schema>()]>(s) };
 
-        let handle = self.buffer.write(&bytes);
+        let _handle = self.buffer.write(&bytes);
 
         self.api.put(self.desc);
     }
 
     pub fn get(&mut self, key: &str) -> Option<u128> {
-        let mut s = Schema {
+        let s = Schema {
             key: ArrayString::from(key).unwrap(),
             val: 0,
         };
         let bytes =
             unsafe { std::mem::transmute::<Schema, [u8; std::mem::size_of::<Schema>()]>(s) };
-        let handle = self.buffer.write(&bytes);
+        let _handle = self.buffer.write(&bytes);
 
         self.api.get(self.desc).unwrap()
     }
 
     pub fn remove(&mut self, key: &str) {
-        let mut s = Schema {
+        let s = Schema {
             key: ArrayString::from(key).unwrap(),
             val: 0,
         };
         let bytes =
             unsafe { std::mem::transmute::<Schema, [u8; std::mem::size_of::<Schema>()]>(s) };
-        let handle = self.buffer.write(&bytes);
+        let _handle = self.buffer.write(&bytes);
 
         self.api.remove(self.desc);
     }

--- a/src/lib/naming/naming-core/src/lib.rs
+++ b/src/lib/naming/naming-core/src/lib.rs
@@ -1,13 +1,3 @@
-use std::sync::OnceLock;
-
-use arrayvec::ArrayString;
-use monitor_api::CompartmentHandle;
-use secgate::{
-    util::{Descriptor, Handle, SimpleBuffer},
-    DynamicSecGate, SecGateReturn,
-};
-use twizzler_rt_abi::object::{MapFlags, ObjID};
-
 pub mod api;
 pub mod definitions;
 pub mod dynamic;

--- a/src/lib/naming/src/lib.rs
+++ b/src/lib/naming/src/lib.rs
@@ -3,10 +3,7 @@ extern "C" {}
 
 pub use naming_core::dynamic::*;
 use naming_core::{api::NamerAPI, handle::NamingHandle};
-use secgate::{
-    secure_gate,
-    util::{Descriptor, HandleMgr, SimpleBuffer},
-};
+use secgate::util::Descriptor;
 use twizzler_rt_abi::object::ObjID;
 
 pub struct StaticNamingAPI {}

--- a/src/lib/twizzler-abi/src/arch/x86_64/mod.rs
+++ b/src/lib/twizzler-abi/src/arch/x86_64/mod.rs
@@ -3,12 +3,6 @@ use crate::object::MAX_SIZE;
 pub mod syscall;
 pub(crate) mod upcall;
 
-#[cfg(feature = "runtime")]
-pub(crate) fn new_thread_tls() -> Option<(usize, *mut u8, usize, usize)> {
-    // x86_64 uses variant II for TLS
-    crate::runtime::tls::tls_variant2()
-}
-
 // Max size of user addr space divided into slots of size MAX_SIZE
 pub const SLOTS: usize = (1 << 47) / MAX_SIZE;
 

--- a/src/lib/twizzler-abi/src/device/bus/pcie.rs
+++ b/src/lib/twizzler-abi/src/device/bus/pcie.rs
@@ -1,7 +1,7 @@
-#[cfg(any(feature = "runtime", feature = "kernel"))]
+#[cfg(any(feature = "kernel"))]
 use core::{mem::size_of, ptr::NonNull};
 
-#[cfg(any(feature = "runtime", feature = "kernel"))]
+#[cfg(any(feature = "kernel"))]
 use volatile::VolatilePtr;
 
 use crate::kso::KactionError;
@@ -136,7 +136,7 @@ pub struct PcieBridgeHeader {
     pub bridge_control: u16,
 }
 
-#[cfg(any(feature = "runtime", feature = "kernel"))]
+#[cfg(any(feature = "kernel"))]
 pub fn get_bar(cfg: VolatilePtr<'_, PcieDeviceHeader>, n: usize) -> VolatilePtr<'_, u32> {
     unsafe {
         cfg.map(|mut x| {

--- a/src/lib/twizzler-abi/src/kso.rs
+++ b/src/lib/twizzler-abi/src/kso.rs
@@ -57,17 +57,18 @@ impl From<(u64, u64)> for KactionValue {
         if x.0 == 0xFFFFFFFFFFFFFFFF {
             Self::U64(x.1)
         } else {
-            Self::ObjID(ObjID::new_from_parts(x.0, x.1))
+            Self::ObjID(ObjID::from_parts([x.0, x.1]))
         }
     }
 }
 
 impl From<KactionValue> for (u64, u64) {
     fn from(x: KactionValue) -> Self {
-        match x {
-            KactionValue::U64(x) => (0xffffffffffffffff, x),
-            KactionValue::ObjID(id) => id.split(),
-        }
+        let parts = match x {
+            KactionValue::U64(x) => [0xffffffffffffffff, x],
+            KactionValue::ObjID(id) => id.parts(),
+        };
+        (parts[0], parts[1])
     }
 }
 

--- a/src/lib/twizzler-abi/src/lib.rs
+++ b/src/lib/twizzler-abi/src/lib.rs
@@ -85,8 +85,6 @@ extern crate test;
 
 #[cfg(test)]
 mod tester {
-    use crate::print_err;
-
     #[bench]
     fn test_bench(bench: &mut test::Bencher) {
         bench.iter(|| {

--- a/src/lib/twizzler-abi/src/lib.rs
+++ b/src/lib/twizzler-abi/src/lib.rs
@@ -9,7 +9,7 @@
 //! All of these interfaces are potentially unstable and should not be used directly by most
 //! programs.
 
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
 #![feature(naked_functions)]
 #![feature(core_intrinsics)]
 #![feature(int_roundings)]
@@ -43,13 +43,7 @@ pub mod upcall;
 
 #[inline]
 unsafe fn internal_abort() -> ! {
-    cfg_if::cfg_if! {
-    if #[cfg(feature = "runtime")] {
-        runtime::OUR_RUNTIME.abort();
-    } else {
-        core::intrinsics::abort();
-    }
-    }
+    core::intrinsics::abort();
 }
 
 pub fn print_err(err: &str) {

--- a/src/lib/twizzler-abi/src/pager.rs
+++ b/src/lib/twizzler-abi/src/pager.rs
@@ -100,7 +100,7 @@ pub enum PagerCompletionData {
 }
 
 pub struct PageDataReq {
-    pub objID: ObjID,
+    pub objid: ObjID,
     pub object_range: ObjectRange,
 }
 

--- a/src/lib/twizzler-abi/src/syscall/create.rs
+++ b/src/lib/twizzler-abi/src/syscall/create.rs
@@ -172,7 +172,7 @@ pub fn sys_object_create(
         code,
         val,
         |c, _| c == 0,
-        crate::object::ObjID::new_from_parts,
+        |x, y| crate::object::ObjID::from_parts([x, y]),
         |_, v| ObjectCreateError::from(v),
     )
 }

--- a/src/lib/twizzler-abi/src/syscall/handle.rs
+++ b/src/lib/twizzler-abi/src/syscall/handle.rs
@@ -22,7 +22,7 @@ pub enum NewHandleError {
     #[num_enum(default)]
     #[error("unknown error")]
     Unknown = 0,
-    /// One of the arguments was invalid.   
+    /// One of the arguments was invalid.
     #[error("invalid argument")]
     InvalidArgument = 1,
     /// The specified object is already a handle.
@@ -76,7 +76,7 @@ pub fn sys_new_handle(
     handle_type: HandleType,
     flags: NewHandleFlags,
 ) -> Result<u64, NewHandleError> {
-    let (hi, lo) = objid.split();
+    let [hi, lo] = objid.parts();
     let (code, val) = unsafe {
         raw_syscall(
             Syscall::NewHandle,
@@ -88,7 +88,7 @@ pub fn sys_new_handle(
 
 /// Unbind an object from handle status.
 pub fn sys_unbind_handle(objid: ObjID, flags: UnbindHandleFlags) {
-    let (hi, lo) = objid.split();
+    let [hi, lo] = objid.parts();
     unsafe {
         raw_syscall(Syscall::UnbindHandle, &[hi, lo, flags.bits()]);
     }

--- a/src/lib/twizzler-abi/src/syscall/kaction.rs
+++ b/src/lib/twizzler-abi/src/syscall/kaction.rs
@@ -13,7 +13,7 @@ pub fn sys_kaction(
     arg2: u64,
     flags: KactionFlags,
 ) -> Result<KactionValue, KactionError> {
-    let (hi, lo) = id.map_or((0, 0), |id| id.split());
+    let [hi, lo] = id.map_or([0, 0], |id| id.parts());
     let (code, val) = unsafe {
         raw_syscall(
             Syscall::Kaction,

--- a/src/lib/twizzler-abi/src/syscall/map.rs
+++ b/src/lib/twizzler-abi/src/syscall/map.rs
@@ -59,7 +59,7 @@ pub fn sys_object_map(
     prot: Protections,
     flags: MapFlags,
 ) -> Result<usize, ObjectMapError> {
-    let (hi, lo) = id.split();
+    let [hi, lo] = id.parts();
     let args = [
         hi,
         lo,
@@ -114,7 +114,7 @@ pub fn sys_object_unmap(
     slot: usize,
     flags: UnmapFlags,
 ) -> Result<(), ObjectUnmapError> {
-    let (hi, lo) = handle.unwrap_or_else(|| 0.into()).split();
+    let [hi, lo] = handle.unwrap_or_else(|| 0.into()).parts();
     let args = [hi, lo, slot as u64, flags.bits() as u64];
     let (code, val) = unsafe { raw_syscall(Syscall::ObjectUnmap, &args) };
     convert_codes_to_result(code, val, |c, _| c != 0, |_, _| (), justval)
@@ -169,7 +169,7 @@ pub fn sys_object_read_map(
     handle: Option<ObjID>,
     slot: usize,
 ) -> Result<MapInfo, ObjectReadMapError> {
-    let (hi, lo) = handle.unwrap_or_else(|| 0.into()).split();
+    let [hi, lo] = handle.unwrap_or_else(|| 0.into()).parts();
     let mut map_info = MaybeUninit::<MapInfo>::uninit();
     let args = [
         hi,

--- a/src/lib/twizzler-abi/src/syscall/object_stat.rs
+++ b/src/lib/twizzler-abi/src/syscall/object_stat.rs
@@ -55,7 +55,7 @@ pub struct ObjectInfo {
 
 /// Read information about a given object.
 pub fn sys_object_stat(id: ObjID) -> Result<ObjectInfo, ObjectStatError> {
-    let (hi, lo) = id.split();
+    let [hi, lo] = id.parts();
     let mut obj_info = MaybeUninit::<ObjectInfo>::uninit();
     let args = [
         hi,

--- a/src/lib/twizzler-abi/src/syscall/random.rs
+++ b/src/lib/twizzler-abi/src/syscall/random.rs
@@ -4,7 +4,7 @@ use bitflags::bitflags;
 use num_enum::{FromPrimitive, IntoPrimitive};
 
 use super::{convert_codes_to_result, Syscall};
-use crate::{arch::syscall::raw_syscall, klog_println};
+use crate::arch::syscall::raw_syscall;
 
 bitflags! {
     #[derive(Debug)]

--- a/src/lib/twizzler-abi/src/syscall/security.rs
+++ b/src/lib/twizzler-abi/src/syscall/security.rs
@@ -41,7 +41,7 @@ impl core::error::Error for SctxAttachError {}
 
 /// Attach to a given security context.
 pub fn sys_sctx_attach(id: ObjID) -> Result<(), SctxAttachError> {
-    let args = [id.split().0, id.split().1, 0, 0, 0];
+    let args = [id.parts()[0], id.parts()[1], 0, 0, 0];
     let (code, val) = unsafe { raw_syscall(Syscall::SctxAttach, &args) };
     convert_codes_to_result(
         code,

--- a/src/lib/twizzler-abi/src/syscall/spawn.rs
+++ b/src/lib/twizzler-abi/src/syscall/spawn.rs
@@ -88,7 +88,7 @@ pub enum ThreadSpawnError {
     #[error("unknown error")]
     #[num_enum(default)]
     Unknown = 0,
-    /// One of the arguments was invalid.   
+    /// One of the arguments was invalid.
     #[error("invalid argument")]
     InvalidArgument = 1,
     /// A specified object (handle) was not found.
@@ -105,7 +105,7 @@ pub unsafe fn sys_spawn(args: ThreadSpawnArgs) -> Result<ObjID, ThreadSpawnError
         code,
         val,
         |c, _| c == 0,
-        crate::object::ObjID::new_from_parts,
+        |x, y| crate::object::ObjID::from_parts([x, y]),
         |_, v| ThreadSpawnError::from(v),
     )
 }

--- a/src/lib/twizzler-abi/src/syscall/thread_control.rs
+++ b/src/lib/twizzler-abi/src/syscall/thread_control.rs
@@ -90,7 +90,7 @@ pub fn sys_thread_settls(tls: u64) {
 /// Get the repr ID of the calling thread.
 pub fn sys_thread_self_id() -> ObjID {
     let (hi, lo) = unsafe { raw_syscall(Syscall::ThreadCtrl, &[ThreadControl::GetSelfId as u64]) };
-    ObjID::new_from_parts(hi, lo)
+    ObjID::from_parts([hi, lo])
 }
 
 /// Get the active security context ID for the calling thread.
@@ -101,7 +101,7 @@ pub fn sys_thread_active_sctx_id() -> ObjID {
             &[ThreadControl::GetActiveSctxId as u64],
         )
     };
-    ObjID::new_from_parts(hi, lo)
+    ObjID::from_parts([hi, lo])
 }
 
 /// Set the upcall location for this thread.
@@ -144,13 +144,13 @@ pub fn sys_thread_ctrl(
     arg2: usize,
 ) -> (u64, u64) {
     let target = target.unwrap_or(ObjID::new(0));
-    let ids = target.split();
+    let ids = target.parts();
     unsafe {
         raw_syscall(
             Syscall::ThreadCtrl,
             &[
-                ids.0,
-                ids.1,
+                ids[0],
+                ids[1],
                 cmd as u64,
                 arg0 as u64,
                 arg1 as u64,

--- a/src/lib/twizzler-abi/src/thread.rs
+++ b/src/lib/twizzler-abi/src/thread.rs
@@ -11,9 +11,7 @@ use twizzler_rt_abi::thread::SpawnError;
 use crate::syscall::*;
 use crate::{
     marker::BaseType,
-    syscall::{
-        ThreadSpawnError, ThreadSyncFlags, ThreadSyncOp, ThreadSyncReference, ThreadSyncSleep,
-    },
+    syscall::{ThreadSyncFlags, ThreadSyncOp, ThreadSyncReference, ThreadSyncSleep},
 };
 #[allow(unused_imports)]
 use crate::{

--- a/src/lib/twizzler-queue/src/sender_queue.rs
+++ b/src/lib/twizzler-queue/src/sender_queue.rs
@@ -10,7 +10,7 @@ use std::{
 };
 
 use async_io::Async;
-use futures::{stream::FuturesUnordered, FutureExt, StreamExt};
+use futures::FutureExt;
 use twizzler_queue_raw::{QueueError, ReceiveFlags, SubmissionFlags};
 
 use crate::Queue;

--- a/src/lib/twizzler/src/alloc.rs
+++ b/src/lib/twizzler/src/alloc.rs
@@ -1,9 +1,6 @@
 use std::alloc::{AllocError, Layout};
 
-use crate::{
-    ptr::{GlobalPtr, RefSlice, RefSliceMut},
-    tx::TxHandle,
-};
+use crate::{ptr::GlobalPtr, tx::TxHandle};
 
 pub mod arena;
 mod global;

--- a/src/lib/twizzler/src/alloc/arena.rs
+++ b/src/lib/twizzler/src/alloc/arena.rs
@@ -8,9 +8,9 @@ use twizzler_abi::object::{MAX_SIZE, NULLPAGE_SIZE};
 use super::{Allocator, OwnedGlobalPtr, SingleObjectAllocator};
 use crate::{
     marker::BaseType,
-    object::{CreateError, Object, ObjectBuilder, RawObject, TypedObject},
-    ptr::{GlobalPtr, Ref},
-    tx::{TxCell, TxError, TxHandle, TxObject, TxRef, UnsafeTxHandle},
+    object::{Object, ObjectBuilder, RawObject},
+    ptr::GlobalPtr,
+    tx::{TxCell, TxError, TxHandle, TxObject, UnsafeTxHandle},
 };
 
 pub struct ArenaObject {

--- a/src/lib/twizzler/src/alloc/invbox.rs
+++ b/src/lib/twizzler/src/alloc/invbox.rs
@@ -1,10 +1,8 @@
-use std::mem::MaybeUninit;
-
 use super::{Allocator, OwnedGlobalPtr};
 use crate::{
     marker::Invariant,
     ptr::{GlobalPtr, InvPtr, Ref},
-    tx::{Result, TxHandle, TxObject},
+    tx::TxObject,
 };
 
 pub struct InvBox<T: Invariant, Alloc: Allocator> {
@@ -17,7 +15,7 @@ impl<T: Invariant, Alloc: Allocator> InvBox<T, Alloc> {
         Self { raw, alloc }
     }
 
-    pub fn new<B>(tx: &TxObject<B>, ogp: OwnedGlobalPtr<T, Alloc>) -> Self {
+    pub fn new<B>(_tx: &TxObject<B>, _ogp: OwnedGlobalPtr<T, Alloc>) -> Self {
         todo!()
     }
 
@@ -32,17 +30,19 @@ impl<T: Invariant, Alloc: Allocator> InvBox<T, Alloc> {
     pub fn as_ptr(&self) -> &InvPtr<T> {
         &self.raw
     }
+
+    pub fn alloc(&self) -> &Alloc {
+        &self.alloc
+    }
 }
 
+#[cfg(test)]
 mod tests {
-    use std::{mem::MaybeUninit, ptr::addr_of_mut};
-
     use super::InvBox;
     use crate::{
-        alloc::arena::{ArenaAllocator, ArenaBase, ArenaObject},
+        alloc::arena::{ArenaAllocator, ArenaObject},
         marker::BaseType,
         object::{ObjectBuilder, TypedObject},
-        tx::{TxHandle, TxObject},
     };
 
     struct Foo {
@@ -50,6 +50,7 @@ mod tests {
     }
     impl BaseType for Foo {}
 
+    #[test]
     fn box_simple() {
         let alloc = ArenaObject::new().unwrap();
         let arena = alloc.tx().unwrap();
@@ -63,6 +64,7 @@ mod tests {
         assert_eq!(*base.x.resolve(), 3);
     }
 
+    #[test]
     fn box_simple_builder() {
         let builder = ObjectBuilder::<Foo>::default();
         let alloc = ArenaObject::new().unwrap();

--- a/src/lib/twizzler/src/collections/list.rs
+++ b/src/lib/twizzler/src/collections/list.rs
@@ -1,11 +1,10 @@
-use std::mem::MaybeUninit;
-
 use crate::{
     alloc::{invbox::InvBox, Allocator, OwnedGlobalPtr},
     marker::{BaseType, Invariant},
-    tx::{Result, TxCell, TxHandle, TxObject, TxRef},
+    tx::TxObject,
 };
 
+#[allow(dead_code)]
 pub struct ListNode<T: Invariant, A: Allocator> {
     value: T,
     next: Option<InvBox<Self, A>>,
@@ -30,14 +29,12 @@ impl<T: Invariant, A: Allocator + Clone> ListNode<T, A> {
     }
 }
 
+#[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{
-        alloc::arena::{ArenaAllocator, ArenaObject},
-        object::{ObjectBuilder, TypedObject},
-    };
+    use crate::alloc::arena::{ArenaAllocator, ArenaObject};
 
-    //#[test]
+    #[test]
     fn simple() {
         let arena = ArenaObject::new().unwrap();
         let alloc = arena.allocator();
@@ -59,7 +56,7 @@ mod tests {
         assert_eq!(rnode0.value, 3);
     }
 
-    //#[test]
+    #[test]
     fn with_boxes() {
         struct Node {
             data: InvBox<u32, ArenaAllocator>,

--- a/src/lib/twizzler/src/collections/list.rs
+++ b/src/lib/twizzler/src/collections/list.rs
@@ -64,9 +64,9 @@ mod tests {
 
         impl Node {
             fn new(
-                tx: impl AsRef<TxObject>,
-                value: u32,
-                alloc: ArenaAllocator,
+                _tx: impl AsRef<TxObject>,
+                _value: u32,
+                _alloc: ArenaAllocator,
             ) -> crate::tx::Result<Self> {
                 todo!()
             }
@@ -76,7 +76,7 @@ mod tests {
 
         let arena = ArenaObject::new().unwrap();
         let alloc = arena.allocator();
-        let data0 = arena.alloc(3);
+        let _data0 = arena.alloc(3);
         let tx = arena.tx().unwrap();
         let node0 = ListNode::new(&tx, Node::new(&tx, 3, alloc).unwrap(), None, alloc).unwrap();
         let node0 = tx.alloc(node0).unwrap();

--- a/src/lib/twizzler/src/collections/vec.rs
+++ b/src/lib/twizzler/src/collections/vec.rs
@@ -143,7 +143,7 @@ impl<T: Invariant + StoreCopy, Alloc: Allocator> Vec<T, Alloc> {
         self.do_push(item, tx)
     }
 
-    pub fn pop(&self, tx: &impl TxHandle) -> Result<T> {
+    pub fn pop(&self, _tx: &impl TxHandle) -> Result<T> {
         todo!()
     }
 }
@@ -165,6 +165,7 @@ impl<T: Invariant, Alloc: Allocator + SingleObjectAllocator> Vec<T, Alloc> {
     }
 }
 
+#[cfg(test)]
 mod tests {
     use super::*;
     use crate::{

--- a/src/lib/twizzler/src/collections/vec.rs
+++ b/src/lib/twizzler/src/collections/vec.rs
@@ -166,6 +166,7 @@ impl<T: Invariant, Alloc: Allocator + SingleObjectAllocator> Vec<T, Alloc> {
 }
 
 #[cfg(test)]
+#[allow(dead_code)]
 mod tests {
     use super::*;
     use crate::{
@@ -240,7 +241,7 @@ mod tests {
         }
     }
 
-    //#[test]
+    #[test]
     fn node_push() {
         let simple_obj = ObjectBuilder::default().build(Simple { x: 3 }).unwrap();
         let vobj = ObjectBuilder::<Vec<Node, VecObjectAlloc>>::default()
@@ -263,7 +264,7 @@ mod tests {
         assert_eq!(unsafe { item.ptr.resolve() }.x, 3);
     }
 
-    //#[test]
+    #[test]
     fn vec_object() {
         let simple_obj = ObjectBuilder::default().build(Simple { x: 3 }).unwrap();
         let vo = VecObject::new(ObjectBuilder::default()).unwrap();

--- a/src/lib/twizzler/src/object/builder.rs
+++ b/src/lib/twizzler/src/object/builder.rs
@@ -2,12 +2,12 @@ use std::{alloc::AllocError, marker::PhantomData, mem::MaybeUninit};
 
 use thiserror::Error;
 use twizzler_abi::syscall::{ObjectCreate, ObjectCreateError};
-use twizzler_rt_abi::object::{MapError, MapFlags, ObjectHandle};
+use twizzler_rt_abi::object::{MapError, MapFlags};
 
-use super::{Object, RawObject};
+use super::Object;
 use crate::{
     marker::{BaseType, StoreCopy},
-    tx::{TxHandle, TxObject},
+    tx::TxObject,
 };
 
 #[derive(Clone, Copy, Debug, Error, PartialEq, Eq)]
@@ -66,6 +66,7 @@ impl<Base: BaseType> Default for ObjectBuilder<Base> {
     }
 }
 
+#[cfg(test)]
 mod tests {
     use super::ObjectBuilder;
     use crate::{
@@ -75,6 +76,7 @@ mod tests {
         tx::{TxHandle, TxObject},
     };
 
+    #[test]
     fn builder_simple() {
         let builder = ObjectBuilder::default();
         let obj = builder.build(42u32).unwrap();
@@ -87,6 +89,7 @@ mod tests {
     }
     impl BaseType for Foo {}
 
+    #[test]
     fn builder_complex() {
         let builder = ObjectBuilder::default();
         let obj_1 = builder.build(42u32).unwrap();

--- a/src/lib/twizzler/src/object/builder.rs
+++ b/src/lib/twizzler/src/object/builder.rs
@@ -69,12 +69,7 @@ impl<Base: BaseType> Default for ObjectBuilder<Base> {
 #[cfg(test)]
 mod tests {
     use super::ObjectBuilder;
-    use crate::{
-        marker::{BaseType, StoreCopy},
-        object::TypedObject,
-        ptr::{GlobalPtr, InvPtr, Ref},
-        tx::{TxHandle, TxObject},
-    };
+    use crate::{marker::BaseType, object::TypedObject, ptr::InvPtr};
 
     #[test]
     fn builder_simple() {

--- a/src/lib/twizzler/src/object/fot.rs
+++ b/src/lib/twizzler/src/object/fot.rs
@@ -14,9 +14,8 @@ bitflags::bitflags! {
     }
 }
 
-pub type ResolverFn = extern "C" fn(ResolveRequest) -> Result<FotResolve, FotError>;
-
 #[derive(Copy, Clone, Debug, PartialEq, PartialOrd, Ord, Eq, Hash, Error)]
+#[repr(C)]
 pub enum FotError {
     #[error("invalid FOT index")]
     InvalidIndex,
@@ -24,8 +23,10 @@ pub enum FotError {
     InvalidFotEntry,
 }
 
+#[repr(C)]
 pub struct ResolveRequest {}
 
+#[repr(C)]
 pub struct FotResolve {}
 
 #[repr(C)]

--- a/src/lib/twizzler/src/ptr/global.rs
+++ b/src/lib/twizzler/src/ptr/global.rs
@@ -1,10 +1,10 @@
-use std::{marker::PhantomData, sync::atomic::AtomicU32};
+use std::marker::PhantomData;
 
 use twizzler_abi::object::ObjID;
 use twizzler_rt_abi::object::MapFlags;
 
 use super::Ref;
-use crate::object::{FotEntry, Object, RawObject};
+use crate::object::RawObject;
 
 #[derive(Debug, Default, PartialEq, PartialOrd, Ord, Eq, Hash)]
 /// A global pointer, containing a fully qualified object ID and offset.

--- a/src/lib/twizzler/src/ptr/invariant.rs
+++ b/src/lib/twizzler/src/ptr/invariant.rs
@@ -6,8 +6,8 @@ use twizzler_rt_abi::object::ObjectHandle;
 use super::{GlobalPtr, Ref};
 use crate::{
     marker::{Invariant, PhantomStoreEffect},
-    object::{FotEntry, RawObject},
-    tx::{Result, TxHandle, TxObject},
+    object::RawObject,
+    tx::TxObject,
 };
 
 #[repr(C)]

--- a/src/lib/twizzler/src/tx.rs
+++ b/src/lib/twizzler/src/tx.rs
@@ -8,7 +8,6 @@ use std::{alloc::AllocError, cell::UnsafeCell, mem::MaybeUninit};
 pub use batch::*;
 pub use object::*;
 pub use reference::*;
-use twizzler_abi::klog_println;
 use twizzler_rt_abi::object::MapError;
 pub use unsafetx::*;
 
@@ -33,8 +32,8 @@ pub trait TxHandle {
 
     fn new_box_with<T: Invariant, A: Allocator, F>(
         &self,
-        alloc: &A,
-        ctor: F,
+        _alloc: &A,
+        _ctor: F,
     ) -> Result<InvBox<T, A>>
     where
         F: FnOnce(&mut MaybeUninit<T>),

--- a/src/lib/twizzler/src/tx/batch.rs
+++ b/src/lib/twizzler/src/tx/batch.rs
@@ -1,9 +1,10 @@
 use std::marker::PhantomData;
 
-use super::{Result, TxHandle, TxObject};
+use super::{Result, TxObject};
 use crate::object::Object;
 
 #[derive(Default)]
+#[allow(dead_code)]
 pub struct TxBatch {
     txs: Vec<Box<TxObject<()>>>,
 }
@@ -20,6 +21,7 @@ impl<B> Clone for HandleIdx<B> {
 
 impl<B> Copy for HandleIdx<B> {}
 
+#[allow(unused_variables)]
 impl TxBatch {
     pub fn tx<B>(&mut self, obj: Object<B>) -> Result<HandleIdx<B>> {
         todo!()
@@ -38,6 +40,7 @@ impl TxBatch {
     }
 }
 
+#[cfg(test)]
 mod tests {
     use crate::{
         marker::BaseType,
@@ -51,6 +54,7 @@ mod tests {
 
     impl BaseType for Simple {}
 
+    #[test]
     fn simple_batch_tx() {
         let builder = ObjectBuilder::default();
         let obj1 = builder.build(Simple { x: 3 }).unwrap();

--- a/src/lib/twizzler/src/tx/object.rs
+++ b/src/lib/twizzler/src/tx/object.rs
@@ -65,7 +65,7 @@ impl<B> TxObject<MaybeUninit<B>> {
 }
 
 impl<B> TxHandle for TxObject<B> {
-    fn tx_mut(&self, data: *const u8, len: usize) -> super::Result<*mut u8> {
+    fn tx_mut(&self, data: *const u8, _len: usize) -> super::Result<*mut u8> {
         // TODO
         Ok(data as *mut u8)
     }
@@ -93,6 +93,7 @@ impl<B> AsRef<TxObject<()>> for TxObject<B> {
     }
 }
 
+#[cfg(test)]
 mod tests {
     use crate::{
         marker::BaseType,
@@ -105,6 +106,7 @@ mod tests {
 
     impl BaseType for Simple {}
 
+    #[test]
     fn single_tx() {
         let builder = ObjectBuilder::default();
         let obj = builder.build(Simple { x: 3 }).unwrap();

--- a/src/lib/twizzler/src/tx/reference.rs
+++ b/src/lib/twizzler/src/tx/reference.rs
@@ -1,11 +1,7 @@
-use std::{
-    any::TypeId,
-    mem::{ManuallyDrop, MaybeUninit},
-    ops::Deref,
-};
+use std::{mem::MaybeUninit, ops::Deref};
 
 use super::TxObject;
-use crate::{marker::BaseType, object::RawObject, ptr::RefMut};
+use crate::{object::RawObject, ptr::RefMut};
 
 pub struct TxRef<T> {
     ptr: *mut T,

--- a/src/rt/minimal/Cargo.toml
+++ b/src/rt/minimal/Cargo.toml
@@ -22,6 +22,11 @@ twizzler-abi = { path = "../../lib/twizzler-abi" }
 static_assertions = "1"
 paste = "1"
 printf-compat = { version = "0.1", default-features = false }
+spin = "*"
 
 [package.metadata]
 twizzler-build = "static"
+
+[features]
+default = ["std"]
+std = []

--- a/src/rt/minimal/src/runtime/core.rs
+++ b/src/rt/minimal/src/runtime/core.rs
@@ -3,8 +3,6 @@
 use core::{alloc::GlobalAlloc, mem::MaybeUninit, ptr};
 
 use twizzler_abi::{
-    klog_println,
-    object::ObjID,
     syscall::{sys_get_random, GetRandomFlags},
     upcall::{UpcallFlags, UpcallInfo, UpcallMode, UpcallOptions, UpcallTarget},
 };
@@ -45,7 +43,11 @@ impl MinimalRuntime {
     }
 
     pub fn abort(&self) -> ! {
-        unsafe { core::intrinsics::abort() };
+        // Unsure why this causes a warning without this.
+        #[allow(unused_unsafe)]
+        unsafe {
+            core::intrinsics::abort()
+        };
     }
 
     pub fn pre_main_hook(&self) -> Option<i32> {

--- a/src/rt/minimal/src/runtime/fs.rs
+++ b/src/rt/minimal/src/runtime/fs.rs
@@ -10,7 +10,6 @@ use rustc_alloc::sync::Arc;
 use stable_vec::{self, StableVec};
 use twizzler_abi::{
     object::{ObjID, NULLPAGE_SIZE},
-    print_err,
     simple_mutex::Mutex,
     syscall::{sys_object_create, BackingType, LifetimeType, ObjectCreate, ObjectCreateFlags},
 };
@@ -21,7 +20,7 @@ use twizzler_rt_abi::{
     object::{MapFlags, ObjectHandle},
 };
 
-use super::{object, MinimalRuntime};
+use super::MinimalRuntime;
 
 #[derive(Clone)]
 struct FileDesc {
@@ -50,7 +49,7 @@ const WRITABLE_BYTES: u64 = (1 << 26) - size_of::<FileMetadata>() as u64 - NULLP
 const OBJECT_COUNT: usize = 256;
 const DIRECT_OBJECT_COUNT: usize = 255; // The number of objects reachable from the direct pointer list
 const MAX_FILE_SIZE: u64 = WRITABLE_BYTES * 256;
-const MAX_LOADABLE_OBJECTS: usize = 16;
+const _MAX_LOADABLE_OBJECTS: usize = 16;
 lazy_static! {
     static ref FD_SLOTS: Mutex<StableVec<FdKind>> = Mutex::new(StableVec::from([
         FdKind::Stdio,
@@ -199,7 +198,7 @@ impl MinimalRuntime {
         fd: RawFd,
         off: Option<u64>,
         buf: &mut [u8],
-        flags: IoFlags,
+        _flags: IoFlags,
     ) -> Result<usize, IoError> {
         if off.is_some() {
             return Err(IoError::SeekError);
@@ -212,7 +211,7 @@ impl MinimalRuntime {
         fd: RawFd,
         off: Option<u64>,
         buf: &[u8],
-        flags: IoFlags,
+        _flags: IoFlags,
     ) -> Result<usize, IoError> {
         if off.is_some() {
             return Err(IoError::SeekError);
@@ -222,20 +221,20 @@ impl MinimalRuntime {
 
     pub fn fd_pwritev(
         &self,
-        fd: RawFd,
-        off: Option<u64>,
-        buf: &[io_vec],
-        flags: IoFlags,
+        _fd: RawFd,
+        _off: Option<u64>,
+        _buf: &[io_vec],
+        _flags: IoFlags,
     ) -> Result<usize, IoError> {
         return Err(IoError::Other);
     }
 
     pub fn fd_preadv(
         &self,
-        fd: RawFd,
-        off: Option<u64>,
-        buf: &[io_vec],
-        flags: IoFlags,
+        _fd: RawFd,
+        _off: Option<u64>,
+        _buf: &[io_vec],
+        _flags: IoFlags,
     ) -> Result<usize, IoError> {
         return Err(IoError::Other);
     }
@@ -355,7 +354,7 @@ impl MinimalRuntime {
     }
 
     pub fn close(&self, fd: RawFd) -> Option<()> {
-        let file_desc = get_fd_slots().lock().remove(fd.try_into().unwrap())?;
+        let _file_desc = get_fd_slots().lock().remove(fd.try_into().unwrap())?;
 
         Some(())
     }

--- a/src/rt/minimal/src/runtime/fs.rs
+++ b/src/rt/minimal/src/runtime/fs.rs
@@ -6,7 +6,7 @@ use core::{
 
 use lazy_static::lazy_static;
 use lru::LruCache;
-use rustc_alloc::{string::ToString, sync::Arc};
+use rustc_alloc::sync::Arc;
 use stable_vec::{self, StableVec};
 use twizzler_abi::{
     object::{ObjID, NULLPAGE_SIZE},

--- a/src/rt/minimal/src/runtime/object.rs
+++ b/src/rt/minimal/src/runtime/object.rs
@@ -1,12 +1,12 @@
 //! Implementation of the object runtime.
 
-use core::{ptr::NonNull, sync::atomic::AtomicU64};
+use core::sync::atomic::AtomicU64;
 
 use rustc_alloc::boxed::Box;
 use slot::global_allocate;
 use twizzler_abi::{
-    object::{ObjID, Protections, MAX_SIZE, NULLPAGE_SIZE},
-    syscall::{sys_object_map, ObjectMapError, UnmapFlags},
+    object::{ObjID, MAX_SIZE, NULLPAGE_SIZE},
+    syscall::{sys_object_map, UnmapFlags},
 };
 use twizzler_rt_abi::object::{MapError, MapFlags, ObjectHandle};
 
@@ -20,7 +20,7 @@ pub use handle::*;
 pub(crate) mod slot;
 
 #[repr(C)]
-struct RuntimeHandleInfo {
+pub(crate) struct RuntimeHandleInfo {
     refs: AtomicU64,
 }
 

--- a/src/rt/minimal/src/runtime/object/handle.rs
+++ b/src/rt/minimal/src/runtime/object/handle.rs
@@ -1,6 +1,6 @@
 //! Implements some helper types and functions for working with objects in this runtime.
 
-use core::{marker::PhantomData, ptr::NonNull};
+use core::marker::PhantomData;
 
 use twizzler_abi::{
     object::{ObjID, Protections, MAX_SIZE, NULLPAGE_SIZE},

--- a/src/rt/minimal/src/runtime/process.rs
+++ b/src/rt/minimal/src/runtime/process.rs
@@ -1,1 +1,1 @@
-use super::MinimalRuntime;
+

--- a/src/rt/minimal/src/runtime/syms.rs
+++ b/src/rt/minimal/src/runtime/syms.rs
@@ -1,4 +1,5 @@
 #![allow(unused_variables)]
+#![allow(non_snake_case)]
 
 // This macro checks that our definition of a function is the same as that
 // defined by the bindings generated from bindgen. Thus the whole ABI
@@ -69,7 +70,6 @@ macro_rules! check_ffi_type {
     };
 }
 
-use twizzler_abi::klog_println;
 // core.h
 use twizzler_rt_abi::bindings::option_exit_code;
 

--- a/src/rt/minimal/src/runtime/thread.rs
+++ b/src/rt/minimal/src/runtime/thread.rs
@@ -6,8 +6,8 @@ use twizzler_abi::{
     object::Protections,
     simple_mutex::Mutex,
     syscall::{
-        ThreadSpawnError, ThreadSpawnFlags, ThreadSync, ThreadSyncError, ThreadSyncFlags,
-        ThreadSyncReference, ThreadSyncSleep, ThreadSyncWake,
+        ThreadSpawnFlags, ThreadSync, ThreadSyncError, ThreadSyncFlags, ThreadSyncReference,
+        ThreadSyncSleep, ThreadSyncWake,
     },
     thread::{ExecutionState, ThreadRepr},
 };

--- a/src/rt/minimal/src/runtime/tls.rs
+++ b/src/rt/minimal/src/runtime/tls.rs
@@ -16,7 +16,7 @@ pub(crate) fn new_thread_tls() -> Option<(usize, *mut u8, usize, usize)> {
 #[allow(dead_code)]
 pub(crate) fn tls_variant1() -> Option<(usize, *mut u8, usize, usize)> {
     unsafe {
-        TLS_INFO.as_ref().map(|tls_template| {
+        TLS_INFO.r#try().map(|tls_template| {
             // TODO: reserved region may be arch specific. aarch64 reserves two
             // words after the thread pointer (TP), before any TLS blocks
             let reserved_bytes = core::mem::size_of::<*const u64>() * 2;
@@ -60,10 +60,7 @@ pub(crate) fn tls_variant1() -> Option<(usize, *mut u8, usize, usize)> {
 #[allow(dead_code)]
 pub(crate) fn tls_variant2() -> Option<(usize, *mut u8, usize, usize)> {
     unsafe {
-        if TLS_INFO.is_none() {
-            crate::print_err("No TLS_INFO\n");
-        }
-        TLS_INFO.as_ref().map(|info| {
+        TLS_INFO.r#try().map(|info| {
             let mut tls_size = info.memsz;
             tls_size += (((!tls_size) + 1) - (info.template_start as usize)) & (info.align - 1);
             let offset = tls_size;
@@ -96,10 +93,11 @@ pub(crate) struct TlsInfo {
     pub align: usize,
 }
 
-static mut TLS_INFO: Option<TlsInfo> = None;
+unsafe impl Send for TlsInfo {}
+unsafe impl Sync for TlsInfo {}
+
+static TLS_INFO: spin::Once<TlsInfo> = spin::Once::INIT;
 
 pub(super) fn set_tls_info(info: TlsInfo) {
-    unsafe {
-        TLS_INFO = Some(info);
-    }
+    TLS_INFO.call_once(|| info);
 }

--- a/src/rt/monitor-api/src/lib.rs
+++ b/src/rt/monitor-api/src/lib.rs
@@ -27,10 +27,7 @@ use secgate::{
     util::{Descriptor, Handle},
     Crossing, DynamicSecGate,
 };
-use twizzler_abi::{
-    klog_println,
-    object::{ObjID, MAX_SIZE, NULLPAGE_SIZE},
-};
+use twizzler_abi::object::{ObjID, MAX_SIZE, NULLPAGE_SIZE};
 
 #[allow(unused_imports, unused_variables, unexpected_cfgs)]
 mod gates {

--- a/src/rt/monitor/Cargo.toml
+++ b/src/rt/monitor/Cargo.toml
@@ -9,8 +9,8 @@ edition = "2021"
 twizzler-abi = { path = "../../lib/twizzler-abi", default-features = false }
 twizzler-rt-abi = "0.99"
 dynlink = { path = "../../lib/dynlink" }
-tracing = { version = "0.1", pub = false }
-tracing-subscriber = { version = "0.3", pub = false }
+tracing = { version = "0.1" }
+tracing-subscriber = { version = "0.3" }
 twizzler-runtime = { path = "../" }
 twizzler-object = { path = "../../lib/twizzler-object" }
 miette = "5.10"

--- a/src/rt/monitor/src/main.rs
+++ b/src/rt/monitor/src/main.rs
@@ -37,6 +37,7 @@ pub fn main() {
         .with_max_level(Level::INFO)
         .with_target(false)
         .with_span_events(FmtSpan::ACTIVE)
+        .without_time()
         .finish();
 
     tracing::subscriber::set_global_default(subscriber).expect("setting default subscriber failed");

--- a/src/rt/monitor/src/mon/mod.rs
+++ b/src/rt/monitor/src/mon/mod.rs
@@ -9,7 +9,7 @@ use happylock::{LockCollection, RwLock, ThreadKey};
 use monitor_api::{RuntimeThreadControl, SharedCompConfig, TlsTemplateInfo, MONITOR_INSTANCE_ID};
 use secgate::util::HandleMgr;
 use thread::DEFAULT_STACK_SIZE;
-use twizzler_abi::{klog_println, syscall::sys_thread_exit, upcall::UpcallFrame};
+use twizzler_abi::{syscall::sys_thread_exit, upcall::UpcallFrame};
 use twizzler_rt_abi::{
     object::{MapError, MapFlags, ObjID},
     thread::{SpawnError, ThreadSpawnArgs},

--- a/src/rt/monitor/tests/montest/src/main.rs
+++ b/src/rt/monitor/tests/montest/src/main.rs
@@ -33,7 +33,6 @@ mod tests {
     use std::sync::atomic::Ordering;
 
     use monitor_api::CompartmentHandle;
-    use twizzler_abi::klog_println;
 
     use crate::montest_lib;
     extern crate secgate;

--- a/src/rt/reference/src/runtime/core.rs
+++ b/src/rt/reference/src/runtime/core.rs
@@ -12,7 +12,6 @@ use monitor_api::{RuntimeThreadControl, SharedCompConfig};
 use secgate::SecGateReturn;
 use tracing::Level;
 use twizzler_abi::{
-    klog_println,
     syscall::{sys_get_random, GetRandomFlags},
     upcall::{UpcallFlags, UpcallInfo, UpcallMode, UpcallOptions, UpcallTarget},
 };

--- a/src/rt/reference/src/runtime/file.rs
+++ b/src/rt/reference/src/runtime/file.rs
@@ -7,7 +7,7 @@ use std::sync::{Arc, Mutex};
 
 use lazy_static::lazy_static;
 use lru::LruCache;
-use naming_core::dynamic::{dynamic_naming_factory, DynamicNamingHandle};
+use naming_core::dynamic::dynamic_naming_factory;
 use stable_vec::{self, StableVec};
 use twizzler_abi::{
     object::{ObjID, NULLPAGE_SIZE},
@@ -248,7 +248,7 @@ impl ReferenceRuntime {
         Some(twizzler_rt_abi::bindings::fd_info { flags: 0 })
     }
 
-    pub fn fd_cmd(&self, fd: RawFd, cmd: u32, arg: *const u8, ret: *mut u8) -> u32 {
+    pub fn fd_cmd(&self, fd: RawFd, cmd: u32, _arg: *const u8, _ret: *mut u8) -> u32 {
         tracing::warn!("fd_cmd: unimp: {} {}", fd, cmd);
         let binding = get_fd_slots().lock().unwrap();
 

--- a/src/rt/reference/src/runtime/object.rs
+++ b/src/rt/reference/src/runtime/object.rs
@@ -1,4 +1,4 @@
-use std::{ffi::c_void, mem::ManuallyDrop, sync::atomic::AtomicU64, usize::MAX};
+use std::{ffi::c_void, sync::atomic::AtomicU64};
 
 use handlecache::HandleCache;
 use tracing::warn;
@@ -101,22 +101,22 @@ impl ReferenceRuntime {
         })
     }
 
-    pub fn insert_fot(&self, handle: *mut object_handle, fot: *const u8) -> Option<u64> {
+    pub fn insert_fot(&self, _handle: *mut object_handle, _fot: *const u8) -> Option<u64> {
         tracing::warn!("TODO: insert FOT entry");
         None
     }
 
     pub fn resolve_fot(
         &self,
-        handle: *mut object_handle,
-        idx: u64,
-        valid_len: usize,
+        _handle: *mut object_handle,
+        _idx: u64,
+        _valid_len: usize,
     ) -> Result<ObjectHandle, MapError> {
         tracing::warn!("TODO: resolve FOT entry");
         Err(MapError::Other)
     }
 
-    pub fn resolve_fot_local(&self, ptr: *mut u8, idx: u64, valid_len: usize) -> *mut u8 {
+    pub fn resolve_fot_local(&self, _ptr: *mut u8, _idx: u64, _valid_len: usize) -> *mut u8 {
         tracing::warn!("TODO: resolve local FOT entry");
         core::ptr::null_mut()
     }

--- a/src/rt/reference/src/runtime/object/handlecache.rs
+++ b/src/rt/reference/src/runtime/object/handlecache.rs
@@ -95,7 +95,7 @@ impl HandleCache {
     }
 
     /// Flush all items in the inactive queue.
-    pub fn flush(&mut self) {
+    pub fn _flush(&mut self) {
         let to_remove = self.queued.drain(..).collect::<Vec<_>>();
         for item in to_remove {
             self.do_remove(item.1);

--- a/src/rt/reference/src/syms.rs
+++ b/src/rt/reference/src/syms.rs
@@ -1,6 +1,6 @@
 #![allow(unused_variables)]
+#![allow(non_snake_case)]
 
-use twizzler_abi::klog_println;
 // This macro checks that our definition of a function is the same as that
 // defined by the bindings generated from bindgen. Thus the whole ABI
 // is type-checked! The only trick is that you have to specify the number of arguments.

--- a/src/srv/naming-srv/src/lib.rs
+++ b/src/srv/naming-srv/src/lib.rs
@@ -1,10 +1,7 @@
 #![feature(naked_functions)]
 #![feature(linkage)]
 
-use std::{
-    default,
-    sync::{Arc, Mutex},
-};
+use std::sync::Mutex;
 
 use arrayvec::ArrayString;
 use lazy_static::lazy_static;
@@ -14,10 +11,8 @@ use secgate::{
     util::{Descriptor, HandleMgr, SimpleBuffer},
 };
 use twizzler::{
-    collections::vec::{Vec, VecObject, VecObjectAlloc},
-    marker::Invariant,
-    object::{Object, ObjectBuilder, TypedObject},
-    ptr::GlobalPtr,
+    collections::vec::{VecObject, VecObjectAlloc},
+    object::ObjectBuilder,
 };
 use twizzler_abi::{
     aux::KernelInitInfo,
@@ -125,12 +120,13 @@ pub fn put(info: &secgate::GateCallInfo, desc: Descriptor) {
         }
     }
 
-    namer.names.push(provided);
+    // TODO: handle error
+    let _ = namer.names.push(provided);
 }
 
 #[secure_gate(options(info))]
 pub fn get(info: &secgate::GateCallInfo, desc: Descriptor) -> Option<u128> {
-    let mut namer = NAMINGSERVICE.lock().unwrap();
+    let namer = NAMINGSERVICE.lock().unwrap();
     let client = namer
         .handles
         .lookup(info.source_context().unwrap_or(0.into()), desc)?;
@@ -172,7 +168,7 @@ pub fn close_handle(info: &secgate::GateCallInfo, desc: Descriptor) {
 
 #[secure_gate(options(info))]
 pub fn enumerate_names(info: &secgate::GateCallInfo, desc: Descriptor) -> Option<usize> {
-    let mut namer = NAMINGSERVICE.lock().unwrap();
+    let namer = NAMINGSERVICE.lock().unwrap();
     let Some(client) = namer
         .handles
         .lookup(info.source_context().unwrap_or(0.into()), desc)
@@ -194,7 +190,7 @@ pub fn enumerate_names(info: &secgate::GateCallInfo, desc: Descriptor) -> Option
 }
 
 #[secure_gate(options(info))]
-pub fn remove(info: &secgate::GateCallInfo, desc: Descriptor) {
+pub fn remove(_info: &secgate::GateCallInfo, _desc: Descriptor) {
     todo!()
     /*let mut namer = NAMINGSERVICE.inner.lock().unwrap();
     let Some(client) = namer

--- a/src/srv/pager-srv/object-store/src/fs.rs
+++ b/src/srv/pager-srv/object-store/src/fs.rs
@@ -1,6 +1,4 @@
-use std::sync::{LazyLock, Mutex};
-
-use fatfs::{FatType, FileSystem, FormatVolumeOptions};
+use fatfs::{FatType, FormatVolumeOptions};
 
 use super::disk::Disk;
 

--- a/src/srv/pager-srv/object-store/src/object_store.rs
+++ b/src/srv/pager-srv/object-store/src/object_store.rs
@@ -1,7 +1,7 @@
 use std::{
     collections::HashSet,
     io::Error,
-    sync::{LazyLock, Mutex, MutexGuard, OnceLock},
+    sync::{LazyLock, Mutex, MutexGuard},
 };
 
 use chacha20::{
@@ -109,7 +109,7 @@ pub fn format() {
     let mut disk = DISK.get().unwrap().clone();
     fs::format(&mut disk);
     drop(disk);
-    let mut fs = FS.get().unwrap().lock().unwrap();
+    let fs = FS.get().unwrap().lock().unwrap();
     crate::disk::init(EXECUTOR.get().unwrap());
     drop(fs);
     let mut khf = KHF.lock().unwrap();
@@ -134,8 +134,8 @@ pub fn disk_length(obj_id: u128) -> Result<u64, Error> {
 /// Either gets a previously set config_id from disk or returns None
 pub fn get_config_id() -> Result<Option<u128>, Error> {
     let _unused = LOCK.lock().unwrap();
-    let mut fs = FS.get().unwrap().lock().unwrap();
-    let mut file = fs.root_dir().open_file("config_id");
+    let fs = FS.get().unwrap().lock().unwrap();
+    let file = fs.root_dir().open_file("config_id");
     let mut file = match file {
         Ok(file) => file,
         Err(fatfs::Error::NotFound) => return Ok(None),
@@ -148,7 +148,7 @@ pub fn get_config_id() -> Result<Option<u128>, Error> {
 
 pub fn set_config_id(id: u128) -> Result<(), Error> {
     let _unused = LOCK.lock().unwrap();
-    let mut fs = FS.get().unwrap().lock().unwrap();
+    let fs = FS.get().unwrap().lock().unwrap();
     let mut file = fs.root_dir().create_file("config_id")?;
     file.truncate()?;
     let bytes = id.to_le_bytes();
@@ -158,8 +158,8 @@ pub fn set_config_id(id: u128) -> Result<(), Error> {
 
 pub fn clear_config_id() -> Result<(), Error> {
     let _unused = LOCK.lock().unwrap();
-    let mut fs = FS.get().unwrap().lock().unwrap();
-    let mut file = fs.root_dir().remove("config_id")?;
+    let fs = FS.get().unwrap().lock().unwrap();
+    let _file = fs.root_dir().remove("config_id")?;
     Ok(())
 }
 

--- a/src/srv/pager-srv/src/data.rs
+++ b/src/srv/pager-srv/src/data.rs
@@ -1,11 +1,9 @@
 use std::{
-    collections::{BTreeMap, HashMap, VecDeque},
-    default,
+    collections::HashMap,
     sync::{Arc, Mutex},
 };
 
 use bitvec::prelude::*;
-use futures::TryFutureExt;
 use miette::Result;
 use twizzler_abi::pager::{
     CompletionToPager, ObjectInfo, ObjectRange, PhysRange, RequestFromPager,
@@ -24,6 +22,7 @@ pub struct PerPageData {
 
 #[derive(Default)]
 pub struct PerObjectInner {
+    #[allow(dead_code)]
     id: ObjID,
     page_map: HashMap<PageNum, PerPageData>,
     meta_page_map: HashMap<PageNum, PerPageData>,
@@ -44,7 +43,7 @@ impl PerObjectInner {
         }
     }
 
-    pub fn track_meta(&mut self, obj_range: ObjectRange, phys_range: PhysRange) {
+    pub fn _track_meta(&mut self, obj_range: ObjectRange, phys_range: PhysRange) {
         assert_eq!(obj_range.len(), PAGE as usize);
         assert_eq!(phys_range.len(), PAGE as usize);
 
@@ -181,7 +180,7 @@ impl PagerDataInner {
     }
 
     /// Remove a page from the bit vector, freeing it for future use.
-    fn remove_page(&mut self, page_number: usize) {
+    fn _remove_page(&mut self, page_number: usize) {
         tracing::trace!("attempting to remove page {}", page_number);
         if page_number < self.bitvec.len() {
             self.bitvec.set(page_number, false);
@@ -207,7 +206,7 @@ impl PagerDataInner {
     }
 
     /// Check if all pages are currently in use.
-    pub fn is_full(&self) -> bool {
+    pub fn _is_full(&self) -> bool {
         let full = self.bitvec.all();
         tracing::trace!("bitvec check full: {}", full);
         full

--- a/src/srv/pager-srv/src/helpers.rs
+++ b/src/srv/pager-srv/src/helpers.rs
@@ -1,4 +1,4 @@
-use std::{io::Error, sync::Arc};
+use std::sync::Arc;
 
 use miette::{IntoDiagnostic, Result};
 use twizzler_abi::pager::{CompletionToPager, ObjectRange, PhysRange, RequestFromPager};
@@ -32,7 +32,7 @@ pub fn page_to_physrange(page_num: usize, range_start: u64) -> PhysRange {
 /// Converts an `ObjectRange` representing a single page into the page number.
 /// Assumes the range is within a valid memory mapping and spans exactly one page (4096 bytes).
 /// Returns the page number starting at 0.
-pub fn objectrange_to_page_number(object_range: &ObjectRange) -> Option<u64> {
+pub fn _objectrange_to_page_number(object_range: &ObjectRange) -> Option<u64> {
     if object_range.end - object_range.start != PAGE {
         return None; // Invalid ObjectRange for a single page
     }
@@ -123,24 +123,24 @@ mod tests {
             start: 0,
             end: 4096,
         };
-        assert_eq!(objectrange_to_page_number(&range), Some(0));
+        assert_eq!(_objectrange_to_page_number(&range), Some(0));
 
         let range = ObjectRange {
             start: 4096,
             end: 8192,
         };
-        assert_eq!(objectrange_to_page_number(&range), Some(1));
+        assert_eq!(_objectrange_to_page_number(&range), Some(1));
 
         let range = ObjectRange {
             start: 0,
             end: 8192,
         }; // Invalid range for one page
-        assert_eq!(objectrange_to_page_number(&range), None);
+        assert_eq!(_objectrange_to_page_number(&range), None);
 
         let range = ObjectRange {
             start: 8192,
             end: 12288,
         };
-        assert_eq!(objectrange_to_page_number(&range), Some(2));
+        assert_eq!(_objectrange_to_page_number(&range), Some(2));
     }
 }

--- a/tools/xtask/src/build.rs
+++ b/tools/xtask/src/build.rs
@@ -253,7 +253,7 @@ fn build_twizzler<'a>(
 fn maybe_build_tests_dynamic<'a>(
     workspace: &'a Workspace,
     build_config: &crate::BuildConfig,
-    static_compilation: &Option<Compilation<'a>>,
+    _static_compilation: &Option<Compilation<'a>>,
     other_options: &OtherOptions,
 ) -> anyhow::Result<Option<Compilation<'a>>> {
     let mode = CompileMode::Test;
@@ -269,7 +269,7 @@ fn maybe_build_tests_dynamic<'a>(
         crate::triple::Host::Twizzler,
         None,
     );
-    let mut packages = locate_packages(workspace, None);
+    let packages = locate_packages(workspace, None);
     let mut options = CompileOptions::new(workspace.gctx(), mode)?;
     options.build_config =
         BuildConfig::new(workspace.gctx(), None, false, &[triple.to_string()], mode)?;


### PR DESCRIPTION
This PR cleans up warnings from the new toolchain (mostly this was fixing static muts and removing unused imports) and formatting.

Lots of churn, very little semantically different.