### PR TITLE
Add kernel memory tracker

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6546,7 +6546,6 @@ dependencies = [
  "fixedbitset",
  "hex-literal",
  "intrusive-collections",
- "lazy_static",
  "limine",
  "linked_list_allocator",
  "log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4717,6 +4717,7 @@ dependencies = [
  "polling",
  "secgate",
  "slab",
+ "stable-vec",
  "tracing",
  "tracing-log",
  "tracing-subscriber",

--- a/src/kernel/Cargo.toml
+++ b/src/kernel/Cargo.toml
@@ -24,7 +24,9 @@ fixedbitset = { version = "0.5.7", default-features = false }
 linked_list_allocator = "0.10"
 tar-no-std = "0.3"
 object = { version = "0.36.7", default-features = false, features = ["read"] }
-addr2line = { version = "0.16", default-features = false, features = ["rustc-demangle"] }
+addr2line = { version = "0.16", default-features = false, features = [
+    "rustc-demangle",
+] }
 backtracer_core = { git = "https://github.com/twizzler-operating-system/backtracer", branch = "twizzler" }
 limine = "0.2.0"
 twizzler-queue-raw = { version = "*", path = "../lib/twizzler-queue-raw", default-features = false }
@@ -49,7 +51,7 @@ twizzler-security = {path = "../lib/twizzler-security", features = ["kernel"],de
 rdrand = { version = "0.8.3", default-features = false }
 uart_16550 = "0.3.0"
 x86 = "0.52.0"
-acpi = { version = "5.2.0", features = ["alloc"]}
+acpi = { version = "5.2.0", features = ["alloc"] }
 
 [target.aarch64-unknown-none.dependencies]
 arm64 = { package = "aarch64-cpu", version = "9.3.1" }
@@ -60,11 +62,5 @@ smccc = "0.2.0"
 [target.'cfg(machine = "morello")'.dependencies]
 arm-gic = "0.2.2"
 
-[dependencies.lazy_static]
-version = "1.0"
-features = ["spin_no_std"]
-
 [package.metadata]
-
-
 twizzler-build = "kernel"

--- a/src/kernel/src/arch/aarch64/context.rs
+++ b/src/kernel/src/arch/aarch64/context.rs
@@ -3,14 +3,16 @@ use arm64::registers::{TTBR0_EL1, TTBR1_EL1};
 use crate::{
     arch::memory::pagetables::{Entry, EntryFlags, Table},
     memory::{
-        frame::{alloc_frame, free_frame, get_frame, PhysicalFrameFlags},
+        frame::get_frame,
         pagetables::{
             DeferredUnmappingOps, MapReader, Mapper, MappingCursor, MappingSettings,
             PhysAddrProvider,
         },
+        tracker::{alloc_frame, free_frame, FrameAllocFlags},
         PhysAddr,
     },
     mutex::Mutex,
+    once::Once,
     spinlock::Spinlock,
     VirtAddr,
 };
@@ -31,30 +33,31 @@ pub struct ArchContext {
 pub struct ArchContextTarget(PhysAddr);
 
 // default kernel mapper that is shared among all kernel instances of ArchContext
-lazy_static::lazy_static! {
-    static ref KERNEL_MAPPER: Spinlock<Mapper> = {
+static KERNEL_MAPPER: Once<(Spinlock<Mapper>, PhysAddr)> = Once::new();
+
+fn kernel_mapper() -> &'static (Spinlock<Mapper>, PhysAddr) {
+    KERNEL_MAPPER.call_once(|| {
         let mut m = Mapper::new(
             // allocate a new physical page frame to hold the
             // data for the page table root
-            alloc_frame(PhysicalFrameFlags::ZEROED).start_address()
+            alloc_frame(FrameAllocFlags::ZEROED).start_address(),
         );
         // initialize half of the page table entries
-        for idx in (Table::PAGE_TABLE_ENTRIES/2)..Table::PAGE_TABLE_ENTRIES {
+        for idx in (Table::PAGE_TABLE_ENTRIES / 2)..Table::PAGE_TABLE_ENTRIES {
             // write out PT entries for a top level table
             // whose entries point to another zeroed page
-            m.set_top_level_table(idx,
+            m.set_top_level_table(
+                idx,
                 Entry::new(
-                    alloc_frame(PhysicalFrameFlags::ZEROED)
-                        .start_address(),
+                    alloc_frame(FrameAllocFlags::ZEROED).start_address(),
                     // intermediate here means another page table
-                    EntryFlags::intermediate()
-                )
+                    EntryFlags::intermediate(),
+                ),
             );
         }
-        Spinlock::new(m)
-    };
-
-    static ref KERNEL_TABLE_ADDR: PhysAddr = KERNEL_MAPPER.lock().root_address();
+        let root = m.root_address();
+        (Spinlock::new(m), root)
+    })
 }
 
 impl Default for ArchContext {
@@ -94,7 +97,7 @@ impl ArchContext {
         // TODO: If the incoming target is already the current user table, this should be a no-op.
         // Also, we don't need to set the kernel tables each time.
         // write TTBR1
-        TTBR1_EL1.set_baddr(KERNEL_TABLE_ADDR.raw());
+        TTBR1_EL1.set_baddr(kernel_mapper().1.raw());
         // write TTBR0
         TTBR0_EL1.set_baddr(tgt.0.raw());
         core::arch::asm!(
@@ -119,7 +122,7 @@ impl ArchContext {
         // the local per-context mappings
         if cursor.start().is_kernel() {
             // upper half addresses go to TTBR1_EL1
-            KERNEL_MAPPER.lock().map(cursor, phys, settings);
+            kernel_mapper().0.lock().map(cursor, phys, settings);
         } else {
             // lower half addresses go to TTBR0_EL1
             self.inner.lock().map(cursor, phys, settings);
@@ -128,7 +131,7 @@ impl ArchContext {
 
     pub fn change(&self, cursor: MappingCursor, settings: &MappingSettings) {
         if cursor.start().is_kernel() {
-            KERNEL_MAPPER.lock().change(cursor, settings);
+            kernel_mapper().0.lock().change(cursor, settings);
         } else {
             self.inner.lock().change(cursor, settings);
         }
@@ -136,7 +139,7 @@ impl ArchContext {
 
     pub fn unmap(&self, cursor: MappingCursor) {
         let ops = if cursor.start().is_kernel() {
-            KERNEL_MAPPER.lock().unmap(cursor)
+            kernel_mapper().0.lock().unmap(cursor)
         } else {
             self.inner.lock().unmap(cursor)
         };
@@ -152,7 +155,7 @@ impl ArchContextInner {
     fn new() -> Self {
         // we need to create a new mapper object by allocating
         // some memory for the page table.
-        let mapper = Mapper::new(alloc_frame(PhysicalFrameFlags::ZEROED).start_address());
+        let mapper = Mapper::new(alloc_frame(FrameAllocFlags::ZEROED).start_address());
         Self { mapper }
     }
 

--- a/src/kernel/src/arch/aarch64/memory/pagetables/mair.rs
+++ b/src/kernel/src/arch/aarch64/memory/pagetables/mair.rs
@@ -12,6 +12,8 @@ use registers::{
 };
 use twizzler_abi::device::CacheType;
 
+use crate::once::Once;
+
 // TODO: check the bounds of this
 pub type AttributeIndex = u8;
 
@@ -229,12 +231,10 @@ impl From<MemoryAttribute> for CacheType {
 }
 
 // TODO: maybe this resource should have a lock? However, it rarely changes
-lazy_static::lazy_static! {
-    static ref MEMORY_ATTR_MANAGER: MemoryAttributeManager = MemoryAttributeManager::new();
-}
+static MEMORY_ATTR_MANAGER: Once<MemoryAttributeManager> = Once::new();
 
 pub fn memory_attr_manager() -> &'static MemoryAttributeManager {
-    &MEMORY_ATTR_MANAGER
+    MEMORY_ATTR_MANAGER.call_once(|| MemoryAttributeManager::new())
 }
 
 // unpredictable states

--- a/src/kernel/src/condvar.rs
+++ b/src/kernel/src/condvar.rs
@@ -110,7 +110,7 @@ mod tests {
 
         const ITERS: usize = 500;
         for _ in 0..ITERS {
-            let handle = run_closure_in_new_thread(Priority::default_user(), || {
+            let handle = run_closure_in_new_thread(Priority::USER, || {
                 let _ = crate::syscall::sync::sys_thread_sync(
                     &mut [],
                     Some(&mut Duration::from_millis(1)),

--- a/src/kernel/src/interrupt.rs
+++ b/src/kernel/src/interrupt.rs
@@ -84,7 +84,8 @@ impl WakeInfo {
     pub fn wake(&self, val: u64) {
         //logln!("wake! {}", val);
         unsafe {
-            self.obj.write_val_and_signal(self.offset, val, usize::MAX);
+            self.obj
+                .try_write_val_and_signal(self.offset, val, usize::MAX);
         }
     }
 

--- a/src/kernel/src/interrupt.rs
+++ b/src/kernel/src/interrupt.rs
@@ -218,7 +218,8 @@ extern "C" fn soft_interrupt_waker() {
 
 pub fn init() {
     INT_THREAD.call_once(|| {
-        crate::thread::entry::start_new_kernel(Priority::default_user(), soft_interrupt_waker, 0)
+        // TODO: priority?
+        crate::thread::entry::start_new_kernel(Priority::USER, soft_interrupt_waker, 0)
     });
 }
 

--- a/src/kernel/src/machine/arm/virt/interrupt.rs
+++ b/src/kernel/src/machine/arm/virt/interrupt.rs
@@ -1,50 +1,47 @@
-use lazy_static::lazy_static;
-
 use super::super::common::gicv2::GICv2;
+use crate::once::Once;
 
 // used by generic kernel interrupt code
 pub const MIN_VECTOR: usize = GICv2::MIN_VECTOR;
 pub const MAX_VECTOR: usize = GICv2::MAX_VECTOR;
 pub const NUM_VECTORS: usize = GICv2::NUM_VECTORS;
 
-lazy_static! {
-    /// System-wide reference to the interrupt controller
-    pub static ref INTERRUPT_CONTROLLER: GICv2 = {
+/// System-wide reference to the interrupt controller
+static INTERRUPT_CONTROLLER: Once<GICv2> = Once::new();
+pub fn interrupt_controller() -> &'static GICv2 {
+    INTERRUPT_CONTROLLER.call_once(|| {
         use twizzler_abi::{device::CacheType, object::Protections};
 
-        use crate::memory::{
-            PhysAddr,
-            pagetables::{
-                ContiguousProvider, MappingCursor, MappingSettings, Mapper,
-                MappingFlags,
+        use crate::{
+            arch::memory::mmio::mmio_allocator,
+            memory::{
+                pagetables::{
+                    ContiguousProvider, Mapper, MappingCursor, MappingFlags, MappingSettings,
+                },
+                PhysAddr,
             },
         };
-        use crate::arch::memory::mmio::MMIO_ALLOCATOR;
 
         // retrive the locations of the MMIO registers
         let (distributor_mmio, cpu_interface_mmio) = crate::machine::info::get_gicv2_info();
         // reserve regions of virtual address space for MMIO
         let (gicc_mmio_base, gicd_mmio_base) = {
-            let mut alloc = MMIO_ALLOCATOR.lock();
-            let cpu = alloc.alloc(cpu_interface_mmio.length as usize)
+            let mut alloc = mmio_allocator().lock();
+            let cpu = alloc
+                .alloc(cpu_interface_mmio.length as usize)
                 .expect("failed to allocate MMIO region");
-            let dist = alloc.alloc(distributor_mmio.length as usize)
+            let dist = alloc
+                .alloc(distributor_mmio.length as usize)
                 .expect("failed to allocate MMIO region");
             (cpu, dist)
         };
         // configure mapping settings for this region of memory
-        let gicc_region = MappingCursor::new(
-            gicc_mmio_base,
-            cpu_interface_mmio.length as usize,
-        );
+        let gicc_region = MappingCursor::new(gicc_mmio_base, cpu_interface_mmio.length as usize);
         let mut gicc_phys = ContiguousProvider::new(
             unsafe { PhysAddr::new_unchecked(cpu_interface_mmio.info) },
             cpu_interface_mmio.length as usize,
         );
-        let gicd_region = MappingCursor::new(
-            gicd_mmio_base,
-            distributor_mmio.length as usize,
-        );
+        let gicd_region = MappingCursor::new(gicd_mmio_base, distributor_mmio.length as usize);
         let mut gicd_phys = ContiguousProvider::new(
             unsafe { PhysAddr::new_unchecked(distributor_mmio.info) },
             distributor_mmio.length as usize,
@@ -68,5 +65,5 @@ lazy_static! {
             gicd_mmio_base,
             gicc_mmio_base,
         )
-    };
+    })
 }

--- a/src/kernel/src/machine/arm/virt/mod.rs
+++ b/src/kernel/src/machine/arm/virt/mod.rs
@@ -6,5 +6,5 @@ pub mod serial;
 
 pub fn machine_post_init() {
     // initialize uart with interrupts
-    serial::SERIAL.late_init();
+    serial::serial().late_init();
 }

--- a/src/kernel/src/machine/pc/pcie.rs
+++ b/src/kernel/src/machine/pc/pcie.rs
@@ -30,9 +30,7 @@ struct PcieKernelInfo {
     segnr: u16,
 }
 
-lazy_static::lazy_static! {
-    static ref DEVS: Mutex<BTreeMap<ObjID, PcieKernelInfo>> = Mutex::new(BTreeMap::new());
-}
+static DEVS: Mutex<BTreeMap<ObjID, PcieKernelInfo>> = Mutex::new(BTreeMap::new());
 
 fn register_device(
     parent: DeviceRef,

--- a/src/kernel/src/main.rs
+++ b/src/kernel/src/main.rs
@@ -198,7 +198,7 @@ pub fn idle_main() -> ! {
             // Run tests on a high priority thread, so any threads spawned by tests
             // don't preempt the testing thread.
             crate::thread::entry::run_closure_in_new_thread(
-                crate::thread::priority::Priority::default_realtime(),
+                crate::thread::priority::Priority::REALTIME,
                 || test_main(),
             )
             .1

--- a/src/kernel/src/memory/context/virtmem.rs
+++ b/src/kernel/src/memory/context/virtmem.rs
@@ -23,6 +23,7 @@ use crate::{
     },
     idcounter::{Id, IdCounter, StableId},
     memory::{
+        frame::PHYS_LEVEL_LAYOUTS,
         pagetables::{
             ContiguousProvider, Mapper, MappingCursor, MappingFlags, MappingSettings,
             PhysAddrProvider, Table, ZeroPageProvider,
@@ -754,7 +755,10 @@ pub fn page_fault(addr: VirtAddr, cause: MemoryAccessKind, flags: PageFaultFlags
                 current_thread_ref().unwrap().send_upcall(oob_upcall);
                 return;
             }
-            let mut fa = FrameAllocator::new(FrameAllocFlags::ZEROED | FrameAllocFlags::WAIT_OK);
+            let mut fa = FrameAllocator::new(
+                FrameAllocFlags::ZEROED | FrameAllocFlags::WAIT_OK,
+                PHYS_LEVEL_LAYOUTS[0],
+            );
             let status = obj_page_tree.get_page(
                 page_number,
                 cause == MemoryAccessKind::Write,

--- a/src/kernel/src/memory/context/virtmem.rs
+++ b/src/kernel/src/memory/context/virtmem.rs
@@ -145,8 +145,8 @@ struct ObjectPageProvider<'a> {
 }
 
 impl<'a> PhysAddrProvider for ObjectPageProvider<'a> {
-    fn peek(&mut self) -> (crate::arch::address::PhysAddr, usize) {
-        (self.page.physical_address(), PageNumber::PAGE_SIZE)
+    fn peek(&mut self) -> Option<(crate::arch::address::PhysAddr, usize)> {
+        Some((self.page.physical_address(), PageNumber::PAGE_SIZE))
     }
 
     fn consume(&mut self, _len: usize) {}

--- a/src/kernel/src/memory/frame.rs
+++ b/src/kernel/src/memory/frame.rs
@@ -17,6 +17,11 @@
 //! is a bit of metadata associated with each physical frame in the system. One can efficiently get
 //! the [FrameRef] given a physical address, and vice versa.
 //!
+//! Allocations can specify a Layout. This is a little more restrictive than standard allocations
+//! in that the layout will be respected, but the physical memory allocator only really allocates
+//! in architecturally-defined chunks (e.g. on x86_64, 4K, 2M, 1G). Large frames can be split into
+//! smaller ones.
+//!
 //! Note: this code is somewhat cursed, since it needs to do a bunch of funky low-level memory
 //! management without ever triggering the memory manager (can't allocate memory, since that could
 //! recurse or deadlock), and we'll need the ability to store sets of pages without allocating
@@ -34,6 +39,7 @@
 
 use alloc::vec::Vec;
 use core::{
+    alloc::Layout,
     mem::{size_of, transmute},
     sync::atomic::{AtomicU8, Ordering},
 };
@@ -43,26 +49,98 @@ use intrusive_collections::{intrusive_adapter, LinkedList, LinkedListLink};
 use super::{MemoryRegion, MemoryRegionKind, PhysAddr};
 use crate::{
     arch::memory::{frame::FRAME_SIZE, phys_to_virt},
-    memory::tracker::print_tracker_stats,
     once::Once,
     spinlock::Spinlock,
 };
 
 pub type FrameRef = &'static Frame;
-pub type FrameMutRef = &'static mut Frame;
+type FrameMutRef = &'static mut Frame;
+
+struct AllocationRegionLevel {
+    alloc_size: usize,
+    align: usize,
+    free: usize,
+    zeroed: LinkedList<FrameAdapter>,
+    non_zeroed: LinkedList<FrameAdapter>,
+}
+
+pub const NR_LEVELS: usize = 3;
+
+pub const PHYS_LEVEL_LAYOUTS: [Layout; NR_LEVELS] = [
+    unsafe { Layout::from_size_align_unchecked(FRAME_SIZE, FRAME_SIZE) },
+    unsafe { Layout::from_size_align_unchecked(FRAME_SIZE * 512, FRAME_SIZE * 512) },
+    unsafe { Layout::from_size_align_unchecked(FRAME_SIZE * 512 * 512, FRAME_SIZE * 512 * 512) },
+];
 
 #[doc(hidden)]
 struct AllocationRegion {
     indexer: FrameIndexer,
-    next_for_init: PhysAddr,
-    pages: usize,
-    zeroed: LinkedList<FrameAdapter>,
-    non_zeroed: LinkedList<FrameAdapter>,
+    nr_pages: usize,
+    levels: [AllocationRegionLevel; NR_LEVELS],
 }
 
 // Safety: this is needed because of the raw pointer, but the raw pointer is static for the life of
 // the kernel.
 unsafe impl Send for AllocationRegion {}
+
+impl AllocationRegionLevel {
+    fn new(layout: Layout) -> Self {
+        Self {
+            alloc_size: layout.size(),
+            align: layout.align(),
+            free: 0,
+            zeroed: LinkedList::new(FrameAdapter::NEW),
+            non_zeroed: LinkedList::new(FrameAdapter::NEW),
+        }
+    }
+
+    fn free(&mut self, frame: FrameRef) {
+        if frame.is_zeroed() {
+            self.zeroed.push_back(frame);
+        } else {
+            self.non_zeroed.push_back(frame);
+        }
+        self.free += 1;
+    }
+
+    fn allocate(&mut self, try_zero: bool, only_zero: bool) -> Option<FrameRef> {
+        if only_zero {
+            if let Some(f) = self.zeroed.pop_back() {
+                self.free -= 1;
+                return Some(f);
+            }
+            return None;
+        }
+        if let Some(f) = self.non_zeroed.pop_back() {
+            self.free -= 1;
+            return Some(f);
+        }
+        if try_zero {
+            if let Some(f) = self.zeroed.pop_back() {
+                self.free -= 1;
+                return Some(f);
+            }
+        }
+        None
+    }
+
+    fn admit_one(
+        &mut self,
+        frame: FrameMutRef,
+        addr: PhysAddr,
+        level: u8,
+        init_flags: PhysicalFrameFlags,
+    ) -> bool {
+        // Safety: the frame can be reset since during admit_one we are the only ones with access to
+        // the frame data.
+        unsafe { frame.reset(addr, level, init_flags) };
+        frame.set_admitted();
+        frame.set_free();
+        self.non_zeroed.push_back(frame);
+        self.free += 1;
+        true
+    }
+}
 
 impl AllocationRegion {
     fn contains(&self, pa: PhysAddr) -> bool {
@@ -81,95 +159,74 @@ impl AllocationRegion {
         self.indexer.get_frame_mut(pa)
     }
 
-    fn admit_region(&mut self, max: usize) -> Option<(PhysAddr, usize)> {
-        let taken = (self.next_for_init - self.indexer.start) / FRAME_SIZE;
-        let remaining = (self.indexer.len / FRAME_SIZE) - taken;
-        let num = remaining.min(max);
-        if num == 0 {
-            return None;
-        }
-
-        let start = self.next_for_init;
-        self.next_for_init = self.next_for_init.offset(FRAME_SIZE * num).unwrap();
-
-        for addr in (start.raw()..(start.raw() + (FRAME_SIZE * num) as u64)).step_by(FRAME_SIZE) {
-            let addr = PhysAddr::new(addr).unwrap();
-            // Unwrap-Ok: we know this address is in this region already
-            // Safety: we are allocating a new, untouched frame here
-            let frame = unsafe { self.get_frame_mut(addr) }.unwrap();
-            // Safety: the frame can be reset since during admit_one we are the only ones with
-            // access to the frame data.
-            unsafe { frame.reset(addr) };
-            frame.set_admitted();
-            frame.set_free();
-            self.non_zeroed.push_back(frame);
-        }
-
-        Some((start, num))
-    }
-
-    fn admit_one(&mut self) -> bool {
-        let next = self.next_for_init;
-        if !self.contains(next) {
-            return false;
-        }
-        self.next_for_init = self.next_for_init.offset(FRAME_SIZE).unwrap();
-
-        // Unwrap-Ok: we know this address is in this region already
-        // Safety: we are allocating a new, untouched frame here
-        let frame = unsafe { self.get_frame_mut(next) }.unwrap();
-        // Safety: the frame can be reset since during admit_one we are the only ones with access to
-        // the frame data.
-        unsafe { frame.reset(next) };
-        frame.set_admitted();
-        frame.set_free();
-        self.non_zeroed.push_back(frame);
-        true
-    }
-
     fn free(&mut self, frame: FrameRef) {
         if !self.contains(frame.start_address()) {
             return;
         }
         frame.set_free();
-        if frame.is_zeroed() {
-            self.zeroed.push_back(frame);
-        } else {
-            self.non_zeroed.push_back(frame);
-        }
+        let level = frame.get_level();
+        assert!(level < NR_LEVELS);
+        self.levels[level].free(frame);
     }
 
-    fn allocate(&mut self, try_zero: bool, only_zero: bool) -> Option<FrameRef> {
-        let frame = self.__do_allocate(try_zero, only_zero)?;
+    fn find_level(&self, layout: Layout) -> Option<usize> {
+        self.levels
+            .iter()
+            .position(|level| level.alloc_size >= layout.size() && level.align >= layout.align())
+    }
+
+    fn do_allocate(&mut self, try_zero: bool, only_zero: bool, level: usize) -> Option<FrameRef> {
+        if level >= NR_LEVELS {
+            return None;
+        }
+        if let Some(frame) = self.levels[level].allocate(try_zero, only_zero) {
+            return Some(frame);
+        }
+
+        let bigger_frame = self.do_allocate(try_zero, only_zero, level + 1)?;
+        self.split(bigger_frame);
+        self.levels[level].allocate(try_zero, only_zero)
+    }
+
+    fn allocate(&mut self, try_zero: bool, only_zero: bool, layout: Layout) -> Option<FrameRef> {
+        let level = self.find_level(layout)?;
+        let frame = self.do_allocate(try_zero, only_zero, level)?;
         assert!(!frame.get_flags().contains(PhysicalFrameFlags::ALLOCATED));
         frame.set_allocated();
         Some(frame)
     }
 
-    fn __do_allocate(&mut self, try_zero: bool, only_zero: bool) -> Option<FrameRef> {
-        if only_zero {
-            if let Some(f) = self.zeroed.pop_back() {
-                return Some(f);
-            }
-            return None;
+    fn split(&mut self, frame: FrameRef) {
+        if !self.contains(frame.start_address()) {
+            logln!("warn -- tried to split a frame within the wrong region");
+            return;
         }
-        if let Some(f) = self.non_zeroed.pop_back() {
-            return Some(f);
+        let level = frame.get_level();
+        assert!(level > 0);
+
+        let new_frame_size = PHYS_LEVEL_LAYOUTS[level - 1].size();
+        let child_count = frame.size() / new_frame_size;
+        // skip the first one for now, as that's our passed in frame.
+        for child_idx in 1..child_count {
+            let pa = frame
+                .start_address()
+                .offset(child_idx * new_frame_size)
+                .unwrap();
+            let child = unsafe { self.get_frame_mut(pa) }.unwrap();
+            self.levels[level - 1].admit_one(
+                child,
+                pa,
+                (level - 1) as u8,
+                frame.get_flags() & PhysicalFrameFlags::ZEROED,
+            );
         }
-        if try_zero {
-            if let Some(f) = self.zeroed.pop_back() {
-                return Some(f);
-            }
-        }
-        for i in 0..16 {
-            if !self.admit_one() {
-                if i == 0 {
-                    return None;
-                }
-                break;
-            }
-        }
-        self.non_zeroed.pop_back()
+        let frame = unsafe { self.get_frame_mut(frame.start_address()) }.unwrap();
+        self.levels[level - 1].admit_one(
+            frame,
+            frame.start_address(),
+            (level - 1) as u8,
+            frame.get_flags() & PhysicalFrameFlags::ZEROED,
+        );
     }
 
     fn new(m: &MemoryRegion) -> Option<Self> {
@@ -187,25 +244,49 @@ impl AllocationRegion {
 
         let frame_array_ptr = phys_to_virt(start).as_mut_ptr();
 
-        let mut this = Self {
-            // Safety: the pointer is to a static region of reserved memory.
-            indexer: unsafe {
-                FrameIndexer::new(
-                    start.offset(array_pages * FRAME_SIZE).unwrap(),
-                    (nr_pages - array_pages) * FRAME_SIZE,
-                    frame_array_ptr,
-                    frame_array_len,
-                )
-            },
-            next_for_init: start.offset(array_pages * FRAME_SIZE).unwrap(),
-            pages: nr_pages - array_pages,
-            zeroed: LinkedList::new(FrameAdapter::NEW),
-            non_zeroed: LinkedList::new(FrameAdapter::NEW),
+        let mut levels = [
+            AllocationRegionLevel::new(PHYS_LEVEL_LAYOUTS[0]),
+            AllocationRegionLevel::new(PHYS_LEVEL_LAYOUTS[1]),
+            AllocationRegionLevel::new(PHYS_LEVEL_LAYOUTS[2]),
+        ];
+
+        // Safety: the pointer is to a static region of reserved memory.
+        let mut indexer = unsafe {
+            FrameIndexer::new(
+                start.offset(array_pages * FRAME_SIZE).unwrap(),
+                (nr_pages - array_pages) * FRAME_SIZE,
+                frame_array_ptr,
+                frame_array_len,
+            )
         };
-        for _ in 0..16 {
-            this.admit_one();
+
+        // Organize into levels.
+        let mut cursor = start.offset(array_pages * FRAME_SIZE).unwrap();
+        let end = start.offset(nr_pages * FRAME_SIZE).unwrap();
+        while cursor < end {
+            let remaining = end - cursor;
+            // select level based on alignment and space
+            // Unwrap-Ok: level 0 will always work.
+            let level = (NR_LEVELS - 1)
+                - levels
+                    .iter()
+                    .rev()
+                    .position(|level| {
+                        cursor.is_aligned_to(level.align) && remaining >= level.alloc_size
+                    })
+                    .unwrap();
+            // Unwrap-Ok: we know this address is in this region already
+            // Safety: we are allocating a new, untouched frame here
+            let frame = unsafe { indexer.get_frame_mut(cursor) }.unwrap();
+            levels[level].admit_one(frame, cursor, level as u8, PhysicalFrameFlags::empty());
+            cursor = cursor.offset(levels[level].alloc_size).unwrap();
         }
-        Some(this)
+
+        Some(Self {
+            indexer,
+            levels,
+            nr_pages,
+        })
     }
 }
 
@@ -223,6 +304,7 @@ pub struct Frame {
     pa: PhysAddr,
     flags: AtomicU8,
     lock: AtomicU8,
+    level: AtomicU8,
     link: LinkedListLink,
 }
 intrusive_adapter!(pub FrameAdapter = &'static Frame: Frame { link: LinkedListLink });
@@ -242,9 +324,10 @@ impl core::fmt::Debug for Frame {
 impl Frame {
     // Safety: must only be called once, during admit_one, when the frame has not been initialized
     // yet.
-    unsafe fn reset(&mut self, pa: PhysAddr) {
+    unsafe fn reset(&mut self, pa: PhysAddr, level: u8, init_flags: PhysicalFrameFlags) {
         self.lock.store(0, Ordering::SeqCst);
-        self.flags.store(0, Ordering::SeqCst);
+        self.flags.store(init_flags.bits(), Ordering::SeqCst);
+        self.level.store(level, Ordering::SeqCst);
         let pa_ptr = &mut self.pa as *mut _;
         *pa_ptr = pa;
         self.link.force_unlink();
@@ -285,9 +368,13 @@ impl Frame {
         self.pa
     }
 
+    fn get_level(&self) -> usize {
+        self.level.load(Ordering::SeqCst) as usize
+    }
+
     /// Get the length of the frame in bytes.
     pub fn size(&self) -> usize {
-        FRAME_SIZE
+        PHYS_LEVEL_LAYOUTS[self.get_level()].size()
     }
 
     /// Zero a frame.
@@ -410,7 +497,7 @@ impl Frame {
 bitflags::bitflags! {
     /// Flags to control the state of a physical frame. Also used by the alloc functions to indicate
     /// what kind of physical frame is being requested.
-    #[derive(Clone, Copy)]
+    #[derive(Clone, Copy, Debug)]
     pub struct PhysicalFrameFlags: u8 {
         /// The frame is zeroed (or, allocate a zeroed frame)
         const ZEROED = 1;
@@ -444,78 +531,27 @@ impl PhysicalFrameAllocator {
     fn total(&self) -> usize {
         self.regions
             .iter()
-            .fold(0, |acc, region| region.pages + acc)
+            .fold(0, |acc, region| region.nr_pages + acc)
     }
 
-    fn free_region(&mut self, start: PhysAddr, len: usize) {
-        self.admitted_regions.push((start, len));
-    }
-
-    fn alloc_region(&mut self, max: usize, flags: PhysicalFrameFlags) -> Option<(PhysAddr, usize)> {
-        fn zero_region(addr: PhysAddr, len: usize) {
-            for off in 0..len {
-                let frame = get_frame(addr.offset(off * FRAME_SIZE).unwrap());
-                frame.unwrap().zero();
-            }
-        }
-        let pos = self.admitted_regions.iter().position(|reg| reg.1 <= max);
-        if let Some(reg) = pos.map(|pos| self.admitted_regions.remove(pos)) {
-            if flags.contains(PhysicalFrameFlags::ZEROED) {
-                zero_region(reg.0, reg.1);
-            }
-            return Some(reg);
-        }
-        for reg in &mut self.regions {
-            let ad_reg = reg.admit_region(max);
-            if let Some(ad_reg) = ad_reg {
-                if flags.contains(PhysicalFrameFlags::ZEROED) {
-                    zero_region(ad_reg.0, ad_reg.1);
-                }
-                return Some(ad_reg);
-            }
-        }
-
-        None
-    }
-
-    fn alloc(&mut self, flags: PhysicalFrameFlags, fallback: bool) -> Option<FrameRef> {
-        let frame = if fallback {
-            Some(self.__do_alloc_fallback())
-        } else {
-            self.__do_alloc(flags)
-        }?;
+    fn alloc(&mut self, flags: PhysicalFrameFlags, layout: Layout) -> Option<FrameRef> {
+        let frame = self.__do_alloc(flags, layout)?;
         if flags.contains(PhysicalFrameFlags::ZEROED) && !frame.is_zeroed() {
             frame.zero();
         }
         Some(frame)
     }
 
-    fn __do_alloc_fallback(&mut self) -> FrameRef {
-        // fallback
+    fn __do_alloc(&mut self, flags: PhysicalFrameFlags, layout: Layout) -> Option<FrameRef> {
+        let needs_zero = flags.contains(PhysicalFrameFlags::ZEROED);
         for reg in &mut self.regions {
-            let frame = reg.allocate(true, false);
-            if let Some(frame) = frame {
+            let frame = reg.allocate(false, needs_zero, layout);
+            if frame.is_some() {
                 return frame;
             }
         }
-        if let Some(reg) = self.admitted_regions.pop() {
-            for off in 0..reg.1 {
-                let pa = reg.0.offset(off * FRAME_SIZE).unwrap();
-                let frame = get_frame(pa).unwrap();
-                self.free(frame);
-            }
-            self.__do_alloc_fallback()
-        } else {
-            print_tracker_stats();
-            panic!("out of memory");
-        }
-    }
-
-    fn __do_alloc(&mut self, flags: PhysicalFrameFlags) -> Option<FrameRef> {
-        let needs_zero = flags.contains(PhysicalFrameFlags::ZEROED);
-        // try to find an exact match
         for reg in &mut self.regions {
-            let frame = reg.allocate(false, needs_zero);
+            let frame = reg.allocate(true, false, layout);
             if frame.is_some() {
                 return frame;
             }
@@ -618,12 +654,8 @@ pub fn init(regions: &[MemoryRegion]) {
     crate::memory::tracker::init(total, total, 0);
 }
 
-pub(super) fn raw_alloc_frame(flags: PhysicalFrameFlags) -> FrameRef {
-    let mut frame = { PFA.wait().lock().alloc(flags, false) };
-    if frame.is_none() {
-        frame = PFA.wait().lock().alloc(flags, true);
-    }
-    let frame = frame.expect("out of memory");
+pub(super) fn raw_alloc_frame(flags: PhysicalFrameFlags, layout: Layout) -> Option<FrameRef> {
+    let frame = { PFA.wait().lock().alloc(flags, layout) }?;
     if flags.contains(PhysicalFrameFlags::ZEROED) {
         assert!(frame.is_zeroed());
     }
@@ -631,11 +663,7 @@ pub(super) fn raw_alloc_frame(flags: PhysicalFrameFlags) -> FrameRef {
     frame.set_not_zero();
     assert!(frame.get_flags().contains(PhysicalFrameFlags::ADMITTED));
     assert!(frame.get_flags().contains(PhysicalFrameFlags::ALLOCATED));
-    frame
-}
-
-pub(super) fn raw_try_alloc_frame(flags: PhysicalFrameFlags) -> Option<FrameRef> {
-    Some(raw_alloc_frame(flags))
+    Some(frame)
 }
 
 pub(super) fn raw_free_frame(frame: FrameRef) {
@@ -656,30 +684,20 @@ pub fn get_frame(pa: PhysAddr) -> Option<FrameRef> {
     None
 }
 
-pub(super) fn raw_try_alloc_region(
-    max: usize,
-    flags: PhysicalFrameFlags,
-) -> Option<(PhysAddr, usize)> {
-    let reg = { PFA.wait().lock().alloc_region(max, flags) };
-    reg
-}
-
-pub(super) fn raw_free_region(start: PhysAddr, len: usize) {
-    PFA.wait().lock().free_region(start, len);
-}
-
 #[cfg(test)]
 mod tests {
     use alloc::vec::Vec;
 
     use twizzler_kernel_macros::kernel_test;
 
-    use super::{get_frame, raw_alloc_frame, raw_free_frame, PhysicalFrameFlags};
+    use super::{
+        get_frame, raw_alloc_frame, raw_free_frame, PhysicalFrameFlags, PHYS_LEVEL_LAYOUTS,
+    };
     use crate::utils::quick_random;
 
     #[kernel_test]
     fn test_get_frame() {
-        let frame = raw_alloc_frame(PhysicalFrameFlags::empty());
+        let frame = raw_alloc_frame(PhysicalFrameFlags::empty(), PHYS_LEVEL_LAYOUTS[0]).unwrap();
         let addr = frame.start_address();
         let test_frame = get_frame(addr).unwrap();
         assert!(core::ptr::eq(frame as *const _, test_frame as *const _));
@@ -694,10 +712,11 @@ mod tests {
             let z = quick_random();
             if x % 2 == 0 && stack.len() < 1000 {
                 let frame = if y % 3 == 0 {
-                    raw_alloc_frame(PhysicalFrameFlags::ZEROED)
+                    raw_alloc_frame(PhysicalFrameFlags::ZEROED, PHYS_LEVEL_LAYOUTS[0])
                 } else {
-                    raw_alloc_frame(PhysicalFrameFlags::empty())
-                };
+                    raw_alloc_frame(PhysicalFrameFlags::empty(), PHYS_LEVEL_LAYOUTS[0])
+                }
+                .unwrap();
                 if z % 5 == 0 {
                     frame.zero();
                 }

--- a/src/kernel/src/memory/mod.rs
+++ b/src/kernel/src/memory/mod.rs
@@ -6,6 +6,7 @@ pub mod allocator;
 pub mod context;
 pub mod frame;
 pub mod pagetables;
+pub mod tracker;
 
 pub use arch::{PhysAddr, VirtAddr};
 use twizzler_abi::object::NULLPAGE_SIZE;

--- a/src/kernel/src/memory/mod.rs
+++ b/src/kernel/src/memory/mod.rs
@@ -8,7 +8,10 @@ pub mod frame;
 pub mod pagetables;
 pub mod tracker;
 
+use alloc::vec::Vec;
+
 pub use arch::{PhysAddr, VirtAddr};
+use tracker::{alloc_frame, print_tracker_stats, reclaim, FrameAllocFlags};
 use twizzler_abi::object::NULLPAGE_SIZE;
 
 use self::context::{KernelMemoryContext, UserContext};
@@ -61,4 +64,23 @@ pub fn is_init() -> bool {
 pub fn prep_smp() {
     let kc = context::kernel_context();
     kc.prep_smp();
+}
+
+pub fn sim_memory_pressure() {
+    logln!("TEST -- simulating memory pressure");
+
+    let alloc_frames = || {
+        (0..4096)
+            .map(|_| alloc_frame(FrameAllocFlags::WAIT_OK))
+            .collect::<Vec<_>>()
+    };
+    const NUM_ITERS: usize = 1024;
+    //let mut alloced = Vec::new();
+    for i in 0..NUM_ITERS {
+        logln!("iteration {} / {}", i, NUM_ITERS);
+        print_tracker_stats();
+        let frames = alloc_frames();
+        //alloced.push(frames);
+        reclaim(frames);
+    }
 }

--- a/src/kernel/src/memory/pagetables/consistency.rs
+++ b/src/kernel/src/memory/pagetables/consistency.rs
@@ -5,7 +5,7 @@ use crate::{
         address::{PhysAddr, VirtAddr},
         memory::pagetables::{ArchCacheLineMgr, ArchTlbMgr},
     },
-    memory::frame::{free_frame, FrameAdapter, FrameRef},
+    memory::frame::{FrameAdapter, FrameRef},
 };
 
 /// Management for consistency, wrapping any cache-line flushing and TLB coherence into a single
@@ -69,7 +69,7 @@ impl Drop for DeferredUnmappingOps {
 impl DeferredUnmappingOps {
     pub fn run_all(mut self) {
         while let Some(page) = self.pages.pop_back() {
-            free_frame(page)
+            crate::memory::tracker::free_frame(page)
         }
     }
 }

--- a/src/kernel/src/memory/pagetables/phys_provider.rs
+++ b/src/kernel/src/memory/pagetables/phys_provider.rs
@@ -9,7 +9,7 @@ use crate::{
 /// A trait for providing a set of physical pages to the mapping function.
 pub trait PhysAddrProvider {
     /// Get the current physical frame.
-    fn peek(&mut self) -> (PhysAddr, usize);
+    fn peek(&mut self) -> Option<(PhysAddr, usize)>;
     /// Consume the current frame and go to the next one.
     fn consume(&mut self, len: usize);
 }
@@ -32,13 +32,13 @@ impl ZeroPageProvider {
 }
 
 impl PhysAddrProvider for ZeroPageProvider {
-    fn peek(&mut self) -> (PhysAddr, usize) {
+    fn peek(&mut self) -> Option<(PhysAddr, usize)> {
         match self.current {
-            Some(frame) => (frame.start_address(), frame.size()),
+            Some(frame) => Some((frame.start_address(), frame.size())),
             None => {
                 let frame = alloc_frame(self.flags);
                 self.current = Some(frame);
-                (frame.start_address(), frame.size())
+                Some((frame.start_address(), frame.size()))
             }
         }
     }
@@ -73,8 +73,8 @@ impl ContiguousProvider {
 }
 
 impl PhysAddrProvider for ContiguousProvider {
-    fn peek(&mut self) -> (PhysAddr, usize) {
-        (self.next, self.rem)
+    fn peek(&mut self) -> Option<(PhysAddr, usize)> {
+        Some((self.next, self.rem))
     }
 
     fn consume(&mut self, len: usize) {

--- a/src/kernel/src/memory/pagetables/table.rs
+++ b/src/kernel/src/memory/pagetables/table.rs
@@ -5,8 +5,9 @@ use crate::{
         memory::pagetables::{Entry, EntryFlags, Table},
     },
     memory::{
-        frame::{alloc_frame, get_frame, FrameRef, PhysicalFrameFlags},
+        frame::{get_frame, FrameRef},
         pagetables::MappingFlags,
+        tracker::{alloc_frame, FrameAllocFlags},
     },
 };
 
@@ -57,7 +58,7 @@ impl Table {
         let count = self.read_count();
         let entry = &mut self[index];
         if !entry.is_present() {
-            let frame = alloc_frame(PhysicalFrameFlags::ZEROED);
+            let frame = alloc_frame(FrameAllocFlags::KERNEL | FrameAllocFlags::ZEROED);
             *entry = Entry::new(frame.start_address(), flags);
             self.set_count(count + 1);
         }

--- a/src/kernel/src/memory/pagetables/tests.rs
+++ b/src/kernel/src/memory/pagetables/tests.rs
@@ -7,8 +7,8 @@ mod test {
     use crate::{
         arch::{address::VirtAddr, memory::pagetables::Table},
         memory::{
-            frame::{alloc_frame, PhysicalFrameFlags},
             pagetables::{phys_provider, Mapper, MappingCursor, MappingFlags, MappingSettings},
+            tracker::{alloc_frame, FrameAllocFlags},
         },
     };
 
@@ -23,7 +23,7 @@ mod test {
 
     #[kernel_test]
     fn test_count() {
-        let mut m = Mapper::new(alloc_frame(PhysicalFrameFlags::ZEROED).start_address());
+        let mut m = Mapper::new(alloc_frame(FrameAllocFlags::ZEROED).start_address());
         for i in 0..Table::PAGE_TABLE_ENTRIES {
             let c = m.root().read_count();
             assert_eq!(c, i);
@@ -39,7 +39,7 @@ mod test {
             return;
         }
         let page_size = Table::level_to_page_size(level);
-        let mut m = Mapper::new(alloc_frame(PhysicalFrameFlags::ZEROED).start_address());
+        let mut m = Mapper::new(alloc_frame(FrameAllocFlags::ZEROED).start_address());
         assert_eq!(
             m.readmap(MappingCursor::new(VirtAddr::new(0).unwrap(), 0))
                 .next(),

--- a/src/kernel/src/memory/pagetables/tests.rs
+++ b/src/kernel/src/memory/pagetables/tests.rs
@@ -14,8 +14,8 @@ mod test {
 
     struct StaticProvider {}
     impl PhysAddrProvider for StaticProvider {
-        fn peek(&mut self) -> (crate::arch::address::PhysAddr, usize) {
-            (crate::arch::address::PhysAddr::new(0).unwrap(), usize::MAX)
+        fn peek(&mut self) -> Option<(crate::arch::address::PhysAddr, usize)> {
+            Some((crate::arch::address::PhysAddr::new(0).unwrap(), usize::MAX))
         }
 
         fn consume(&mut self, _len: usize) {}
@@ -62,7 +62,7 @@ mod test {
             CacheType::WriteBack,
             MappingFlags::empty(),
         );
-        m.map(cur, &mut phys, &settings);
+        let _ = m.map(cur, &mut phys, &settings);
 
         let mut reader = m.readmap(cur);
         let read = reader.nth(0).unwrap();

--- a/src/kernel/src/memory/tracker.rs
+++ b/src/kernel/src/memory/tracker.rs
@@ -443,7 +443,6 @@ fn reclaim_main() {
     let mut state = rt.state.lock();
     const MAX_RECLAIM_ROUNDS: usize = 1000;
     const MAX_PER_ROUND: usize = 100;
-    let mut real = false;
     loop {
         let mut count = 0;
         let mut rounds = 0;
@@ -457,15 +456,12 @@ fn reclaim_main() {
             4. If should_reclaim because page > idle / 2, then cache replacement clean objects.
             5. If pressure is high, cache replace any object.
             */
-            if get_waiting_threads() > 1 || real {
-                real = true;
-                while let Some(f) = state.pop() {
-                    free_frame(f);
-                    count += 1;
-                    thisround += 1;
-                    if thisround >= MAX_PER_ROUND {
-                        break;
-                    }
+            while let Some(f) = state.pop() {
+                free_frame(f);
+                count += 1;
+                thisround += 1;
+                if thisround >= MAX_PER_ROUND {
+                    break;
                 }
             }
 

--- a/src/kernel/src/memory/tracker.rs
+++ b/src/kernel/src/memory/tracker.rs
@@ -1,0 +1,316 @@
+use alloc::vec::Vec;
+use core::sync::atomic::{AtomicUsize, Ordering};
+
+use bitflags::bitflags;
+use intrusive_collections::{intrusive_adapter, LinkedList};
+use twizzler_abi::thread::ExecutionState;
+
+use super::{
+    frame::{FrameRef, PhysicalFrameFlags},
+    MemoryRegion,
+};
+use crate::{
+    arch::memory::frame::FRAME_SIZE,
+    condvar::CondVar,
+    once::Once,
+    spinlock::Spinlock,
+    syscall::sync::finish_blocking,
+    thread::{current_thread_ref, entry::start_new_kernel, priority::Priority, Thread, ThreadRef},
+};
+
+pub struct MemoryTracker {
+    kernel_used: AtomicUsize,
+    page_data: AtomicUsize,
+    idle: AtomicUsize,
+    total: AtomicUsize,
+    pager_outstanding: AtomicUsize,
+    reclaim: Once<ReclaimThread>,
+    waiters: Spinlock<LinkedList<LinkAdapter>>,
+}
+intrusive_adapter!(pub LinkAdapter = ThreadRef: Thread { mutex_link: intrusive_collections::linked_list::AtomicLink });
+
+impl MemoryTracker {
+    fn free_frame(&self, frame: FrameRef) {
+        let old = if frame.is_kernel() {
+            self.kernel_used.fetch_sub(1, Ordering::SeqCst)
+        } else {
+            self.page_data.fetch_sub(1, Ordering::SeqCst)
+        };
+        assert!(old > 0);
+        self.idle.fetch_add(1, Ordering::SeqCst);
+        crate::memory::frame::raw_free_frame(frame);
+        self.wake();
+    }
+
+    fn try_alloc_frame(&self, flags: FrameAllocFlags) -> Option<FrameRef> {
+        let pff = if flags.contains(FrameAllocFlags::ZEROED) {
+            PhysicalFrameFlags::ZEROED
+        } else {
+            PhysicalFrameFlags::empty()
+        };
+        loop {
+            if let Some(frame) = crate::memory::frame::raw_try_alloc_frame(pff) {
+                if flags.contains(FrameAllocFlags::KERNEL) {
+                    frame.set_kernel(true);
+                    self.kernel_used.fetch_add(1, Ordering::SeqCst);
+                } else {
+                    frame.set_kernel(false);
+                    self.page_data.fetch_add(1, Ordering::SeqCst);
+                }
+                let old = self.idle.fetch_sub(1, Ordering::SeqCst);
+                assert!(old > 0);
+                return Some(frame);
+            }
+
+            if flags.contains(FrameAllocFlags::WAIT_OK) {
+                self.wait();
+            } else {
+                return None;
+            }
+        }
+    }
+
+    fn alloc_frame(&self, flags: FrameAllocFlags) -> FrameRef {
+        self.try_alloc_frame(flags).expect("cannot wait for page")
+    }
+
+    fn wait(&self) {
+        self.trigger_reclaim();
+        let Some(current_thread) = current_thread_ref() else {
+            logln!("warning -- cannot wait on memory before threading initialized");
+            return;
+        };
+        let guard = current_thread.enter_critical();
+        current_thread.set_state(ExecutionState::Sleeping);
+        self.waiters.lock().push_back(current_thread.clone());
+        finish_blocking(guard);
+        current_thread.set_state(ExecutionState::Running);
+    }
+
+    fn wake(&self) {
+        let mut waiters = self.waiters.lock();
+        while let Some(waiter) = waiters.pop_back() {
+            crate::sched::schedule_thread(waiter);
+        }
+    }
+
+    fn trigger_reclaim(&self) {
+        if let Some(reclaim) = self.reclaim.poll() {
+            reclaim.cv.signal();
+        } else {
+            logln!("warning -- cannot trigger reclaim thread before it is started");
+        }
+    }
+
+    fn consider_reclaim(&self) {
+        if self.should_reclaim() {
+            self.trigger_reclaim();
+        }
+    }
+
+    fn should_reclaim(&self) -> bool {
+        let idle = self.idle();
+        let kern = self.kernel_used();
+        let page = self.page_data();
+
+        let k2 = kern * 2;
+        let split_idle = idle / 2;
+
+        logln!(
+            "should reclaim? {} {} {}, {}",
+            idle,
+            kern,
+            page,
+            page >= split_idle || idle < k2
+        );
+
+        page >= split_idle || idle < k2
+    }
+
+    fn idle(&self) -> usize {
+        self.idle.load(Ordering::Acquire)
+    }
+
+    fn kernel_used(&self) -> usize {
+        self.kernel_used.load(Ordering::Acquire)
+    }
+
+    fn page_data(&self) -> usize {
+        self.page_data.load(Ordering::Acquire)
+    }
+
+    fn track_frame_pager(&self) {
+        self.pager_outstanding.fetch_add(1, Ordering::SeqCst);
+    }
+
+    fn untrack_frame_pager(&self) {
+        self.pager_outstanding.fetch_sub(1, Ordering::SeqCst);
+    }
+
+    fn pager_outstanding(&self) -> usize {
+        self.pager_outstanding.load(Ordering::SeqCst)
+    }
+}
+
+pub static TRACKER: Once<MemoryTracker> = Once::new();
+
+/// Allocate a physical frame. Flags specify zeroing, ownership tracking, and if waiting is okay.
+///
+/// The `flags` argument allows one to control if the resulting frame is
+/// zeroed or not. Note that passing [FrameAllocFlags]::ZEROED guarantees that the returned frame
+/// is zeroed, but the converse is not true.
+///
+/// The returned frame will have its ZEROED flag cleared. In the future, this will probably change
+/// to reflect the correct state of the frame.
+///
+/// # Panic
+/// Will panic if out of physical memory. For this reason, you probably want to use
+/// [try_alloc_frame].
+///
+/// # Examples
+/// ```
+/// let uninitialized_frame = alloc_frame(FrameAllocFlags::empty());
+/// let zeroed_frame = alloc_frame(FrameAllocFlags::ZEROED);
+/// ```
+pub fn alloc_frame(flags: FrameAllocFlags) -> FrameRef {
+    TRACKER
+        .poll()
+        .expect("page tracker not initialized")
+        .alloc_frame(flags)
+}
+
+/// Try to allocate a physical frame. The flags argument is the same as in [alloc_frame]. Returns
+/// None if no physical frame is available.
+pub fn try_alloc_frame(flags: FrameAllocFlags) -> Option<FrameRef> {
+    TRACKER
+        .poll()
+        .expect("page tracker not initialized")
+        .try_alloc_frame(flags)
+}
+
+/// Free a physical frame.
+///
+/// If the frame's flags indicates that it is zeroed, it will be placed on
+/// the zeroed list.
+pub fn free_frame(frame: FrameRef) {
+    TRACKER
+        .poll()
+        .expect("page tracker not initialized")
+        .free_frame(frame)
+}
+
+/// Track a page as owned by the pager.
+pub fn track_page_pager(_frame: FrameRef) {
+    TRACKER
+        .poll()
+        .expect("page tracker not initialized")
+        .track_frame_pager()
+}
+
+/// Track a page as owned by the pager.
+pub fn untrack_page_pager(_frame: FrameRef) {
+    TRACKER
+        .poll()
+        .expect("page tracker not initialized")
+        .untrack_frame_pager()
+}
+
+/// Get outstanding pager pages
+pub fn get_outstanding_pager_pages() -> usize {
+    TRACKER
+        .poll()
+        .expect("page tracker not initialized")
+        .pager_outstanding()
+}
+
+bitflags! {
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+    pub struct FrameAllocFlags: u32 {
+        /// The page will be zeroed before returning.
+        const ZEROED = 1;
+        /// The page will be tracked as a kernel page.
+        const KERNEL = 2;
+        /// If no pages are available, wait.
+        const WAIT_OK = 4;
+    }
+}
+
+struct ReclaimThread {
+    th: ThreadRef,
+    state: Spinlock<()>,
+    cv: CondVar,
+}
+
+impl ReclaimThread {
+    fn new() -> Self {
+        extern "C" fn reclaim_start() {
+            reclaim_main();
+        }
+        Self {
+            th: start_new_kernel(Priority::REALTIME, reclaim_start, 0),
+            state: Spinlock::new(()),
+            cv: CondVar::new(),
+        }
+    }
+}
+
+fn reclaim_main() {
+    let tracker = TRACKER.wait();
+    let rt = tracker.reclaim.wait();
+    let mut state = rt.state.lock();
+    loop {
+        logln!("reclaim thread triggered");
+        state = rt.cv.wait(state);
+    }
+}
+
+pub fn init(regions: &[MemoryRegion]) {
+    TRACKER.call_once(|| {
+        let total = regions.iter().fold(0, |acc, x| acc + x.length / FRAME_SIZE);
+        MemoryTracker {
+            kernel_used: AtomicUsize::new(0),
+            page_data: AtomicUsize::new(0),
+            idle: AtomicUsize::new(total),
+            total: AtomicUsize::new(total),
+            pager_outstanding: AtomicUsize::new(0),
+            reclaim: Once::new(),
+            waiters: Spinlock::new(LinkedList::new(LinkAdapter::NEW)),
+        }
+    });
+}
+
+pub struct FrameAllocator {
+    flags: FrameAllocFlags,
+    frames: Vec<FrameRef>,
+}
+
+impl FrameAllocator {
+    pub fn new(flags: FrameAllocFlags) -> Self {
+        FrameAllocator {
+            flags,
+            frames: Vec::new(),
+        }
+    }
+
+    pub fn try_allocate(&mut self) -> Option<FrameRef> {
+        if self.frames.len() == 0 {
+            try_alloc_frame(self.flags)
+        } else {
+            self.frames.pop()
+        }
+    }
+
+    pub fn abort(&mut self, frames: impl IntoIterator<Item = FrameRef>) {
+        for frame in frames {
+            self.frames.push(frame);
+        }
+    }
+}
+
+impl Drop for FrameAllocator {
+    fn drop(&mut self) {
+        for frame in self.frames.drain(..) {
+            free_frame(frame);
+        }
+    }
+}

--- a/src/kernel/src/mutex.rs
+++ b/src/kernel/src/mutex.rs
@@ -79,17 +79,15 @@ impl<T> Mutex<T> {
     #[track_caller]
     pub fn lock(&self) -> LockGuard<'_, T> {
         let current_thread = current_thread_ref();
-        //let current_donated_priority = current_thread
-        //.as_ref()
-        //.and_then(|t| t.get_donated_priority());
+        let current_donated_priority = current_thread
+            .as_ref()
+            .and_then(|t| t.get_donated_priority());
 
         if let Some(ref current_thread) = current_thread {
-            /* TODO: maybe try to support critical threads by falling back to a spinloop? */
             assert!(!current_thread.is_critical());
         }
 
         let mut i = 0;
-        //let mut istate;
         loop {
             i += 1;
             if i > 100 {
@@ -100,13 +98,11 @@ impl<T> Mutex<T> {
                 let mut queue = self.queue.lock();
                 if !queue.owned {
                     queue.owned = true;
-                    /*
                     if let Some(ref thread) = current_thread {
                         if let Some(ref pri) = queue.pri {
                             thread.donate_priority(pri.clone());
                         }
                     }
-                    */
 
                     queue.owner = current_thread.clone();
                     break;
@@ -124,16 +120,14 @@ impl<T> Mutex<T> {
                         thread.set_state(ExecutionState::Sleeping);
                         queue.queue.push_back(thread.clone());
                         reinsert = false;
-                        /*
                         queue.pri = queue.queue.iter().map(|t| t.effective_priority()).max();
                         if let Some(ref owner) = queue.owner {
                             if let Some(ref pri) = queue.pri {
                                 if pri > &owner.effective_priority() {
-                                owner.donate_priority(pri.clone());
+                                    owner.donate_priority(pri.clone());
                                 }
                             }
                         }
-                        */
                     }
                 }
                 reinsert
@@ -147,7 +141,7 @@ impl<T> Mutex<T> {
 
         LockGuard {
             lock: self,
-            prev_donated_priority: None,
+            prev_donated_priority: current_donated_priority,
         }
     }
 
@@ -185,7 +179,6 @@ impl<T> core::ops::DerefMut for LockGuard<'_, T> {
 
 impl<T> Drop for LockGuard<'_, T> {
     fn drop(&mut self) {
-        /*
         if let Some(ref prev) = self.prev_donated_priority {
             if let Some(thread) = current_thread_ref() {
                 thread.donate_priority(prev.clone());
@@ -193,7 +186,6 @@ impl<T> Drop for LockGuard<'_, T> {
         } else if let Some(thread) = current_thread_ref() {
             thread.remove_donated_priority();
         }
-        */
         self.lock.release();
     }
 }
@@ -271,7 +263,7 @@ mod test {
                 let handles: Vec<_> = locks
                     .into_iter()
                     .map(|lock| {
-                        run_closure_in_new_thread(Priority::default_user(), move || {
+                        run_closure_in_new_thread(Priority::USER, move || {
                             for _ in 0..INNER_ITER {
                                 let mut inner = lock.lock();
                                 if quick_random() % 20 == 0 {

--- a/src/kernel/src/obj/copy.rs
+++ b/src/kernel/src/obj/copy.rs
@@ -454,6 +454,7 @@ mod test {
     use crate::{
         memory::{
             context::{kernel_context, KernelMemoryContext, ObjectContextInfo},
+            frame::PHYS_LEVEL_LAYOUTS,
             tracker::{FrameAllocFlags, FrameAllocator},
         },
         obj::{copy::zero_ranges, pages::Page, range::PageStatus, ObjectRef, PageNumber},
@@ -538,7 +539,10 @@ mod test {
         let src = create_blank_object();
         let dest = create_blank_object();
 
-        let mut allocator = FrameAllocator::new(FrameAllocFlags::KERNEL | FrameAllocFlags::ZEROED);
+        let mut allocator = FrameAllocator::new(
+            FrameAllocFlags::KERNEL | FrameAllocFlags::ZEROED,
+            PHYS_LEVEL_LAYOUTS[0],
+        );
         // Skip the null page, otherwise fill the source with pages that have different fills
         for p in 1..255u8 {
             let mut tree: crate::mutex::LockGuard<'_, crate::obj::range::PageRangeTree> =
@@ -590,7 +594,10 @@ mod test {
         // function).
         let second_page = ps * 2;
         let third_page = ps * 3;
-        let mut allocator2 = FrameAllocator::new(FrameAllocFlags::KERNEL | FrameAllocFlags::ZEROED);
+        let mut allocator2 = FrameAllocator::new(
+            FrameAllocFlags::KERNEL | FrameAllocFlags::ZEROED,
+            PHYS_LEVEL_LAYOUTS[0],
+        );
         copy_ranges_and_check(&src, second_page, &dest, second_page, ps, &mut allocator2);
         copy_ranges_and_check(&src, third_page, &dest, second_page, ps, &mut allocator2);
 

--- a/src/kernel/src/operations.rs
+++ b/src/kernel/src/operations.rs
@@ -25,7 +25,7 @@ pub fn read_object(obj: &ObjectRef) -> Vec<u8> {
     let mut tree = obj.lock_page_tree();
     let mut v = alloc::vec![];
     let mut pn = 1.into();
-    while let PageStatus::Ready(p, _) = tree.get_page(pn, false) {
+    while let PageStatus::Ready(p, _) = tree.get_page(pn, false, None) {
         v.extend_from_slice(p.as_slice());
         pn = pn.next();
     }

--- a/src/kernel/src/pager.rs
+++ b/src/kernel/src/pager.rs
@@ -1,14 +1,10 @@
-use alloc::vec::Vec;
-
 use inflight::InflightManager;
 use request::ReqKind;
-use twizzler_abi::object::{ObjID, NULLPAGE_SIZE};
+use twizzler_abi::object::ObjID;
 
 use crate::{
-    memory::{MemoryRegion, MemoryRegionKind},
     mutex::Mutex,
     obj::{LookupFlags, ObjectRef, PageNumber},
-    once::Once,
     syscall::sync::finish_blocking,
     thread::current_thread_ref,
 };
@@ -19,61 +15,6 @@ mod request;
 
 pub use queues::init_pager_queue;
 pub use request::Request;
-
-static PAGER_MEMORY: Once<Vec<MemoryRegion>> = Once::new();
-
-const MAX_RESERVE_KERNEL: usize = 1024 * 1024 * 1024; // 1G
-
-pub fn pager_select_memory_regions(regions: &[MemoryRegion]) -> Vec<MemoryRegion> {
-    let mut fa_regions = Vec::new();
-    let mut pager_regions = Vec::new();
-    let total = regions.iter().fold(0, |acc, val| {
-        if val.kind == MemoryRegionKind::UsableRam {
-            acc + val.length
-        } else {
-            acc
-        }
-    });
-    let mut reserved = 0;
-    for reg in regions {
-        if matches!(reg.kind, MemoryRegionKind::UsableRam) {
-            // TODO: don't just pick one, and don't just pick the first one.
-            if reserved >= MAX_RESERVE_KERNEL {
-                pager_regions.push(*reg);
-            } else if reg.length > NULLPAGE_SIZE * 2 {
-                let (first, second) = (*reg).split(reg.length / 2).unwrap();
-                reserved += first.length;
-                fa_regions.push(first);
-                pager_regions.push(second);
-            } else {
-                reserved += reg.length;
-                fa_regions.push(*reg);
-            }
-        }
-    }
-    let total_pager = pager_regions.iter().fold(0, |acc, val| {
-        if val.kind == MemoryRegionKind::UsableRam {
-            acc + val.length
-        } else {
-            acc
-        }
-    });
-    let total_kernel = fa_regions.iter().fold(0, |acc, val| {
-        if val.kind == MemoryRegionKind::UsableRam {
-            acc + val.length
-        } else {
-            acc
-        }
-    });
-    logln!(
-        "[kernel::pager] split memory: {} MB pager / {} MB kernel",
-        total_pager / (1024 * 1024),
-        total_kernel / (1024 * 1024)
-    );
-    assert_eq!(total, total_pager + total_kernel);
-    PAGER_MEMORY.call_once(|| pager_regions);
-    fa_regions
-}
 
 lazy_static::lazy_static! {
     static ref INFLIGHT_MGR: Mutex<InflightManager> = Mutex::new(InflightManager::new());

--- a/src/kernel/src/pager/inflight.rs
+++ b/src/kernel/src/pager/inflight.rs
@@ -6,7 +6,10 @@ use alloc::{
 use stable_vec::StableVec;
 use twizzler_abi::{
     object::{ObjID, NULLPAGE_SIZE},
-    pager::{KernelCommand, ObjectEvictInfo, ObjectInfo, ObjectRange, RequestFromKernel},
+    pager::{
+        KernelCommand, ObjectEvictFlags, ObjectEvictInfo, ObjectInfo, ObjectRange, PhysRange,
+        RequestFromKernel,
+    },
     syscall::LifetimeType,
 };
 
@@ -36,9 +39,9 @@ impl Inflight {
             ),
             ReqKind::Sync(obj_id) => KernelCommand::ObjectEvict(ObjectEvictInfo {
                 obj_id,
-                range: todo!(),
-                phys: todo!(),
-                flags: todo!(),
+                range: ObjectRange::new(0, 0),
+                phys: PhysRange::new(0, 0),
+                flags: ObjectEvictFlags::SYNC | ObjectEvictFlags::FENCE,
             }),
             ReqKind::Del(obj_id) => KernelCommand::ObjectDel(obj_id),
             ReqKind::Create(obj_id) => {

--- a/src/kernel/src/pager/inflight.rs
+++ b/src/kernel/src/pager/inflight.rs
@@ -6,7 +6,8 @@ use alloc::{
 use stable_vec::StableVec;
 use twizzler_abi::{
     object::{ObjID, NULLPAGE_SIZE},
-    pager::{KernelCommand, ObjectInfo, ObjectRange, RequestFromKernel},
+    pager::{KernelCommand, ObjectEvictInfo, ObjectInfo, ObjectRange, RequestFromKernel},
+    syscall::LifetimeType,
 };
 
 use super::{request::ReqKind, Request};
@@ -33,9 +34,16 @@ impl Inflight {
                 obj_id,
                 ObjectRange::new((s * NULLPAGE_SIZE) as u64, ((s + l) * NULLPAGE_SIZE) as u64),
             ),
-            ReqKind::Sync(obj_id) => KernelCommand::ObjectSync(obj_id),
+            ReqKind::Sync(obj_id) => KernelCommand::ObjectEvict(ObjectEvictInfo {
+                obj_id,
+                range: todo!(),
+                phys: todo!(),
+                flags: todo!(),
+            }),
             ReqKind::Del(obj_id) => KernelCommand::ObjectDel(obj_id),
-            ReqKind::Create(obj_id) => KernelCommand::ObjectCreate(ObjectInfo::new(obj_id)),
+            ReqKind::Create(obj_id) => {
+                KernelCommand::ObjectCreate(obj_id, ObjectInfo::new(LifetimeType::Persistent))
+            }
         };
         Some(RequestFromKernel::new(cmd))
     }

--- a/src/kernel/src/pager/queues.rs
+++ b/src/kernel/src/pager/queues.rs
@@ -94,7 +94,7 @@ pub(super) fn pager_request_handler_main() {
 
                 start_reclaim_thread();
                 // TODO
-                if is_test_mode() || true {
+                if is_test_mode() && false {
                     run_closure_in_new_thread(Priority::USER, || {
                         sim_memory_pressure();
                     });

--- a/src/kernel/src/pager/queues.rs
+++ b/src/kernel/src/pager/queues.rs
@@ -181,7 +181,8 @@ pub fn init_pager_queue(id: ObjID, outgoing: bool) {
         RECEIVER.call_once(|| receiver);
     }
     if SENDER.poll().is_some() && RECEIVER.poll().is_some() {
-        start_new_kernel(Priority::default_user(), pager_compl_handler_entry, 0);
-        start_new_kernel(Priority::default_user(), pager_request_handler_entry, 0);
+        // TODO: these should be higher?
+        start_new_kernel(Priority::USER, pager_compl_handler_entry, 0);
+        start_new_kernel(Priority::USER, pager_request_handler_entry, 0);
     }
 }

--- a/src/kernel/src/random/mod.rs
+++ b/src/kernel/src/random/mod.rs
@@ -148,7 +148,7 @@ pub fn start_entropy_contribution_thread() {
     // FIXME: currently this thread never is actually run again due to
     // default_background priority coupled with sys_thread_sync never actually
     // causing the thread to resume.
-    run_closure_in_new_thread(Priority::default_user(), || contribute_entropy_regularly());
+    run_closure_in_new_thread(Priority::USER, || contribute_entropy_regularly());
 }
 
 extern "C" fn contribute_entropy_regularly() {

--- a/src/kernel/src/syscall/object.rs
+++ b/src/kernel/src/syscall/object.rs
@@ -18,7 +18,10 @@ use twizzler_rt_abi::{
 
 use crate::{
     arch::context::ArchContext,
-    memory::context::{virtmem::Slot, Context, ContextRef, UserContext},
+    memory::{
+        context::{virtmem::Slot, Context, ContextRef, UserContext},
+        tracker::{FrameAllocFlags, FrameAllocator},
+    },
     mutex::Mutex,
     obj::{calculate_new_id, lookup_object, LookupFlags, Object, ObjectRef},
     once::Once,
@@ -46,12 +49,14 @@ pub fn sys_object_create(
         } else {
             let so = crate::obj::lookup_object(src.id, LookupFlags::empty())
                 .ok_or(ObjectError::NoSuchObject)?;
+            let mut fa = FrameAllocator::new(FrameAllocFlags::WAIT_OK | FrameAllocFlags::ZEROED);
             crate::obj::copy::copy_ranges(
                 &so,
                 src.src_start as usize,
                 &obj,
                 src.dest_start as usize,
                 src.len,
+                &mut fa,
             )
         }
     }

--- a/src/kernel/src/syscall/object.rs
+++ b/src/kernel/src/syscall/object.rs
@@ -20,6 +20,7 @@ use crate::{
     arch::context::ArchContext,
     memory::{
         context::{virtmem::Slot, Context, ContextRef, UserContext},
+        frame::PHYS_LEVEL_LAYOUTS,
         tracker::{FrameAllocFlags, FrameAllocator},
     },
     mutex::Mutex,
@@ -49,7 +50,10 @@ pub fn sys_object_create(
         } else {
             let so = crate::obj::lookup_object(src.id, LookupFlags::empty())
                 .ok_or(ObjectError::NoSuchObject)?;
-            let mut fa = FrameAllocator::new(FrameAllocFlags::WAIT_OK | FrameAllocFlags::ZEROED);
+            let mut fa = FrameAllocator::new(
+                FrameAllocFlags::WAIT_OK | FrameAllocFlags::ZEROED,
+                PHYS_LEVEL_LAYOUTS[0],
+            );
             crate::obj::copy::copy_ranges(
                 &so,
                 src.src_start as usize,

--- a/src/kernel/src/thread/entry.rs
+++ b/src/kernel/src/thread/entry.rs
@@ -39,13 +39,9 @@ extern "C" fn user_new_start() {
 pub fn start_new_user(args: ThreadSpawnArgs) -> twizzler_rt_abi::Result<ObjID> {
     let mut thread = if let Some(handle) = args.vm_context_handle {
         let vmc = get_vmcontext_from_handle(handle).ok_or(ArgumentError::BadHandle)?;
-        Thread::new(Some(vmc), Some(args), Priority::default_user())
+        Thread::new(Some(vmc), Some(args), Priority::USER)
     } else {
-        Thread::new(
-            current_memory_context(),
-            Some(args),
-            Priority::default_user(),
-        )
+        Thread::new(current_memory_context(), Some(args), Priority::USER)
     };
     match args.upcall_target {
         UpcallTargetSpawnOption::DefaultAbort => {}
@@ -67,11 +63,7 @@ pub fn start_new_user(args: ThreadSpawnArgs) -> twizzler_rt_abi::Result<ObjID> {
 }
 
 pub fn start_new_init() {
-    let mut thread = Thread::new(
-        Some(Arc::new(Context::new())),
-        None,
-        Priority::default_user(),
-    );
+    let mut thread = Thread::new(Some(Arc::new(Context::new())), None, Priority::USER);
     thread.secctx = SecCtxMgr::new(Arc::new(SecurityContext::new(None)));
     unsafe {
         thread.init(user_init);
@@ -187,7 +179,7 @@ mod test {
 
     #[kernel_test]
     fn test_closure() {
-        let x = super::run_closure_in_new_thread(Priority::default_user(), || 42)
+        let x = super::run_closure_in_new_thread(Priority::USER, || 42)
             .1
             .wait();
         assert_eq!(42, x);

--- a/src/kernel/src/thread/priority.rs
+++ b/src/kernel/src/thread/priority.rs
@@ -1,86 +1,74 @@
-use core::sync::atomic::{AtomicI32, Ordering};
+use core::{sync::atomic::Ordering, u32};
 
 use super::{current_thread_ref, flags::THREAD_HAS_DONATED_PRIORITY, Thread};
 /// [`Thread`]s are triggered based on their priority, which is their [`PriorityClass`] coupled
 /// with their adjustment number. Their
 /// [`  PriorityClass`]
-#[derive(Default, Debug)]
+#[derive(Default, Debug, PartialEq, Eq, Hash, Clone, Copy)]
 pub struct Priority {
-    pub(super) class: PriorityClass,
-    pub(super) adjust: AtomicI32,
+    raw: u32,
 }
+
 impl Priority {
-    #[allow(clippy::declare_interior_mutable_const)]
-    pub const REALTIME: Self = Self {
-        class: PriorityClass::RealTime,
-        adjust: AtomicI32::new(0),
-    };
+    pub const REALTIME: Self = Self::new(PriorityClass::RealTime, 0);
+    pub const USER: Self = Self::new(PriorityClass::User, 0);
+    pub const BACKGROUND: Self = Self::new(PriorityClass::Background, 0);
+    pub const IDLE: Self = Self::new(PriorityClass::Idle, 0);
+
+    pub const fn new(class: PriorityClass, adjust: u16) -> Self {
+        Self {
+            raw: ((class.as_u16() as u32) << 16) | adjust as u32,
+        }
+    }
+
+    pub fn from_raw(raw: u32) -> Self {
+        if raw == u32::MAX {
+            Self::IDLE
+        } else {
+            Self { raw }
+        }
+    }
+
+    pub fn raw(&self) -> u32 {
+        self.raw
+    }
+
+    pub fn class(&self) -> PriorityClass {
+        let upper = (self.raw >> 16) as u16;
+        PriorityClass::from(upper)
+    }
+
+    pub fn adjust(&self) -> u16 {
+        self.raw as u16
+    }
+
     pub fn queue_number<const NR_QUEUES: usize>(&self) -> usize {
         assert_eq!(NR_QUEUES % PriorityClass::ClassCount as usize, 0);
         let queues_per_class = NR_QUEUES / PriorityClass::ClassCount as usize;
-        assert!(queues_per_class > 0 && queues_per_class % 2 == 0);
-        let equilibrium = (queues_per_class / 2) as i32;
-        let base_queue = self.class as usize * queues_per_class + equilibrium as usize;
-        let adj = self
-            .adjust
-            .load(Ordering::SeqCst)
-            .clamp(-equilibrium, equilibrium);
-        let q = ((base_queue as i32) + adj) as usize;
+        assert!(queues_per_class > 0);
+        let base_queue = self.class() as usize * queues_per_class;
+        let adj = self.adjust().clamp(0, (queues_per_class - 1) as u16);
+        let q = base_queue + adj as usize;
         assert!(q < NR_QUEUES);
         q
     }
 
     pub fn from_queue_number<const NR_QUEUES: usize>(queue: usize) -> Self {
         if queue == NR_QUEUES {
-            return Self {
-                class: PriorityClass::Idle,
-                adjust: AtomicI32::new(i32::MAX),
-            };
+            return Self::new(PriorityClass::Idle, u16::MAX);
         }
         let queues_per_class = NR_QUEUES / PriorityClass::ClassCount as usize;
         let class = queue / queues_per_class;
         assert!(class < PriorityClass::ClassCount as usize);
-        let equilibrium = queues_per_class / 2;
-        let base_queue = class * queues_per_class + equilibrium;
-        let adj = queue as i32 - base_queue as i32;
-        Self {
-            class: unsafe { core::intrinsics::transmute(class as u32) },
-            adjust: AtomicI32::new(adj),
-        }
-    }
-
-    pub fn default_user() -> Self {
-        Self {
-            class: PriorityClass::User,
-            adjust: Default::default(),
-        }
-    }
-
-    pub fn default_realtime() -> Self {
-        Self {
-            class: PriorityClass::RealTime,
-            adjust: Default::default(),
-        }
-    }
-
-    pub fn default_idle() -> Self {
-        Self {
-            class: PriorityClass::Idle,
-            adjust: Default::default(),
-        }
-    }
-
-    pub fn default_background() -> Self {
-        Self {
-            class: PriorityClass::Background,
-            adjust: Default::default(),
-        }
+        let base_queue = class * queues_per_class;
+        let adj = queue.saturating_sub(base_queue);
+        Self::new(PriorityClass::from(class as u16), adj as u16)
     }
 }
 
-#[derive(Clone, Copy, PartialEq, Default, Debug)]
-#[repr(u32)]
-pub(super) enum PriorityClass {
+#[derive(Clone, Copy, PartialEq, Default, Debug, Eq)]
+#[repr(u16)]
+pub enum PriorityClass {
     /// Highest Priority
     RealTime = 0,
     /// Second highest priority
@@ -93,94 +81,95 @@ pub(super) enum PriorityClass {
     ClassCount = 4,
 }
 
-impl PartialEq for Priority {
-    fn eq(&self, other: &Self) -> bool {
-        self.class == other.class
-            && self.adjust.load(Ordering::Relaxed) == other.adjust.load(Ordering::Relaxed)
+impl From<PriorityClass> for u16 {
+    fn from(value: PriorityClass) -> Self {
+        value.as_u16()
+    }
+}
+
+impl From<u16> for PriorityClass {
+    fn from(value: u16) -> Self {
+        match value {
+            0 => Self::RealTime,
+            1 => Self::User,
+            2 => Self::Background,
+            _ => Self::Idle,
+        }
     }
 }
 
 impl PartialOrd for PriorityClass {
     fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
         /* backwards because of how priority works */
-        (*other as usize).partial_cmp(&(*self as usize))
+        (*other as u32).partial_cmp(&(*self as u32))
     }
 }
 
 impl PartialOrd for Priority {
     fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
-        match self.class.partial_cmp(&other.class) {
-            Some(core::cmp::Ordering::Equal) => {}
-            ord => return ord,
-        }
-        let thisadj = self.adjust.load(Ordering::Relaxed);
-        let thatadj = other.adjust.load(Ordering::Relaxed);
         /* backwards because of how priority works */
-        thatadj.partial_cmp(&thisadj)
+        other.raw.partial_cmp(&self.raw)
     }
-}
-
-impl Clone for Priority {
-    fn clone(&self) -> Self {
-        Self {
-            class: self.class,
-            adjust: AtomicI32::new(self.adjust.load(Ordering::SeqCst)),
-        }
-    }
-}
-
-impl Eq for Priority {
-    fn assert_receiver_is_total_eq(&self) {}
 }
 
 impl Ord for Priority {
     fn cmp(&self, other: &Self) -> core::cmp::Ordering {
-        //is this okay?
         self.partial_cmp(other).unwrap()
+    }
+}
+
+impl PriorityClass {
+    pub const fn as_u16(&self) -> u16 {
+        match self {
+            PriorityClass::RealTime => 0,
+            PriorityClass::User => 1,
+            PriorityClass::Background => 2,
+            PriorityClass::Idle => 3,
+            PriorityClass::ClassCount => 4,
+        }
     }
 }
 
 impl Thread {
     pub fn remove_donated_priority(&self) {
-        let current_priority = self.effective_priority();
-        let mut donated_priority = self.donated_priority.lock();
+        self.donated_priority.store(u32::MAX, Ordering::SeqCst);
         self.flags
             .fetch_and(!THREAD_HAS_DONATED_PRIORITY, Ordering::SeqCst);
-        *donated_priority = None;
-        drop(donated_priority);
-        if current_priority < self.effective_priority() {
-            self.maybe_reschedule_thread();
-        }
     }
 
     pub fn get_donated_priority(&self) -> Option<Priority> {
-        let d = self.donated_priority.lock();
-        (*d).clone()
+        if self.flags.load(Ordering::SeqCst) & THREAD_HAS_DONATED_PRIORITY != 0 {
+            let d = self.donated_priority.load(Ordering::SeqCst);
+            if d == u32::MAX {
+                None
+            } else {
+                Some(Priority::from_raw(d))
+            }
+        } else {
+            None
+        }
     }
 
     pub fn effective_priority(&self) -> Priority {
+        let priority = Priority::from_raw(self.priority.load(Ordering::SeqCst));
         if self.flags.load(Ordering::SeqCst) & THREAD_HAS_DONATED_PRIORITY != 0 {
-            let donated_priority = self.donated_priority.lock();
-            if let Some(ref donated) = *donated_priority {
-                return core::cmp::max(donated.clone(), self.priority.clone());
-            }
+            let donated_priority = Priority::from_raw(self.donated_priority.load(Ordering::SeqCst));
+            return core::cmp::max(donated_priority, priority);
         }
-        self.priority.clone()
+        priority
     }
 
     pub fn donate_priority(&self, pri: Priority) -> bool {
         let current_priority = self.effective_priority();
-        let mut donated_priority = self.donated_priority.lock();
-        if let Some(ref current) = *donated_priority {
-            if current > &pri {
+        if let Some(current) = self.get_donated_priority() {
+            if current > pri {
                 return false;
             }
         }
         let needs_resched = pri > current_priority;
-        *donated_priority = Some(pri);
+        self.donated_priority.store(pri.raw(), Ordering::SeqCst);
         self.flags
             .fetch_or(THREAD_HAS_DONATED_PRIORITY, Ordering::SeqCst);
-        drop(donated_priority);
         if needs_resched {
             if let Some(cur) = current_thread_ref() {
                 if cur.id() == self.id() {
@@ -194,6 +183,61 @@ impl Thread {
 
     #[inline]
     pub fn queue_number<const NR_QUEUES: usize>(&self) -> usize {
-        self.priority.queue_number::<NR_QUEUES>()
+        self.effective_priority().queue_number::<NR_QUEUES>()
+    }
+}
+
+mod test {
+    use core::u16;
+
+    use twizzler_kernel_macros::kernel_test;
+
+    use super::*;
+
+    #[kernel_test]
+    fn test_priority() {
+        assert!(Priority::REALTIME > Priority::USER);
+        assert!(Priority::REALTIME > Priority::BACKGROUND);
+        assert!(Priority::REALTIME > Priority::IDLE);
+        assert!(Priority::USER > Priority::BACKGROUND);
+        assert!(Priority::USER > Priority::IDLE);
+        assert!(Priority::BACKGROUND > Priority::IDLE);
+
+        let pri = Priority::BACKGROUND;
+        let raw = pri.raw();
+        let new_pri = Priority::from_raw(raw);
+        assert_eq!(pri, new_pri);
+    }
+
+    #[kernel_test]
+    fn test_queue_number() {
+        for i in 0..u16::MAX {
+            let pri = Priority::new(PriorityClass::User, i);
+            let q = pri.queue_number::<64>();
+
+            let pri2 = Priority::new(PriorityClass::Background, i);
+            let q2 = pri2.queue_number::<64>();
+            assert!(q < q2);
+        }
+    }
+
+    #[kernel_test]
+    fn test_queue_number_roundtrip() {
+        for i in 0..u16::MAX {
+            for class in [
+                PriorityClass::Idle,
+                PriorityClass::Background,
+                PriorityClass::RealTime,
+                PriorityClass::User,
+            ] {
+                let pri = Priority::new(class, i);
+                let q = pri.queue_number::<64>();
+                let new_pri = Priority::from_queue_number::<64>(q);
+
+                let q = new_pri.queue_number::<64>();
+                let new_pri2 = Priority::from_queue_number::<64>(q);
+                assert_eq!(new_pri, new_pri2);
+            }
+        }
     }
 }

--- a/src/kernel/src/thread/suspend.rs
+++ b/src/kernel/src/thread/suspend.rs
@@ -122,7 +122,7 @@ mod test {
         let incr = Arc::new(Spinlock::new(0));
         let incr2 = incr.clone();
         let exit_flag = &AtomicBool::default();
-        let test_thread = run_closure_in_new_thread(Priority::default_user(), move || loop {
+        let test_thread = run_closure_in_new_thread(Priority::USER, move || loop {
             if exit_flag.load(Ordering::SeqCst) {
                 break;
             }

--- a/src/lib/twizzler-abi/src/pager.rs
+++ b/src/lib/twizzler-abi/src/pager.rs
@@ -1,3 +1,4 @@
+use bitflags::bitflags;
 use twizzler_rt_abi::{error::RawTwzError, object::ObjID};
 
 use crate::{
@@ -44,15 +45,27 @@ pub enum KernelCommand {
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Ord, Eq)]
 pub struct CompletionToKernel {
     data: KernelCompletionData,
+    flags: KernelCompletionFlags,
+}
+
+bitflags! {
+    #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Ord, Eq)]
+    pub struct KernelCompletionFlags: u32 {
+        const DONE = 1;
+    }
 }
 
 impl CompletionToKernel {
-    pub fn new(data: KernelCompletionData) -> Self {
-        Self { data }
+    pub fn new(data: KernelCompletionData, flags: KernelCompletionFlags) -> Self {
+        Self { data, flags }
     }
 
     pub fn data(&self) -> KernelCompletionData {
         self.data
+    }
+
+    pub fn flags(&self) -> KernelCompletionFlags {
+        self.flags
     }
 }
 
@@ -61,7 +74,7 @@ pub enum KernelCompletionData {
     Okay,
     Error(RawTwzError),
     PageDataCompletion(ObjID, ObjectRange, PhysRange),
-    ObjectInfoCompletion(ObjectInfo),
+    ObjectInfoCompletion(ObjID, ObjectInfo),
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Ord, Eq)]
@@ -111,7 +124,6 @@ pub enum PagerCompletionData {
     Okay,
     Error(RawTwzError),
     DramPages(PhysRange),
-    Ready(ObjID),
 }
 
 pub struct PageDataReq {

--- a/src/ports/hw-c/Cargo.toml
+++ b/src/ports/hw-c/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "hw-c"
 version = "0.1.0"
+edition = "2021"
 
 [dependencies]
 

--- a/src/srv/pager-srv/Cargo.toml
+++ b/src/srv/pager-srv/Cargo.toml
@@ -21,6 +21,7 @@ devmgr = { path = "../../lib/devmgr" }
 slab = { version = "*", features = [] }
 blocking = "*"
 itertools = "*"
+stable-vec = "*"
 
 async-trait = "0.1.66"
 volatile = "0.6"

--- a/src/srv/pager-srv/src/lib.rs
+++ b/src/srv/pager-srv/src/lib.rs
@@ -37,7 +37,7 @@ pub static EXECUTOR: OnceLock<Executor> = OnceLock::new();
 fn tracing_init() {
     tracing::subscriber::set_global_default(
         tracing_subscriber::fmt()
-            .with_max_level(tracing::Level::INFO)
+            .with_max_level(tracing::Level::DEBUG)
             .without_time()
             .finish(),
     )
@@ -145,7 +145,7 @@ async fn listen_queue<R, C, F>(
     handler: impl Fn(&'static PagerContext, R) -> F + Copy + Send + Sync + 'static,
     ex: &'static Executor<'static>,
 ) where
-    F: std::future::Future<Output = Option<C>> + Send + 'static,
+    F: std::future::Future<Output = C> + Send + 'static,
     R: std::fmt::Debug + Copy + Send + Sync + 'static,
     C: std::fmt::Debug + Copy + Send + Sync + 'static,
 {
@@ -164,14 +164,12 @@ async fn listen_queue<R, C, F>(
     }
 }
 
-async fn notify<R, C>(q: &Arc<twizzler_queue::CallbackQueueReceiver<R, C>>, id: u32, res: Option<C>)
+async fn notify<R, C>(q: &Arc<twizzler_queue::CallbackQueueReceiver<R, C>>, id: u32, res: C)
 where
     R: std::fmt::Debug + Copy + Send + Sync,
     C: std::fmt::Debug + Copy + Send + Sync + 'static,
 {
-    if let Some(res) = res {
-        q.complete(id, res).await.unwrap();
-    }
+    q.complete(id, res).await.unwrap();
     tracing::trace!("request {} complete", id);
 }
 

--- a/src/srv/pager-srv/src/request_handle.rs
+++ b/src/srv/pager-srv/src/request_handle.rs
@@ -47,12 +47,7 @@ pub async fn handle_kernel_request(
                 )))
             }
         }
-        KernelCommand::ObjectSync(obj_id) => {
-            ctx.data.sync(ctx, obj_id).await;
-            Some(CompletionToKernel::new(KernelCompletionData::SyncOkay(
-                obj_id,
-            )))
-        }
+
         KernelCommand::ObjectDel(obj_id) => {
             if ctx.paged_ostore.delete_object(obj_id.raw()).is_ok() {
                 let _ = ctx
@@ -64,10 +59,10 @@ pub async fn handle_kernel_request(
                 obj_id,
             )))
         }
-        KernelCommand::ObjectCreate(object_info) => {
-            let _ = ctx.paged_ostore.delete_object(object_info.obj_id.raw());
-            if let Err(e) = ctx.paged_ostore.create_object(object_info.obj_id.raw()) {
-                tracing::warn!("failed to create object {}: {}", object_info.obj_id, e);
+        KernelCommand::ObjectCreate(id, object_info) => {
+            let _ = ctx.paged_ostore.delete_object(id.raw());
+            if let Err(e) = ctx.paged_ostore.create_object(id.raw()) {
+                tracing::warn!("failed to create object {}: {}", id, e);
                 Some(CompletionToKernel::new(KernelCompletionData::Error))
             } else {
                 Some(CompletionToKernel::new(
@@ -78,6 +73,10 @@ pub async fn handle_kernel_request(
         KernelCommand::DramPages(phys_range) => {
             tracing::debug!("tracking {} MB memory", phys_range.len() / (1024 * 1024));
             ctx.data.init_range(phys_range);
+            Some(CompletionToKernel::new(KernelCompletionData::Okay))
+        }
+        KernelCommand::ObjectEvict(obj_id) => {
+            ctx.data.sync(ctx, obj_id).await;
             Some(CompletionToKernel::new(KernelCompletionData::Okay))
         }
     }

--- a/src/srv/pager-srv/src/request_handle.rs
+++ b/src/srv/pager-srv/src/request_handle.rs
@@ -52,10 +52,10 @@ pub async fn handle_kernel_request(
             }
             Err(e) => KernelCompletionData::Error(TwzError::from(e).into()),
         },
-        KernelCommand::ObjectCreate(id, _object_info) => {
+        KernelCommand::ObjectCreate(id, object_info) => {
             let _ = ctx.paged_ostore.delete_object(id.raw());
             match ctx.paged_ostore.create_object(id.raw()) {
-                Ok(_) => KernelCompletionData::Okay,
+                Ok(_) => KernelCompletionData::ObjectInfoCompletion(id, object_info),
                 Err(e) => {
                     tracing::warn!("failed to create object {}: {}", id, e);
                     KernelCompletionData::Error(TwzError::from(e).into())

--- a/src/srv/pager-srv/src/request_handle.rs
+++ b/src/srv/pager-srv/src/request_handle.rs
@@ -1,83 +1,77 @@
 use twizzler::object::ObjID;
 use twizzler_abi::pager::{
-    CompletionToKernel, KernelCommand, KernelCompletionData, ObjectInfo, ObjectRange, PhysRange,
-    RequestFromKernel,
+    CompletionToKernel, KernelCommand, KernelCompletionData, KernelCompletionFlags, ObjectInfo,
+    ObjectRange, PhysRange, RequestFromKernel,
 };
+use twizzler_rt_abi::{error::TwzError, Result};
 
 use crate::PagerContext;
 
-async fn page_data_req(
+async fn handle_page_data_request(
     ctx: &'static PagerContext,
     id: ObjID,
     range: ObjectRange,
-) -> Option<PhysRange> {
+) -> Result<PhysRange> {
     ctx.data
         .fill_mem_page(ctx, id, range)
         .await
         .inspect_err(|e| tracing::warn!("page data request failed: {}", e))
-        .ok()
 }
 
-fn object_info_req(ctx: &PagerContext, id: ObjID) -> Option<ObjectInfo> {
+fn object_info_req(ctx: &PagerContext, id: ObjID) -> Result<ObjectInfo> {
     ctx.data.lookup_object(ctx, id)
 }
 
 pub async fn handle_kernel_request(
     ctx: &'static PagerContext,
     request: RequestFromKernel,
-) -> Option<CompletionToKernel> {
+) -> CompletionToKernel {
     tracing::debug!("handling kernel request {:?}", request);
 
-    match request.cmd() {
-        KernelCommand::PageDataReq(obj_id, range) => Some(CompletionToKernel::new(
-            if let Some(phys_range) = page_data_req(ctx, obj_id, range).await {
-                KernelCompletionData::PageDataCompletion(obj_id, range, phys_range)
-            } else {
-                KernelCompletionData::Error
-            },
-        )),
-        KernelCommand::ObjectInfoReq(obj_id) => {
-            if let Some(obj_info) = object_info_req(ctx, obj_id) {
-                Some(CompletionToKernel::new(
-                    KernelCompletionData::ObjectInfoCompletion(obj_info),
-                ))
-            } else {
-                Some(CompletionToKernel::new(KernelCompletionData::NoSuchObject(
-                    obj_id,
-                )))
+    let data = match request.cmd() {
+        KernelCommand::PageDataReq(obj_id, range) => {
+            match handle_page_data_request(ctx, obj_id, range).await {
+                Ok(phys_range) => {
+                    KernelCompletionData::PageDataCompletion(obj_id, range, phys_range)
+                }
+                Err(e) => KernelCompletionData::Error(e.into()),
             }
         }
+        KernelCommand::ObjectInfoReq(obj_id) => match object_info_req(ctx, obj_id) {
+            Ok(info) => KernelCompletionData::ObjectInfoCompletion(obj_id, info),
+            Err(e) => KernelCompletionData::Error(e.into()),
+        },
 
-        KernelCommand::ObjectDel(obj_id) => {
-            if ctx.paged_ostore.delete_object(obj_id.raw()).is_ok() {
+        KernelCommand::ObjectDel(obj_id) => match ctx.paged_ostore.delete_object(obj_id.raw()) {
+            Ok(_) => {
                 let _ = ctx
                     .paged_ostore
                     .flush()
                     .inspect_err(|e| tracing::warn!("failed to advance epoch: {}", e));
+                KernelCompletionData::Okay
             }
-            Some(CompletionToKernel::new(KernelCompletionData::SyncOkay(
-                obj_id,
-            )))
-        }
-        KernelCommand::ObjectCreate(id, object_info) => {
+            Err(e) => KernelCompletionData::Error(TwzError::from(e).into()),
+        },
+        KernelCommand::ObjectCreate(id, _object_info) => {
             let _ = ctx.paged_ostore.delete_object(id.raw());
-            if let Err(e) = ctx.paged_ostore.create_object(id.raw()) {
-                tracing::warn!("failed to create object {}: {}", id, e);
-                Some(CompletionToKernel::new(KernelCompletionData::Error))
-            } else {
-                Some(CompletionToKernel::new(
-                    KernelCompletionData::ObjectInfoCompletion(object_info),
-                ))
+            match ctx.paged_ostore.create_object(id.raw()) {
+                Ok(_) => KernelCompletionData::Okay,
+                Err(e) => {
+                    tracing::warn!("failed to create object {}: {}", id, e);
+                    KernelCompletionData::Error(TwzError::from(e).into())
+                }
             }
         }
         KernelCommand::DramPages(phys_range) => {
-            tracing::debug!("tracking {} MB memory", phys_range.len() / (1024 * 1024));
-            ctx.data.init_range(phys_range);
-            Some(CompletionToKernel::new(KernelCompletionData::Okay))
+            tracing::debug!("tracking {} KB memory", phys_range.len() / 1024);
+            ctx.data.add_memory_range(phys_range);
+            KernelCompletionData::Okay
         }
-        KernelCommand::ObjectEvict(obj_id) => {
-            ctx.data.sync(ctx, obj_id).await;
-            Some(CompletionToKernel::new(KernelCompletionData::Okay))
+        KernelCommand::ObjectEvict(info) => {
+            ctx.data.sync(ctx, info.obj_id).await;
+            KernelCompletionData::Okay
         }
-    }
+    };
+
+    CompletionToKernel::new(data, KernelCompletionFlags::DONE)
 }

--- a/tools/xtask/src/build.rs
+++ b/tools/xtask/src/build.rs
@@ -95,6 +95,7 @@ fn build_third_party<'a>(
         return Ok(vec![]);
     }
     crate::toolchain::set_static();
+    crate::toolchain::set_cc(&build_config.twz_triple());
     let config = user_workspace.gctx();
     let smap = SourceConfigMap::new(config)?;
     let mut registry = PackageRegistry::new_with_source_config(config, smap)?;

--- a/tools/xtask/src/main.rs
+++ b/tools/xtask/src/main.rs
@@ -102,6 +102,8 @@ enum MessageFormat {
 
 #[derive(Args, Debug)]
 struct CheckOptions {
+    #[clap(short, long)]
+    package: Option<String>,
     #[clap(flatten)]
     pub config: BuildConfig,
     #[clap(long, short)]
@@ -116,6 +118,8 @@ struct CheckOptions {
     all_targets: bool,
     #[clap(long)]
     keep_going: bool,
+    #[clap(long)]
+    bin: Option<String>,
 }
 
 #[derive(Args, Debug, Clone)]


### PR DESCRIPTION
This PR:

- Adds a tracking mechanism to physical memory allocation and adds a reclaim thread
- Adds support for large frames to physical memory allocation (note, frames can split, but recombination will be done by a background thread, in another PR)
- Cleans up the pager-kernel interaction data types
- Removes lazy-static from the kernel (correctness issue)
- Fixes priority data structures and re-enables priority donation

Most of the churn is in the lazy-static removal, most of the new code is in the memory tracking.

Also note that there are a few TODOs in there for the next PR, as they will need to be fixed by further intrusive API modification.