### PR TITLE
Added Removing to Naming

### DIFF
--- a/src/bin/init/Cargo.toml
+++ b/src/bin/init/Cargo.toml
@@ -20,3 +20,4 @@ futures = "*"
 twizzler-futures = { path = "../../lib/twizzler-futures" }
 monitor-api = { path = "../../rt/monitor-api" }
 twizzler = { path = "../../lib/twizzler" }
+naming-core = { path = "../../lib/naming/naming-core" }

--- a/src/bin/init/src/main.rs
+++ b/src/bin/init/src/main.rs
@@ -68,13 +68,10 @@ fn initialize_namer(bootstrap: ObjID) {
 
     let mut handle = dynamic_naming_factory().unwrap();
     let kernel_init_info = get_kernel_init_info();
-
-    // Load the initrd names from the kernel, removing the old names
-    // Maybe there should be a mounting system or something?
-    //handle.remove("/initrd", true);
-    handle.put_namespace("/initrd");
+    let _ = handle.remove("/initrd", true);
+    let _ = handle.put_namespace("/initrd");
     for name in kernel_init_info.names() {
-        handle.put(&format!("/initrd/{}", name.name()), name.id().raw());
+        let _ = handle.put(&format!("/initrd/{}", name.name()), name.id().raw());
     }
 
     tracing::info!("naming ready");
@@ -147,11 +144,12 @@ fn main() {
     initialize_pager();
     std::mem::forget(dev_comp);
 
-    let foo: VecObject<u32, VecObjectAlloc> = VecObject::new(ObjectBuilder::default().persist()).unwrap();
-    // This id will be loaded from the object store
+    // This will be loaded from the object store instead
+    let foo: VecObject<u32, VecObjectAlloc> =
+        VecObject::new(ObjectBuilder::default().persist()).unwrap();
     let id = foo.object().id();
     initialize_namer(id);
-    
+
     run_tests("test_bins", false);
     run_tests("bench_bins", true);
 
@@ -237,8 +235,12 @@ fn run_tests(test_list_name: &str, benches: bool) {
 }
 
 use monitor_api::{CompartmentFlags, CompartmentHandle, CompartmentLoader, NewCompartmentFlags};
+use naming_core::dynamic::dynamic_naming_factory;
 use tracing::{debug, info, warn};
-use twizzler::{collections::vec::{VecObject, VecObjectAlloc}, object::{ObjectBuilder, RawObject}};
+use twizzler::{
+    collections::vec::{VecObject, VecObjectAlloc},
+    object::{ObjectBuilder, RawObject},
+};
 use twizzler_abi::{
     aux::KernelInitInfo,
     object::{ObjID, Protections, MAX_SIZE, NULLPAGE_SIZE},
@@ -249,4 +251,3 @@ use twizzler_abi::{
     },
 };
 use twizzler_object::{CreateSpec, Object, ObjectInitFlags};
-use naming_core::dynamic::dynamic_naming_factory;

--- a/src/bin/naming-test/src/main.rs
+++ b/src/bin/naming-test/src/main.rs
@@ -5,7 +5,6 @@ use naming_core::{Entry, EntryType, ErrorKind, NameStore};
 fn test_single_put_then_get() {
     println!("doing test_single_put_then_get");
     let store = NameStore::new();
-
     let session = store.root_session();
     assert_eq!(session.put("foo", EntryType::Object(1)), Ok(()));
     assert_eq!(
@@ -125,7 +124,7 @@ fn traverse_namespace_nested_1() {
 }
 
 fn traverse_namespace_nested_2() {
-    println!("doing test_traverse_namespace");
+    println!("doing test_traverse_namespace_2");
 
     let store = NameStore::new();
 
@@ -254,6 +253,79 @@ fn traverse_namespace_nested_2() {
     );
 }
 
+fn remove() {
+    println!("doing remove");
+
+    let store = NameStore::new();
+
+    let mut session = store.root_session();
+    session.put("/a", EntryType::Object(1));
+    assert_eq!(session.get("/a"), Entry::try_new("a", EntryType::Object(1)));
+    assert_eq!(session.remove("a", false), Ok(()));
+    assert_eq!(session.get("/a"), Err(ErrorKind::NotFound));
+
+    session.put("/a", EntryType::Object(1));
+    assert_eq!(session.get("/a"), Entry::try_new("a", EntryType::Object(1)));
+}
+
+fn remove_nested() {
+    println!("doing remove_nested");
+
+    let store = NameStore::new();
+
+    let mut session = store.root_session();
+    session.put("/b", EntryType::Object(1));
+    session.put("/c", EntryType::Object(1));
+    session.put("/a", EntryType::Namespace);
+    session.put("/a/a", EntryType::Namespace);
+    session.put("/a/a/a", EntryType::Object(1));
+    session.put("/a/a/b", EntryType::Object(2));
+    
+    assert_eq!(session.get("/a/a/a"), Entry::try_new("a", EntryType::Object(1)));
+    assert_eq!(session.remove("/a/a", false), Err(ErrorKind::NotFile));
+    assert_eq!(session.remove("/a/a/a", false), Ok(()));
+
+    assert_eq!(session.remove("b", false), Ok(()));
+    assert_eq!(session.remove("c", false), Ok(()));
+    assert_eq!(session.get("/a/a/a"), Err(ErrorKind::NotFound));
+    assert_eq!(session.get("/a/a/b"), Entry::try_new("b", EntryType::Object(2)));
+}
+
+fn remove_recursive() {
+    println!("doing remove_recursive");
+
+    let store = NameStore::new();
+
+    let mut session = store.root_session();
+
+    session.put("/a", EntryType::Namespace);
+    session.put("/b", EntryType::Namespace);
+    session.put("/a/c", EntryType::Namespace);
+    session.put("/a/d", EntryType::Namespace);
+    session.put("/b/e", EntryType::Namespace);
+    session.put("/b/f", EntryType::Namespace);
+    session.put("/g", EntryType::Object(0));
+    session.put("/h", EntryType::Object(1));
+    session.put("/a/i", EntryType::Object(0));
+    session.put("/b/j", EntryType::Object(1));
+    
+    assert_eq!(session.remove("a", true), Ok(()));
+    assert_eq!(session.remove("a", true), Err(ErrorKind::NotFound));
+
+    assert_eq!(session.get("b"), Entry::try_new("b", EntryType::Namespace));
+    assert_eq!(session.get("b/e"), Entry::try_new("e", EntryType::Namespace));
+    assert_eq!(session.get("b/f"), Entry::try_new("f", EntryType::Namespace));
+    assert_eq!(session.get("g"), Entry::try_new("g", EntryType::Object(0)));
+    assert_eq!(session.get("h"), Entry::try_new("h", EntryType::Object(1)));
+    
+    assert_eq!(session.remove("b", true), Ok(()));
+
+    assert_eq!(session.get("e"), Err(ErrorKind::NotFound));
+    assert_eq!(session.get("f"), Err(ErrorKind::NotFound));
+    assert_eq!(session.get("g"), Entry::try_new("g", EntryType::Object(0)));
+    assert_eq!(session.get("h"), Entry::try_new("h", EntryType::Object(1)));
+}
+
 fn main() {
     test_single_put_then_get();
     test_multi_put_then_get();
@@ -261,4 +333,7 @@ fn main() {
     namespace_nested();
     traverse_namespace_nested_1();
     traverse_namespace_nested_2();
+    remove();
+    remove_nested();
+    remove_recursive();
 }

--- a/src/bin/naming-test/src/main.rs
+++ b/src/bin/naming-test/src/main.rs
@@ -257,14 +257,13 @@ fn remove() {
     println!("doing remove");
 
     let store = NameStore::new();
+    let session = store.root_session();
 
-    let mut session = store.root_session();
-    session.put("/a", EntryType::Object(1));
+    assert_eq!(session.put("/a", EntryType::Object(1)), Ok(()));
     assert_eq!(session.get("/a"), Entry::try_new("a", EntryType::Object(1)));
     assert_eq!(session.remove("a", false), Ok(()));
     assert_eq!(session.get("/a"), Err(ErrorKind::NotFound));
-
-    session.put("/a", EntryType::Object(1));
+    assert_eq!(session.put("/a", EntryType::Object(1)), Ok(()));
     assert_eq!(session.get("/a"), Entry::try_new("a", EntryType::Object(1)));
 }
 
@@ -272,23 +271,29 @@ fn remove_nested() {
     println!("doing remove_nested");
 
     let store = NameStore::new();
-
-    let mut session = store.root_session();
-    session.put("/b", EntryType::Object(1));
-    session.put("/c", EntryType::Object(1));
-    session.put("/a", EntryType::Namespace);
-    session.put("/a/a", EntryType::Namespace);
-    session.put("/a/a/a", EntryType::Object(1));
-    session.put("/a/a/b", EntryType::Object(2));
+    let session = store.root_session();
     
-    assert_eq!(session.get("/a/a/a"), Entry::try_new("a", EntryType::Object(1)));
+    assert_eq!(session.put("/b", EntryType::Object(1)), Ok(()));
+    assert_eq!(session.put("/c", EntryType::Object(1)), Ok(()));
+    assert_eq!(session.put("/a", EntryType::Namespace), Ok(()));
+    assert_eq!(session.put("/a/a", EntryType::Namespace), Ok(()));
+    assert_eq!(session.put("/a/a/a", EntryType::Object(1)), Ok(()));
+    assert_eq!(session.put("/a/a/b", EntryType::Object(2)), Ok(()));
+
+    assert_eq!(
+        session.get("/a/a/a"),
+        Entry::try_new("a", EntryType::Object(1))
+    );
     assert_eq!(session.remove("/a/a", false), Err(ErrorKind::NotFile));
     assert_eq!(session.remove("/a/a/a", false), Ok(()));
 
     assert_eq!(session.remove("b", false), Ok(()));
     assert_eq!(session.remove("c", false), Ok(()));
     assert_eq!(session.get("/a/a/a"), Err(ErrorKind::NotFound));
-    assert_eq!(session.get("/a/a/b"), Entry::try_new("b", EntryType::Object(2)));
+    assert_eq!(
+        session.get("/a/a/b"),
+        Entry::try_new("b", EntryType::Object(2))
+    );
 }
 
 fn remove_recursive() {
@@ -296,28 +301,34 @@ fn remove_recursive() {
 
     let store = NameStore::new();
 
-    let mut session = store.root_session();
+    let session = store.root_session();
 
-    session.put("/a", EntryType::Namespace);
-    session.put("/b", EntryType::Namespace);
-    session.put("/a/c", EntryType::Namespace);
-    session.put("/a/d", EntryType::Namespace);
-    session.put("/b/e", EntryType::Namespace);
-    session.put("/b/f", EntryType::Namespace);
-    session.put("/g", EntryType::Object(0));
-    session.put("/h", EntryType::Object(1));
-    session.put("/a/i", EntryType::Object(0));
-    session.put("/b/j", EntryType::Object(1));
-    
+    assert_eq!(session.put("/a", EntryType::Namespace), Ok(()));
+    assert_eq!(session.put("/b", EntryType::Namespace), Ok(()));
+    assert_eq!(session.put("/a/c", EntryType::Namespace), Ok(()));
+    assert_eq!(session.put("/a/d", EntryType::Namespace), Ok(()));
+    assert_eq!(session.put("/b/e", EntryType::Namespace), Ok(()));
+    assert_eq!(session.put("/b/f", EntryType::Namespace), Ok(()));
+    assert_eq!(session.put("/g", EntryType::Object(0)), Ok(()));
+    assert_eq!(session.put("/h", EntryType::Object(1)), Ok(()));
+    assert_eq!(session.put("/a/i", EntryType::Object(0)), Ok(()));
+    assert_eq!(session.put("/b/j", EntryType::Object(1)), Ok(()));
+
     assert_eq!(session.remove("a", true), Ok(()));
     assert_eq!(session.remove("a", true), Err(ErrorKind::NotFound));
 
     assert_eq!(session.get("b"), Entry::try_new("b", EntryType::Namespace));
-    assert_eq!(session.get("b/e"), Entry::try_new("e", EntryType::Namespace));
-    assert_eq!(session.get("b/f"), Entry::try_new("f", EntryType::Namespace));
+    assert_eq!(
+        session.get("b/e"),
+        Entry::try_new("e", EntryType::Namespace)
+    );
+    assert_eq!(
+        session.get("b/f"),
+        Entry::try_new("f", EntryType::Namespace)
+    );
     assert_eq!(session.get("g"), Entry::try_new("g", EntryType::Object(0)));
     assert_eq!(session.get("h"), Entry::try_new("h", EntryType::Object(1)));
-    
+
     assert_eq!(session.remove("b", true), Ok(()));
 
     assert_eq!(session.get("e"), Err(ErrorKind::NotFound));

--- a/src/bin/naming-test/src/main.rs
+++ b/src/bin/naming-test/src/main.rs
@@ -272,7 +272,7 @@ fn remove_nested() {
 
     let store = NameStore::new();
     let session = store.root_session();
-    
+
     assert_eq!(session.put("/b", EntryType::Object(1)), Ok(()));
     assert_eq!(session.put("/c", EntryType::Object(1)), Ok(()));
     assert_eq!(session.put("/a", EntryType::Namespace), Ok(()));
@@ -337,6 +337,23 @@ fn remove_recursive() {
     assert_eq!(session.get("h"), Entry::try_new("h", EntryType::Object(1)));
 }
 
+fn load_from_object() {
+    println!("doing load_from_object");
+
+    let id = {
+        let store = NameStore::new();
+        let session = store.root_session();
+        session.put("a", EntryType::Name).unwrap();
+        store.id()
+    };
+
+    {
+        let store = NameStore::new_in(id).expect("NameStore should have loaded properly");
+        let session = store.root_session();
+        assert_eq!(session.get("a"), Entry::try_new("a", EntryType::Name));
+    }
+}
+
 fn main() {
     test_single_put_then_get();
     test_multi_put_then_get();
@@ -347,4 +364,5 @@ fn main() {
     remove();
     remove_nested();
     remove_recursive();
+    load_from_object();
 }

--- a/src/lib/naming/naming-core/src/api.rs
+++ b/src/lib/naming/naming-core/src/api.rs
@@ -10,6 +10,6 @@ pub trait NamerAPI {
     fn open_handle(&self) -> SecGateReturn<Option<(Descriptor, ObjID)>>;
     fn close_handle(&self, desc: Descriptor) -> SecGateReturn<()>;
     fn enumerate_names(&self, desc: Descriptor) -> SecGateReturn<Result<usize>>;
-    fn remove(&self, desc: Descriptor) -> SecGateReturn<Result<()>>;
+    fn remove(&self, desc: Descriptor, recursive: bool) -> SecGateReturn<Result<()>>;
     fn change_namespace(&self, desc: Descriptor) -> SecGateReturn<Result<()>>;
 }

--- a/src/lib/naming/naming-core/src/dynamic.rs
+++ b/src/lib/naming/naming-core/src/dynamic.rs
@@ -13,7 +13,7 @@ pub struct DynamicNamerAPI {
     open_handle: DynamicSecGate<'static, (), Option<(Descriptor, ObjID)>>,
     close_handle: DynamicSecGate<'static, (Descriptor,), ()>,
     enumerate_names: DynamicSecGate<'static, (Descriptor,), Result<usize>>,
-    remove: DynamicSecGate<'static, (Descriptor, bool,), Result<()>>,
+    remove: DynamicSecGate<'static, (Descriptor, bool), Result<()>>,
     change_namespace: DynamicSecGate<'static, (Descriptor,), Result<()>>,
 }
 

--- a/src/lib/naming/naming-core/src/dynamic.rs
+++ b/src/lib/naming/naming-core/src/dynamic.rs
@@ -13,7 +13,7 @@ pub struct DynamicNamerAPI {
     open_handle: DynamicSecGate<'static, (), Option<(Descriptor, ObjID)>>,
     close_handle: DynamicSecGate<'static, (Descriptor,), ()>,
     enumerate_names: DynamicSecGate<'static, (Descriptor,), Result<usize>>,
-    remove: DynamicSecGate<'static, (Descriptor,), Result<()>>,
+    remove: DynamicSecGate<'static, (Descriptor, bool,), Result<()>>,
     change_namespace: DynamicSecGate<'static, (Descriptor,), Result<()>>,
 }
 
@@ -38,8 +38,8 @@ impl NamerAPI for DynamicNamerAPI {
         (self.enumerate_names)(desc)
     }
 
-    fn remove(&self, desc: Descriptor) -> SecGateReturn<Result<()>> {
-        (self.remove)(desc)
+    fn remove(&self, desc: Descriptor, recursive: bool) -> SecGateReturn<Result<()>> {
+        (self.remove)(desc, recursive)
     }
 
     fn change_namespace(&self, desc: Descriptor) -> SecGateReturn<Result<()>> {
@@ -83,7 +83,7 @@ pub fn dynamic_namer_api() -> &'static DynamicNamerAPI {
             },
             remove: unsafe {
                 handle
-                    .dynamic_gate::<(Descriptor,), Result<()>>("remove")
+                    .dynamic_gate::<(Descriptor, bool), Result<()>>("remove")
                     .expect("failed to find remove gate call")
             },
             change_namespace: unsafe {

--- a/src/lib/naming/naming-core/src/handle.rs
+++ b/src/lib/naming/naming-core/src/handle.rs
@@ -46,13 +46,13 @@ impl<'a, API: NamerAPI> NamingHandle<'a, API> {
         }
     }
 
-    pub fn remove(&mut self, path: &str) -> Result<()> {
+    pub fn remove(&mut self, path: &str, recursive: bool) -> Result<()> {
         let s = Entry::try_new(path, EntryType::Namespace)?;
 
         let bytes = unsafe { std::mem::transmute::<Entry, [u8; std::mem::size_of::<Entry>()]>(s) };
         let _handle = self.buffer.write(&bytes);
 
-        self.api.remove(self.desc).unwrap()
+        self.api.remove(self.desc, recursive).unwrap()
     }
 
     pub fn enumerate_names_relative(&mut self, path: &str) -> Result<Vec<Entry>> {

--- a/src/lib/naming/naming-core/src/store.rs
+++ b/src/lib/naming/naming-core/src/store.rs
@@ -1,16 +1,15 @@
 use std::{
-    collections::VecDeque,
-    path::{Component, Path, PathBuf},
-    sync::{Mutex, MutexGuard},
+    collections::{HashSet, VecDeque}, hash::Hash, mem::{swap, MaybeUninit}, ops::DerefMut, path::{Component, Path, PathBuf}, sync::{Mutex, MutexGuard}
 };
 
 use arrayvec::ArrayString;
 use twizzler::{
     collections::vec::{VecObject, VecObjectAlloc},
     marker::Invariant,
-    object::ObjectBuilder,
+    object::{Object, ObjectBuilder},
     ptr::Ref,
 };
+use twizzler_rt_abi::object::{ObjID, MapFlags};
 
 use crate::{error::ErrorKind, Result, MAX_KEY_SIZE};
 
@@ -55,6 +54,28 @@ struct Node {
     entry: Entry,
 }
 
+impl Node {
+    fn is_namespace(&self) -> bool {
+        self.entry.entry_type == EntryType::Namespace
+    }
+
+    fn is_object(&self) -> bool {
+        self.entry.entry_type == EntryType::Namespace
+    }
+
+    fn id(&self) -> Option<u128> {
+        match self.entry.entry_type {
+            EntryType::Namespace => None,
+            EntryType::Object(x) => Some(x),
+            EntryType::Name => None,
+        }
+    }
+
+    fn name(&self) -> ArrayString<MAX_KEY_SIZE> {
+        self.entry.name.clone()
+    }
+}
+
 unsafe impl Invariant for Node {}
 
 // Ideally when transactions are finished the mutex is unnecessary
@@ -70,7 +91,7 @@ unsafe impl Sync for NameStore {}
 // existing I can finally make this a tree instead of a flat vec
 impl NameStore {
     pub fn new() -> NameStore {
-        let mut store = VecObject::new(ObjectBuilder::default()).unwrap();
+        let mut store = VecObject::new(ObjectBuilder::default().persist()).unwrap();
         store
             .push(Node {
                 parent: 0,
@@ -78,9 +99,30 @@ impl NameStore {
                 entry: Entry::try_new("/", EntryType::Namespace).unwrap(),
             })
             .unwrap();
+        
         NameStore {
             name_universe: Mutex::new(store),
         }
+    }
+
+    // Loads in an existing object store from an Object ID
+    pub fn new_in(id: ObjID) -> Result<NameStore> {
+        let mut store = VecObject::from(Object::map(id, MapFlags::READ | MapFlags::WRITE | MapFlags::PERSIST).map_err(|_| ErrorKind::NotFound)?);
+
+        // todo make "/" not an entry
+        if store.get(0).is_none() {
+            store
+                .push(Node {
+                    parent: 0,
+                    curr: 0,
+                    entry: Entry::try_new("/", EntryType::Namespace).unwrap(),
+                })
+                .unwrap();
+        
+        }
+        Ok(NameStore {
+            name_universe: Mutex::new(store),
+        })
     }
 
     // session is created from root
@@ -287,8 +329,104 @@ impl NameSession<'_> {
         }
     }
 
-    // It's good that this doesn't exist yet because it would be really bad if it did
-    pub fn remove<P: AsRef<Path>>(&self, _name: P) {
-        todo!()
+    pub fn remove<P: AsRef<Path>>(&self, name: P, recursive: bool) -> Result<()> {
+        let mut store = self
+            .store
+            .name_universe
+            .lock()
+            .map_err(|_| ErrorKind::Other)?;
+
+        let entry = self.namei(&store, &name)?;
+        let index = entry.curr;
+        if !recursive && entry.entry.entry_type == EntryType::Namespace {
+            return Err(ErrorKind::NotFile);
+        }
+        if entry.curr == 0 {
+            return Err(ErrorKind::InvalidName);
+        }
+
+        drop(entry);
+        
+        // Copies a node to another index. If it's a directory
+        // it will fix all the child nodes if they exist
+        unsafe fn swap_node(store: &MutexGuard<VecObject<Node, VecObjectAlloc>>, old: usize, new: usize) {
+            let mut old_node = store.get(old).unwrap().mutable();
+            let mut new_node = store.get(new).unwrap().mutable();
+            std::ptr::swap(old_node.raw(), new_node.raw());
+            std::mem::swap(&mut old_node.curr, &mut new_node.curr);
+
+            unsafe {
+                for i in 0..store.len() {
+                    let mut node = unsafe { store.get(i).unwrap().mutable()};
+                    // If the node's parent is pointing to where the swapped node is, fix it
+                    if old_node.is_namespace() && node.parent == new_node.curr {
+                        node.parent = old_node.curr;
+                    }
+                    if new_node.is_namespace() && node.parent == old_node.curr {
+                        node.parent = new_node.curr;
+                    }
+                }
+            }
+
+        };
+
+        fn recurse_helper(store: &MutexGuard<VecObject<Node, VecObjectAlloc>>, set: &mut HashSet<usize>, index: usize) {
+            let node: Ref<'_, Node> = store.get(index).unwrap();
+            set.insert(index);
+            if !node.is_namespace() {
+                return;
+            }
+            for i in 1..store.len() {
+                let candidate = store.get(i).unwrap();
+                if candidate.parent != node.curr { continue; }
+                recurse_helper(store, set, candidate.curr);
+            }
+        };
+
+        if recursive {
+            let mut candidates = HashSet::new();
+            recurse_helper(&store, &mut candidates, index);
+            let candidates_num = candidates.len();
+            // Swap valid nodes to the left with all invalid nodes to the right
+            // Then trim the vector of invalid nodes
+            let mut left: usize = 1;
+            let mut right: usize = store.len() - 1;            
+            while left < right {
+                let left_node: Ref<'_, Node> = store.get(left).unwrap();
+                let right_node: Ref<'_, Node> = store.get(right).unwrap();
+                
+                // I want the right node to contain a valid node that is able to be swapped
+                // If the left node contains an invalid node...
+                match (candidates.contains(&left_node.curr), candidates.contains(&right_node.curr)) {
+                    (true, true) => {
+                        right -= 1; // right fish for valid
+                    },
+                    (true, false) => {
+                        candidates.remove(&left);
+                        unsafe { swap_node(&store, left, right) }; // swap left and right
+                        right -= 1;
+                    },
+                    (false, true) => {
+                        right -= 1;
+                    },
+                    (false, false) => {
+                        left += 1; // left fish for invalid
+                    },
+                }
+            }
+
+            // pop off all the candidates 
+            for i in 0..candidates_num {
+                let end = store.len();
+                store.remove(end - 1);
+            }
+        }
+        else {
+            unsafe { swap_node(&store, index, store.len() - 1) };
+            let end = store.len();
+            store.remove(end - 1);
+        }
+
+        Ok(())
     }
 }

--- a/src/lib/naming/naming-core/src/store.rs
+++ b/src/lib/naming/naming-core/src/store.rs
@@ -8,7 +8,7 @@ use arrayvec::ArrayString;
 use twizzler::{
     collections::vec::{VecObject, VecObjectAlloc},
     marker::Invariant,
-    object::{Object, ObjectBuilder},
+    object::{Object, ObjectBuilder, RawObject},
     ptr::Ref,
 };
 use twizzler_rt_abi::object::{MapFlags, ObjID};
@@ -85,6 +85,7 @@ unsafe impl Invariant for Node {}
 // Though I don't know how to write this without the mutex :think:
 pub struct NameStore {
     name_universe: Mutex<VecObject<Node, VecObjectAlloc>>,
+    backing_id: ObjID,
 }
 
 unsafe impl Send for NameStore {}
@@ -102,9 +103,10 @@ impl NameStore {
                 entry: Entry::try_new("/", EntryType::Namespace).unwrap(),
             })
             .unwrap();
-
+        let id = store.object().id();
         NameStore {
             name_universe: Mutex::new(store),
+            backing_id: id,
         }
     }
 
@@ -127,7 +129,12 @@ impl NameStore {
         }
         Ok(NameStore {
             name_universe: Mutex::new(store),
+            backing_id: id,
         })
+    }
+
+    pub fn id(&self) -> ObjID {
+        self.backing_id
     }
 
     // session is created from root

--- a/src/lib/naming/src/lib.rs
+++ b/src/lib/naming/src/lib.rs
@@ -29,8 +29,8 @@ impl NamerAPI for StaticNamingAPI {
         naming_srv::enumerate_names(desc)
     }
 
-    fn remove(&self, desc: Descriptor) -> secgate::SecGateReturn<Result<()>> {
-        naming_srv::remove(desc)
+    fn remove(&self, desc: Descriptor, recursive: bool) -> secgate::SecGateReturn<Result<()>> {
+        naming_srv::remove(desc, recursive)
     }
 
     fn change_namespace(&self, desc: Descriptor) -> secgate::SecGateReturn<Result<()>> {

--- a/src/srv/naming-srv/Cargo.toml
+++ b/src/srv/naming-srv/Cargo.toml
@@ -17,5 +17,6 @@ twizzler-abi = { path = "../../lib/twizzler-abi" }
 twizzler = { path = "../../lib/twizzler" }
 arrayvec = "0.7.6"
 naming-core = { path = "../../lib/naming/naming-core" }
+lazy-init = "0.5.1"
 
 [features]

--- a/src/srv/naming-srv/src/lib.rs
+++ b/src/srv/naming-srv/src/lib.rs
@@ -3,20 +3,17 @@
 #[warn(unused_variables)]
 use std::sync::Mutex;
 
-use lazy_static::lazy_static;
 use lazy_init::LazyTransform;
+use lazy_static::lazy_static;
 use naming_core::{Entry, ErrorKind, NameSession, NameStore, Result};
 use secgate::{
     secure_gate,
     util::{Descriptor, HandleMgr, SimpleBuffer},
 };
-use twizzler_abi::{
-    aux::KernelInitInfo,
-    object::{MAX_SIZE, NULLPAGE_SIZE},
-    syscall::{sys_object_create, BackingType, LifetimeType, ObjectCreate, ObjectCreateFlags},
+use twizzler_abi::syscall::{
+    sys_object_create, BackingType, LifetimeType, ObjectCreate, ObjectCreateFlags,
 };
 use twizzler_rt_abi::object::{MapFlags, ObjID};
-
 
 struct NamespaceClient<'a> {
     session: NameSession<'a>,
@@ -69,7 +66,7 @@ impl Namer<'_> {
         let names = NameStore::new_in(id)?;
         Ok(Self {
             handles: Mutex::new(HandleMgr::new(None)),
-            names: names
+            names,
         })
     }
 }
@@ -82,7 +79,9 @@ lazy_static! {
 #[secure_gate(options(info))]
 pub fn namer_start(_info: &secgate::GateCallInfo, bootstrap: ObjID) {
     NAMINGSERVICE.get_or_create(|_| {
-        Namer::new_in(bootstrap).or::<ErrorKind>(Ok(Namer::new())).unwrap()
+        Namer::new_in(bootstrap)
+            .or::<ErrorKind>(Ok(Namer::new()))
+            .unwrap()
     });
 }
 


### PR DESCRIPTION
Added the ability to remove names from the naming system recursively or not.
And added a mechanism to load a naming system from an object id. Which allows the naming service to bootstrap itself.