### PR TITLE
Upgrade to happylock 0.4

### DIFF
--- a/src/rt/monitor/Cargo.toml
+++ b/src/rt/monitor/Cargo.toml
@@ -19,7 +19,7 @@ monitor-api = { path = "../monitor-api" }
 static_assertions = "1.1"
 lazy_static = "1.4"
 talc = "3.1"
-happylock = "0.3"
+happylock = "0.4.3"
 parking_lot = "*"
 
 [features]


### PR DESCRIPTION
Hi. I found a bug in HappyLock that caused undefined behavior. Tuples in `LockCollection`s only locked the first lock in the collection. I don't think you're affected by it, because you seem to always lock the entire monitor, but I wanted to upgrade you before I yank your version. There are some breaking changes between 0.3 and 0.4, but I looked through and you don't seem to be affected by any of them. But I must confess, I didn't try very hard to get this code to compile on my machine.