### PR TITLE
Fix benchmark starting in unittest.

### DIFF
--- a/src/bin/unittest/src/main.rs
+++ b/src/bin/unittest/src/main.rs
@@ -4,8 +4,80 @@ use unittest_report::{Report, ReportInfo, TestResult};
 
 static RESULT: OnceLock<Report> = OnceLock::new();
 
+fn try_bench(path: &str) {
+    let Ok(file) = std::fs::File::open(path) else {
+        return;
+    };
+    println!("starting benchmarking ({})", path);
+    let start = Instant::now();
+    for line in std::io::BufReader::new(file).lines() {
+        if let Ok(line) = &line {
+            if line.contains("\u{0000}") {
+                continue;
+            }
+            if !line.is_ascii() {
+                continue;
+            }
+            println!("STARTING {}", line);
+            let mut possibles = Vec::new();
+            for exe in std::fs::read_dir("/initrd").unwrap() {
+                if exe
+                    .as_ref()
+                    .unwrap()
+                    .file_name()
+                    .to_string_lossy()
+                    .starts_with(line)
+                {
+                    possibles.push(format!(
+                        "/initrd/{}",
+                        exe.as_ref().unwrap().file_name().to_string_lossy()
+                    ));
+                }
+                if exe
+                    .as_ref()
+                    .unwrap()
+                    .file_name()
+                    .to_string_lossy()
+                    .starts_with(&line.replace("-", "_"))
+                {
+                    possibles.push(format!(
+                        "/initrd/{}",
+                        exe.as_ref().unwrap().file_name().to_string_lossy()
+                    ));
+                }
+            }
+            for (i, exe) in possibles.iter().enumerate() {
+                if let Ok(test_comp) = monitor_api::CompartmentLoader::new(
+                    &exe,
+                    &exe,
+                    monitor_api::NewCompartmentFlags::empty(),
+                )
+                .args(&[exe.as_str(), "--bench"])
+                .load()
+                {
+                    let mut flags = test_comp.info().flags;
+                    while !flags.contains(monitor_api::CompartmentFlags::EXITED) {
+                        flags = test_comp.wait(flags);
+                    }
+                } else {
+                    if i == possibles.len() - 1 {
+                        eprintln!("failed to start {}", line);
+                    }
+                }
+            }
+        }
+    }
+    let dur = Instant::now() - start;
+    println!("unittest: benches finished in {:?}", dur);
+}
+
 fn main() {
-    let file = std::fs::File::open("/initrd/test_bins").expect("no test binaries specified");
+    try_bench("/initrd/bench_bins");
+    try_bench("/initrd/bench_bin");
+    let Ok(file) = std::fs::File::open("/initrd/test_bins") else {
+        eprintln!("failed to open test bins");
+        return;
+    };
 
     let heartbeat_thread = std::thread::spawn(|| io_heartbeat());
 

--- a/tools/xtask/src/main.rs
+++ b/tools/xtask/src/main.rs
@@ -128,8 +128,10 @@ struct ImageOptions {
     pub config: BuildConfig,
     #[clap(long, short, help = "Build tests-enabled system.")]
     tests: bool,
-    #[clap(long, short, help = "Build benchmark-enabled system.")]
+    #[clap(long, help = "Build benchmark-enabled system.")]
     benches: bool,
+    #[clap(long, short, help = "Select a single program to bench.")]
+    bench: Option<String>,
     #[clap(long, short, help = "Only build kernel part of system.")]
     kernel: bool,
     #[clap(long, short, help = "Share a file/directory with Twizzler")]
@@ -142,7 +144,7 @@ impl From<ImageOptions> for BuildOptions {
     fn from(io: ImageOptions) -> Self {
         Self {
             config: io.config,
-            tests: io.tests || io.benches,
+            tests: io.tests || io.benches || io.bench.is_some(),
             kernel: io.kernel,
         }
     }
@@ -162,10 +164,11 @@ struct QemuOptions {
     tests: bool,
     #[clap(
         long,
-        short,
         help = "Run benchmarks instead of booting normally. Can be used with --tests."
     )]
     benches: bool,
+    #[clap(long, short, help = "Select a single program to bench.")]
+    bench: Option<String>,
     #[clap(long, short, help = "Only build kernel part of system.")]
     kernel: bool,
     #[clap(long, short, help = "Share a file/directory with Twizzler")]
@@ -189,6 +192,7 @@ impl From<&QemuOptions> for ImageOptions {
             kernel: qo.kernel,
             data: qo.data.clone(),
             autostart: qo.autostart.clone(),
+            bench: qo.bench.clone(),
         }
     }
 }

--- a/tools/xtask/src/qemu.rs
+++ b/tools/xtask/src/qemu.rs
@@ -151,7 +151,7 @@ impl QemuCommand {
                 self.cmd.arg("-machine").arg("q35,nvdimm=on");
 
                 // add qemu exit device for testing
-                if options.tests || options.benches {
+                if options.tests || options.benches || options.bench.is_some() {
                     // x86 specific
                     self.cmd
                         .arg("-device")
@@ -292,7 +292,7 @@ pub(crate) fn do_start_qemu(cli: QemuOptions) -> anyhow::Result<()> {
         }
         Ok(())
     } else {
-        if cli.tests || cli.benches {
+        if cli.tests || cli.benches || cli.bench.is_some() {
             if exit_status.code().unwrap() == 1 {
                 eprintln!("qemu reports tests passed");
                 if cli.repeat {


### PR DESCRIPTION
This PR fixes the benchmarking mechanism in the build system and in the unittest runner:

- The start-qemu and build-image command lines now support --bench <crate-name> to run a specific, single crate's bench program. They still support --benches and --tests in the same way.
- Benches get run if either --bench or --benches are supplied.

One benchmark is implemented as a test in twizzler-abi/lib.rs.