### PR TITLE
Add GDB initial support

### DIFF
--- a/.gdbinit
+++ b/.gdbinit
@@ -1,0 +1,2 @@
+set sysroot target/debug_sysroot
+target remote :2159

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1494,6 +1494,7 @@ dependencies = [
  "tracing",
  "tracing-log",
  "tracing-subscriber",
+ "twizzler",
  "twizzler-abi",
  "twizzler-rt-abi",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -385,6 +385,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "backtrace-ext"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "537beee3be4a18fb023b570f80e3ae28003db9167a751266b259926e25539d50"
+dependencies = [
+ "backtrace",
+]
+
+[[package]]
 name = "backtracer_core"
 version = "0.0.7"
 source = "git+https://github.com/twizzler-operating-system/backtracer?branch=twizzler#0b85917581f463464fb30980fad86f7856334e46"
@@ -1474,6 +1483,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "debug"
+version = "0.1.0"
+dependencies = [
+ "clap",
+ "gdbstub",
+ "gdbstub_arch",
+ "miette",
+ "monitor-api",
+ "tracing",
+ "tracing-log",
+ "tracing-subscriber",
+ "twizzler-abi",
+ "twizzler-rt-abi",
+]
+
+[[package]]
 name = "der"
 version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2107,6 +2132,30 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "gdbstub"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71d66e32caf5dd59f561be0143e413e01d651bd8498eb9aa0be8c482c81c8d31"
+dependencies = [
+ "bitflags 2.9.0",
+ "cfg-if 1.0.0",
+ "log",
+ "managed",
+ "num-traits",
+ "paste",
+]
+
+[[package]]
+name = "gdbstub_arch"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22dde0e1b68787036ccedd0b1ff6f953527a0e807e571fbe898975203027278f"
+dependencies = [
+ "gdbstub",
+ "num-traits",
 ]
 
 [[package]]
@@ -3666,6 +3715,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
+name = "is_ci"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7655c9839580ee829dfacba1d1278c2b7883e50a277ff7541299489d6bdfdc45"
+
+[[package]]
 name = "is_executable"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4080,6 +4135,12 @@ name = "lwext4-rs"
 version = "0.1.0"
 
 [[package]]
+name = "managed"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ca88d725a0a943b096803bd34e73a4437208b6077654cc4ecb2947a5f91618d"
+
+[[package]]
 name = "matchers"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4139,8 +4200,16 @@ version = "7.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a955165f87b37fd1862df2a59547ac542c77ef6d17c666f619d1ad22dd89484"
 dependencies = [
+ "backtrace",
+ "backtrace-ext",
  "cfg-if 1.0.0",
  "miette-derive",
+ "owo-colors",
+ "supports-color",
+ "supports-hyperlinks",
+ "supports-unicode",
+ "terminal_size",
+ "textwrap",
  "thiserror 1.0.69",
  "unicode-width 0.1.14",
 ]
@@ -4743,6 +4812,12 @@ name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
+name = "owo-colors"
+version = "4.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1036865bb9422d3300cf723f657c2851d0e9ab12567854b1f4eba3d77decf564"
 
 [[package]]
 name = "p256"
@@ -6115,6 +6190,15 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "supports-color"
+version = "3.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c64fc7232dd8d2e4ac5ce4ef302b1d81e0b80d055b9d77c7c4f51f6aa4c867d6"
+dependencies = [
+ "is_ci",
+]
 
 [[package]]
 name = "supports-hyperlinks"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,7 @@ members = [
     #"src/bin/ls",
     #"src/lib/devmgr",
     #"src/bin/serialecho", "tools/serialtest",
-    "src/bin/ptest",
+    "src/bin/ptest", "src/bin/debug",
 ]
 
 exclude = ["toolchain/src/rust", "src/ports/candle-test/candle", "src/ports/candle-test/gemm"]
@@ -71,6 +71,7 @@ initrd = [
     "lib:pager-srv",
     "crate:unittest",
     "crate:uuhelper",
+    "crate:debug",
 
     "crate:sec-test",
     "crate:ptest",

--- a/doc/src/Debug.md
+++ b/doc/src/Debug.md
@@ -1,0 +1,32 @@
+# Debugging
+
+Debugging support is in-progress on Twizzler. Currently, you can debug userspace programs via GDB in a limited way.
+
+## Using the debug stub in QEMU
+
+To debug a program in Twizzler from within QEMU, you can run it under the debug stub program:
+
+```
+debug run <your-program>
+```
+
+The program will start in a suspended state and wait for a debugger connection. From the host machine,
+start GDB in the twizzler source directory. This will run the .gdbinit script and will configure GDB for
+debugging Twizzler userspace programs. Note that this file may trigger a warning that it needs to be allowed
+to run. If that warning pops up, follow its instructions.
+
+At this point, you should see the (gdb) prompt and it should have connected to the debug stub. If not, you can
+try connecting manually via `target remote :2159`. Note that many features are missing, but are in the process
+of being added.
+
+## Using the debug stub to attach to a crashed compartment
+
+TODO
+
+## Planned additional features
+
+ - Single stepping
+ - Memory map reading
+ - Multithreaded debugging
+ - Signals
+

--- a/doc/src/Debug.md
+++ b/doc/src/Debug.md
@@ -37,8 +37,9 @@ TODO
 
 ## Planned additional features
 
- - Setting / clearing breakpoints
- - Single stepping
+ - Setting / clearing breakpoints (in-progress)
+ - Single stepping (in-progress)
  - Memory map reading
  - Multithreaded debugging
  - Signals
+ - Support for aarch64

--- a/doc/src/Debug.md
+++ b/doc/src/Debug.md
@@ -23,10 +23,22 @@ of being added.
 
 TODO
 
+## Some other debugging techniques
+
+ - Loading of compartments and libraries can be printed by specifying MONDEBUG=1 as an environment variable when starting programs.
+ - Many system services use the tracing crate for logging. You can increase the verbosity by changing the log level in the relevant initialization routines. TODO: get these from environment variables.
+ - The kernel uses the log crate, and its verbosity is controlled in main.rs.
+
+## Working features
+
+ - Reading registers
+ - Reading and poking memory
+ - Tracing stopped threads
+
 ## Planned additional features
 
+ - Setting / clearing breakpoints
  - Single stepping
  - Memory map reading
  - Multithreaded debugging
  - Signals
-

--- a/doc/src/SUMMARY.md
+++ b/doc/src/SUMMARY.md
@@ -4,6 +4,10 @@
 
 [Building Twizzler](./BUILD.md)
 
+[Developing on Twizzler](./develop.md)
+
+[Debugging Twizzler](./Debug.md)
+
 # Fundamentals
 
 - [Objects](./Object.md)

--- a/src/bin/bootstrap/src/main.rs
+++ b/src/bin/bootstrap/src/main.rs
@@ -61,7 +61,10 @@ impl ContextEngine for Engine {
                     );
                 return Err(DynlinkErrorKind::NewBackingFail.into());
             }
-            Ok((Backing::new(text_handle), Backing::new(data_handle)))
+            Ok((
+                Backing::new(text_handle, src.full_name().to_owned()),
+                Backing::new(data_handle, src.full_name().to_owned()),
+            ))
         };
         dynlink::engines::twizzler::load_segments(src, ld, 0.into(), map)
     }
@@ -71,6 +74,7 @@ impl ContextEngine for Engine {
         Ok(Backing::new(
             twizzler_rt_abi::object::twz_rt_map_object(id, MapFlags::READ)
                 .map_err(|_err| DynlinkErrorKind::NewBackingFail)?,
+            unlib.name.clone(),
         ))
     }
 

--- a/src/bin/debug/Cargo.toml
+++ b/src/bin/debug/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "debug"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+gdbstub = "*"
+gdbstub_arch = "*"
+clap = { version = "4", features = ["derive"] }
+miette = { version = "*", features = ["fancy"] }
+tracing = "*"
+tracing-subscriber = "*"
+tracing-log = "*"
+twizzler-abi = { path = "../../lib/twizzler-abi" }
+twizzler-rt-abi = { path = "../../abi/rt-abi" }
+monitor-api = { path = "../../rt/monitor-api" }

--- a/src/bin/debug/Cargo.toml
+++ b/src/bin/debug/Cargo.toml
@@ -14,3 +14,4 @@ tracing-log = "*"
 twizzler-abi = { path = "../../lib/twizzler-abi" }
 twizzler-rt-abi = { path = "../../abi/rt-abi" }
 monitor-api = { path = "../../rt/monitor-api" }
+twizzler = { path = "../../lib/twizzler" }

--- a/src/bin/debug/src/gdb.rs
+++ b/src/bin/debug/src/gdb.rs
@@ -1,0 +1,238 @@
+#![allow(unused)]
+
+use std::{
+    fs::File,
+    io::{Read, Write},
+    os::fd::{AsFd, FromRawFd},
+    time::Duration,
+};
+
+use gdbstub::{
+    conn::{Connection, ConnectionExt},
+    stub::{
+        MultiThreadStopReason,
+        run_blocking::{Event, WaitForStopReasonError},
+    },
+    target::{
+        Target,
+        ext::{
+            base::{BaseOps, multithread::MultiThreadBase},
+            breakpoints::{Breakpoints, SwBreakpoint},
+        },
+    },
+};
+use miette::IntoDiagnostic;
+use monitor_api::CompartmentHandle;
+use twizzler_abi::syscall::{KernelConsoleReadFlags, KernelConsoleWriteFlags};
+use twizzler_rt_abi::error::TwzError;
+
+pub struct TwizzlerGdb {}
+
+impl gdbstub::stub::run_blocking::BlockingEventLoop for TwizzlerGdb {
+    type Target = TwizzlerTarget;
+
+    type Connection = TwizzlerConn;
+
+    type StopReason = MultiThreadStopReason<u64>;
+
+    fn wait_for_stop_reason(
+        target: &mut Self::Target,
+        conn: &mut Self::Connection,
+    ) -> Result<
+        Event<Self::StopReason>,
+        WaitForStopReasonError<
+            <Self::Target as gdbstub::target::Target>::Error,
+            <Self::Connection as gdbstub::conn::Connection>::Error,
+        >,
+    > {
+        tracing::debug!("waiting for stop reason or data");
+        loop {
+            if conn
+                .peek()
+                .map_err(|e| WaitForStopReasonError::Connection(e))?
+                .is_some()
+            {
+                let byte = conn
+                    .read()
+                    .map_err(|e| WaitForStopReasonError::Connection(e))?;
+                return Ok(Event::IncomingData(byte));
+            } else if false {
+                return Ok(Event::TargetStopped(MultiThreadStopReason::Exited(0)));
+            } else {
+                std::thread::sleep(Duration::from_millis(10));
+            }
+        }
+    }
+
+    fn on_interrupt(
+        target: &mut Self::Target,
+    ) -> Result<Option<Self::StopReason>, <Self::Target as gdbstub::target::Target>::Error> {
+        // TODO
+        Ok(None)
+    }
+}
+
+pub struct TwizzlerTarget {
+    comp: CompartmentHandle,
+}
+
+impl TwizzlerTarget {
+    pub fn new(comp: CompartmentHandle) -> Self {
+        Self { comp }
+    }
+}
+
+impl MultiThreadBase for TwizzlerTarget {
+    fn read_registers(
+        &mut self,
+        regs: &mut <Self::Arch as gdbstub::arch::Arch>::Registers,
+        tid: gdbstub::common::Tid,
+    ) -> gdbstub::target::TargetResult<(), Self> {
+        todo!()
+    }
+
+    fn write_registers(
+        &mut self,
+        regs: &<Self::Arch as gdbstub::arch::Arch>::Registers,
+        tid: gdbstub::common::Tid,
+    ) -> gdbstub::target::TargetResult<(), Self> {
+        todo!()
+    }
+
+    fn read_addrs(
+        &mut self,
+        start_addr: <Self::Arch as gdbstub::arch::Arch>::Usize,
+        data: &mut [u8],
+        tid: gdbstub::common::Tid,
+    ) -> gdbstub::target::TargetResult<usize, Self> {
+        todo!()
+    }
+
+    fn write_addrs(
+        &mut self,
+        start_addr: <Self::Arch as gdbstub::arch::Arch>::Usize,
+        data: &[u8],
+        tid: gdbstub::common::Tid,
+    ) -> gdbstub::target::TargetResult<(), Self> {
+        todo!()
+    }
+
+    fn list_active_threads(
+        &mut self,
+        thread_is_active: &mut dyn FnMut(gdbstub::common::Tid),
+    ) -> Result<(), Self::Error> {
+        todo!()
+    }
+}
+
+impl Breakpoints for TwizzlerTarget {
+    fn support_sw_breakpoint(
+        &mut self,
+    ) -> Option<gdbstub::target::ext::breakpoints::SwBreakpointOps<'_, Self>> {
+        Some(self)
+    }
+
+    fn support_hw_breakpoint(
+        &mut self,
+    ) -> Option<gdbstub::target::ext::breakpoints::HwBreakpointOps<'_, Self>> {
+        None
+    }
+
+    fn support_hw_watchpoint(
+        &mut self,
+    ) -> Option<gdbstub::target::ext::breakpoints::HwWatchpointOps<'_, Self>> {
+        None
+    }
+}
+
+impl SwBreakpoint for TwizzlerTarget {
+    fn add_sw_breakpoint(
+        &mut self,
+        addr: <Self::Arch as gdbstub::arch::Arch>::Usize,
+        kind: <Self::Arch as gdbstub::arch::Arch>::BreakpointKind,
+    ) -> gdbstub::target::TargetResult<bool, Self> {
+        todo!()
+    }
+
+    fn remove_sw_breakpoint(
+        &mut self,
+        addr: <Self::Arch as gdbstub::arch::Arch>::Usize,
+        kind: <Self::Arch as gdbstub::arch::Arch>::BreakpointKind,
+    ) -> gdbstub::target::TargetResult<bool, Self> {
+        todo!()
+    }
+}
+
+impl Target for TwizzlerTarget {
+    type Arch = gdbstub_arch::x86::X86_64_SSE;
+
+    type Error = TwzError;
+
+    fn base_ops(&mut self) -> BaseOps<'_, Self::Arch, Self::Error> {
+        BaseOps::MultiThread(self)
+    }
+
+    fn guard_rail_implicit_sw_breakpoints(&self) -> bool {
+        true
+    }
+}
+
+pub struct TwizzlerConn {
+    peek: Option<u8>,
+}
+
+impl TwizzlerConn {
+    pub fn new() -> Self {
+        Self { peek: None }
+    }
+}
+
+impl Connection for TwizzlerConn {
+    type Error = TwzError;
+
+    fn write(&mut self, byte: u8) -> Result<(), Self::Error> {
+        twizzler_abi::syscall::sys_kernel_console_write(&[byte], KernelConsoleWriteFlags::empty());
+        Ok(())
+    }
+
+    fn flush(&mut self) -> Result<(), Self::Error> {
+        Ok(())
+    }
+}
+
+impl ConnectionExt for TwizzlerConn {
+    fn read(&mut self) -> Result<u8, Self::Error> {
+        if let Some(byte) = self.peek.take() {
+            return Ok(byte);
+        }
+        let mut bytes = [0];
+        let r = twizzler_abi::syscall::sys_kernel_console_read(
+            &mut bytes,
+            KernelConsoleReadFlags::empty(),
+        )?;
+        if r == 0 {
+            std::thread::sleep(Duration::from_millis(10));
+            return self.read();
+        }
+        Ok(bytes[0])
+    }
+
+    fn peek(&mut self) -> Result<Option<u8>, Self::Error> {
+        if let Some(byte) = &self.peek {
+            return Ok(Some(*byte));
+        }
+        let mut bytes = [0];
+        let r = twizzler_abi::syscall::sys_kernel_console_read(
+            &mut bytes,
+            KernelConsoleReadFlags::NONBLOCKING,
+        );
+        if matches!(r, Err(TwzError::WOULD_BLOCK)) {
+            return Ok(None);
+        }
+        if r? == 0 {
+            return Ok(None);
+        }
+        self.peek = Some(bytes[0]);
+        Ok(Some(bytes[0]))
+    }
+}

--- a/src/bin/debug/src/main.rs
+++ b/src/bin/debug/src/main.rs
@@ -1,0 +1,68 @@
+use clap::Parser;
+use gdb::{TwizzlerConn, TwizzlerGdb, TwizzlerTarget};
+use gdbstub::stub::GdbStub;
+use miette::IntoDiagnostic;
+use monitor_api::{CompartmentLoader, NewCompartmentFlags};
+
+mod gdb;
+
+#[derive(clap::Subcommand, Clone, Debug)]
+enum Commands {
+    #[clap(about = "Run a program and debug it.")]
+    Run(RunCli),
+    #[clap(about = "Attach to an existing compartment.")]
+    Attach,
+}
+
+#[derive(clap::Args, Clone, Debug)]
+struct RunCli {
+    #[arg(trailing_var_arg = true, allow_hyphen_values = true, hide = true)]
+    cmdline: Vec<String>,
+}
+
+#[derive(clap::Parser, Clone, Debug)]
+#[clap(name = "debug", author = "Daniel Bittman <danielbittman1@gmail.com>", version = "1.0", about = "Debugger stub for Twizzler", long_about = None)]
+struct Cli {
+    #[clap(subcommand)]
+    cmd: Commands,
+}
+
+fn main() -> miette::Result<()> {
+    tracing::subscriber::set_global_default(
+        tracing_subscriber::fmt::fmt()
+            .with_max_level(tracing::Level::DEBUG)
+            .finish(),
+    )
+    .into_diagnostic()?;
+    tracing_log::LogTracer::init().into_diagnostic()?;
+
+    let cli = Cli::parse();
+    tracing::info!("Twizzler Debugging Starting");
+
+    match cli.cmd {
+        Commands::Run(run_cli) => {
+            run_debug_program(&run_cli)?;
+        }
+        Commands::Attach => todo!(),
+    }
+
+    Ok(())
+}
+
+fn run_debug_program(run_cli: &RunCli) -> miette::Result<()> {
+    let name = &run_cli.cmdline[0];
+    let compname = format!("debug-{}", name);
+
+    let mut comp = CompartmentLoader::new(compname, name, NewCompartmentFlags::empty());
+    comp.args(&run_cli.cmdline);
+    let comp = comp.load().into_diagnostic()?;
+
+    let gdb = GdbStub::new(TwizzlerConn::new());
+    let mut target = TwizzlerTarget::new(comp);
+    let r = gdb
+        .run_blocking::<TwizzlerGdb>(&mut target)
+        .into_diagnostic()?;
+
+    tracing::info!("disconnected: {:?}", r);
+    Ok(())
+}

--- a/src/bin/debug/src/main.rs
+++ b/src/bin/debug/src/main.rs
@@ -30,7 +30,7 @@ struct Cli {
 fn main() -> miette::Result<()> {
     tracing::subscriber::set_global_default(
         tracing_subscriber::fmt::fmt()
-            .with_max_level(tracing::Level::DEBUG)
+            .with_max_level(tracing::Level::TRACE)
             .finish(),
     )
     .into_diagnostic()?;

--- a/src/bin/debug/src/main.rs
+++ b/src/bin/debug/src/main.rs
@@ -39,6 +39,7 @@ fn main() -> miette::Result<()> {
     let cli = Cli::parse();
     tracing::info!("Twizzler Debugging Starting");
 
+    unsafe { std::env::set_var("MONDEBUG", "1") };
     match cli.cmd {
         Commands::Run(run_cli) => {
             run_debug_program(&run_cli)?;
@@ -53,10 +54,11 @@ fn run_debug_program(run_cli: &RunCli) -> miette::Result<()> {
     let name = &run_cli.cmdline[0];
     let compname = format!("debug-{}", name);
 
-    let mut comp = CompartmentLoader::new(compname, name, NewCompartmentFlags::empty());
+    let mut comp = CompartmentLoader::new(compname, name, NewCompartmentFlags::DEBUG);
     comp.args(&run_cli.cmdline);
     let comp = comp.load().into_diagnostic()?;
 
+    tracing::info!("Compartment loaded, starting debugging monitor");
     let (send, recv) = std::sync::mpsc::channel();
     let gdb = GdbStub::new(TwizzlerConn::new(recv));
     let mut target = TwizzlerTarget::new(comp, send);

--- a/src/bin/unittest/src/main.rs
+++ b/src/bin/unittest/src/main.rs
@@ -74,8 +74,9 @@ fn try_bench(path: &str) {
 fn main() {
     try_bench("/initrd/bench_bins");
     try_bench("/initrd/bench_bin");
-    let Ok(file) = std::fs::File::open("/initrd/test_bins") else {
-        eprintln!("failed to open test bins");
+    let Ok(file) = std::fs::File::open("/initrd/test_bins")
+        .inspect_err(|e| eprintln!("failed to open test bins: {}", e))
+    else {
         return;
     };
 

--- a/src/kernel/src/arch/aarch64/thread.rs
+++ b/src/kernel/src/arch/aarch64/thread.rs
@@ -11,7 +11,12 @@ use core::cell::RefCell;
 
 use arm64::registers::TPIDR_EL0;
 use registers::interfaces::Writeable;
-use twizzler_abi::upcall::{UpcallFrame, UpcallInfo, UpcallTarget, UPCALL_EXIT_CODE};
+use twizzler_abi::{
+    arch::ArchRegisters,
+    thread::ExecutionState,
+    upcall::{UpcallFrame, UpcallInfo, UpcallTarget, UPCALL_EXIT_CODE},
+};
+use twizzler_rt_abi::error::TwzError;
 
 use super::{exception::ExceptionContext, interrupt::DAIFMaskBits, syscall::Armv8SyscallContext};
 use crate::{memory::VirtAddr, processor::KERNEL_STACK_SIZE, thread::Thread};
@@ -229,5 +234,22 @@ impl Thread {
         // by default interrupts are enabled (unmask the I bit)
         // in other words set bits D,A, and F in DAIF[9:6]
         self.arch.context.daif = (DAIFMaskBits::IRQ.complement().bits() as u64) << 6;
+    }
+
+    pub fn read_registers(&self) -> Result<ArchRegisters, TwzError> {
+        if self.get_state() != ExecutionState::Suspended {
+            return Err(TwzError::Generic(
+                twizzler_rt_abi::error::GenericError::AccessDenied,
+            ));
+        }
+        let mut frame: Option<UpcallFrame> = *self.arch.upcall_restore_frame.borrow();
+        unsafe {
+            if frame.is_none() {
+                frame = Some((**self.arch.entry_registers.borrow()).into());
+            }
+        }
+        Ok(ArchRegisters {
+            frame: frame.unwrap(),
+        })
     }
 }

--- a/src/kernel/src/arch/amd64/interrupt.rs
+++ b/src/kernel/src/arch/amd64/interrupt.rs
@@ -547,7 +547,7 @@ fn generic_isr_handler(ctx: *mut IsrContext, number: u64, user: bool) {
         34 => {
             // TODO (urgent): why is this being raised?
         }
-        36 => {
+        36 | 35 => {
             crate::machine::serial::interrupt_handler();
         }
         _ => crate::interrupt::external_interrupt_entry(number as u32),

--- a/src/kernel/src/arch/amd64/thread.rs
+++ b/src/kernel/src/arch/amd64/thread.rs
@@ -253,6 +253,7 @@ where
     let data_ptr = data_start as usize as *mut UpcallData;
     let frame_ptr = frame_start as usize as *mut UpcallFrame;
     let mut frame: UpcallFrame = (*regs).into();
+    frame.prior_ctx = upcall_data.source_ctx;
 
     // Step 3a: we need to fill out some extra stuff in the upcall frame, like the thread pointer
     // and fpu state.

--- a/src/kernel/src/arch/amd64/thread.rs
+++ b/src/kernel/src/arch/amd64/thread.rs
@@ -4,12 +4,14 @@ use core::{
 };
 
 use twizzler_abi::{
-    arch::XSAVE_LEN,
+    arch::{ArchRegisters, XSAVE_LEN},
     object::{ObjID, MAX_SIZE, NULLPAGE_SIZE},
+    thread::ExecutionState,
     upcall::{
         UpcallData, UpcallFrame, UpcallHandlerFlags, UpcallInfo, UpcallTarget, UPCALL_EXIT_CODE,
     },
 };
+use twizzler_rt_abi::error::TwzError;
 
 use super::{interrupt::IsrContext, syscall::X86SyscallContext};
 use crate::{
@@ -457,6 +459,39 @@ impl Thread {
 
     pub unsafe fn init(&mut self, f: extern "C" fn()) {
         self.init_va(f as usize as u64);
+    }
+
+    pub fn read_registers(&self) -> Result<ArchRegisters, TwzError> {
+        if self.get_state() != ExecutionState::Suspended {
+            return Err(TwzError::Generic(
+                twizzler_rt_abi::error::GenericError::AccessDenied,
+            ));
+        }
+        let mut frame = *self.arch.upcall_restore_frame.borrow();
+        if frame.is_none() {
+            frame = Some(match *self.arch.entry_registers.borrow() {
+                Registers::None => {
+                    unreachable!()
+                }
+                Registers::Interrupt(int, _) => {
+                    let int = unsafe { &mut *int };
+                    (*int).into()
+                }
+                Registers::Syscall(sys, _) => {
+                    let sys = unsafe { &mut *sys };
+                    (*sys).into()
+                }
+            });
+        }
+        Ok(ArchRegisters {
+            frame: frame.unwrap(),
+            fs: 0,
+            gs: 0,
+            es: 0,
+            ds: 0,
+            ss: 0,
+            cs: 0,
+        })
     }
 }
 

--- a/src/kernel/src/condvar.rs
+++ b/src/kernel/src/condvar.rs
@@ -1,11 +1,17 @@
 use alloc::vec::Vec;
+use core::time::Duration;
 
 use intrusive_collections::{intrusive_adapter, KeyAdapter, RBTree};
-use twizzler_abi::object::ObjID;
+use twizzler_abi::{
+    object::ObjID,
+    syscall::{ThreadSync, ThreadSyncSleep},
+};
+use twizzler_rt_abi::error::TwzError;
 
 use crate::{
     sched::schedule_thread,
     spinlock::{SpinLockGuard, Spinlock},
+    syscall::sync::{add_to_requeue, requeue_all, sys_thread_sync},
     thread::{current_thread_ref, Thread, ThreadRef},
 };
 
@@ -35,6 +41,50 @@ impl CondVar {
     }
 
     #[track_caller]
+    pub fn wait_waiters<'a, T>(
+        &self,
+        mut guard: SpinLockGuard<'a, T>,
+        mut timeout: Option<Duration>,
+        waiter: Option<ThreadSyncSleep>,
+    ) -> (SpinLockGuard<'a, T>, bool) {
+        if waiter.is_none() && timeout.is_none() {
+            return (self.wait(guard), false);
+        }
+        let current_thread =
+            current_thread_ref().expect("cannot call wait before threading is enabled");
+        let mut inner = self.inner.lock();
+        inner.queue.insert(current_thread);
+        drop(inner);
+
+        unsafe { guard.force_unlock() };
+        let mut to = false;
+        if let Some(waiter) = waiter {
+            let _ = sys_thread_sync(&mut [ThreadSync::new_sleep(waiter)], timeout.as_mut())
+                .inspect_err(|e| {
+                    if *e != TwzError::TIMED_OUT {
+                        log::warn!("thread sync error in kernel-cv wait");
+                    } else {
+                        to = true;
+                    }
+                });
+        } else {
+            let _ = sys_thread_sync(&mut [], timeout.as_mut()).inspect_err(|e| {
+                if *e != TwzError::TIMED_OUT {
+                    log::warn!("thread sync error in kernel-cv wait");
+                } else {
+                    to = true;
+                }
+            });
+        }
+        let res = unsafe { guard.force_relock() };
+        let current_thread = current_thread_ref().unwrap();
+        let mut inner = self.inner.lock();
+        inner.queue.find_mut(&current_thread.objid()).remove();
+        drop(inner);
+        (res, to)
+    }
+
+    #[track_caller]
     pub fn wait<'a, T>(&self, mut guard: SpinLockGuard<'a, T>) -> SpinLockGuard<'a, T> {
         let current_thread =
             current_thread_ref().expect("cannot call wait before threading is enabled");
@@ -43,6 +93,8 @@ impl CondVar {
         drop(inner);
         let current_thread = current_thread_ref().unwrap();
         let critical_guard = current_thread.enter_critical();
+        current_thread.set_sync_sleep();
+        current_thread.set_sync_sleep_done();
         let res = unsafe {
             guard.force_unlock();
             crate::syscall::sync::finish_blocking(critical_guard);
@@ -52,6 +104,8 @@ impl CondVar {
         let mut inner = self.inner.lock();
         inner.queue.find_mut(&current_thread.objid()).remove();
         drop(inner);
+        current_thread.reset_sync_sleep();
+        current_thread.reset_sync_sleep_done();
         res
     }
 
@@ -63,18 +117,19 @@ impl CondVar {
                 break;
             }
             let mut node = inner.queue.front_mut();
-            while let Some(t) = node.remove() {
-                threads_to_wake.push(t);
-                if threads_to_wake.len() == 8 {
-                    break;
+            while threads_to_wake.len() < 8 && !node.is_null() {
+                if node.get().unwrap().reset_sync_sleep() {
+                    threads_to_wake.push(node.remove().unwrap());
                 }
+                node.move_next();
             }
 
             drop(inner);
             for t in threads_to_wake.drain(..) {
-                schedule_thread(t);
+                add_to_requeue(t);
             }
         }
+        requeue_all();
     }
 
     pub fn has_waiters(&self) -> bool {

--- a/src/kernel/src/condvar.rs
+++ b/src/kernel/src/condvar.rs
@@ -9,7 +9,6 @@ use twizzler_abi::{
 use twizzler_rt_abi::error::TwzError;
 
 use crate::{
-    sched::schedule_thread,
     spinlock::{SpinLockGuard, Spinlock},
     syscall::sync::{add_to_requeue, requeue_all, sys_thread_sync},
     thread::{current_thread_ref, Thread, ThreadRef},

--- a/src/kernel/src/machine/arm/virt/serial.rs
+++ b/src/kernel/src/machine/arm/virt/serial.rs
@@ -93,7 +93,7 @@ impl PL011 {
     }
 }
 
-pub fn write(data: &[u8], _flags: crate::log::KernelConsoleWriteFlags) {
+pub fn write(data: &[u8], _flags: crate::log::KernelConsoleWriteFlags, _debug: bool) {
     // We need the memory management system up and running to use MMIO.
     // Other requests to log to the console are ignored. The console is
     // initialized lazily on first access.
@@ -111,7 +111,7 @@ pub fn write(data: &[u8], _flags: crate::log::KernelConsoleWriteFlags) {
 pub fn serial_interrupt_handler() {
     let byte = serial().rx_byte();
     if let Some(x) = byte {
-        crate::log::push_input_byte(x);
+        crate::log::push_input_byte(x, false);
     }
     serial().clear_rx_interrupt();
 }

--- a/src/kernel/src/machine/mod.rs
+++ b/src/kernel/src/machine/mod.rs
@@ -16,16 +16,18 @@ pub use time::*;
 
 use crate::log::KernelConsoleHardware;
 
-pub struct MachineConsoleHardware;
+pub struct MachineConsoleHardware {
+    debug: bool,
+}
 
 impl KernelConsoleHardware for MachineConsoleHardware {
     fn write(&self, data: &[u8], flags: crate::log::KernelConsoleWriteFlags) {
-        serial::write(data, flags);
+        serial::write(data, flags, self.debug);
     }
 }
 
 impl MachineConsoleHardware {
-    pub const fn new() -> Self {
-        Self
+    pub const fn new(debug: bool) -> Self {
+        Self { debug }
     }
 }

--- a/src/kernel/src/machine/pc/serial.rs
+++ b/src/kernel/src/machine/pc/serial.rs
@@ -125,9 +125,6 @@ impl core::fmt::Write for SerialPort {
     fn write_str(&mut self, s: &str) -> core::fmt::Result {
         for byte in s.bytes() {
             self.send(byte);
-            if byte == b'\n' {
-                self.send(b'\r');
-            }
         }
         Ok(())
     }

--- a/src/kernel/src/memory/context/virtmem/fault.rs
+++ b/src/kernel/src/memory/context/virtmem/fault.rs
@@ -227,7 +227,6 @@ pub fn do_page_fault(
 pub fn page_fault(addr: VirtAddr, cause: MemoryAccessKind, flags: PageFaultFlags, ip: VirtAddr) {
     let res = do_page_fault(addr, cause, flags, ip);
     if let Err(upcall) = res {
-        logln!("UpCall:{:?}", upcall);
         current_thread_ref().unwrap().send_upcall(upcall);
     }
 }

--- a/src/kernel/src/panic.rs
+++ b/src/kernel/src/panic.rs
@@ -164,3 +164,7 @@ fn panic(info: &PanicInfo) -> ! {
 
 #[lang = "eh_personality"]
 pub extern "C" fn rust_eh_personality() {}
+
+pub fn is_panicing() -> bool {
+    DID_PANIC.load(core::sync::atomic::Ordering::SeqCst)
+}

--- a/src/kernel/src/syscall/mod.rs
+++ b/src/kernel/src/syscall/mod.rs
@@ -6,12 +6,11 @@ use twizzler_abi::{
     object::{ObjID, Protections},
     syscall::{
         ClockFlags, ClockInfo, ClockKind, ClockSource, FemtoSeconds, GetRandomFlags, HandleType,
-        KernelConsoleSource, KernelConsoleWriteFlags, MapFlags, ReadClockListFlags, SysInfo,
-        Syscall,
+        KernelConsoleSource, MapFlags, ReadClockListFlags, SysInfo, Syscall,
     },
 };
 use twizzler_rt_abi::{
-    error::{ArgumentError, IoError, ResourceError, TwzError},
+    error::{ArgumentError, ResourceError, TwzError},
     Result,
 };
 

--- a/src/kernel/src/syscall/mod.rs
+++ b/src/kernel/src/syscall/mod.rs
@@ -282,14 +282,14 @@ pub fn syscall_entry<T: SyscallContext>(context: &mut T) {
                     KernelConsoleReadSource::Console => {
                         let flags =
                             twizzler_abi::syscall::KernelConsoleReadFlags::from_bits_truncate(
-                                context.arg2(),
+                                context.arg3(),
                             );
                         crate::log::read_bytes(slice, flags).map_err(|x| x.into())
                     }
                     KernelConsoleReadSource::Buffer => {
                         let _flags =
                             twizzler_abi::syscall::KernelConsoleReadBufferFlags::from_bits_truncate(
-                                context.arg2(),
+                                context.arg3(),
                             );
                         crate::log::read_buffer_bytes(slice).map_err(|x| x.into())
                     }

--- a/src/kernel/src/syscall/mod.rs
+++ b/src/kernel/src/syscall/mod.rs
@@ -435,8 +435,17 @@ pub fn syscall_entry<T: SyscallContext>(context: &mut T) {
             }
         }
         Syscall::ThreadCtrl => {
-            let [code, val] =
-                thread_ctrl(context.arg0::<u64>().into(), context.arg1(), context.arg2());
+            let target = ObjID::from_parts([context.arg0::<u64>(), context.arg1::<u64>()]);
+            let [code, val] = thread_ctrl(
+                context.arg2::<u64>().into(),
+                if target.raw() == 0 {
+                    None
+                } else {
+                    Some(target)
+                },
+                context.arg3(),
+                context.arg4(),
+            );
             context.set_return_values(code, val);
             return;
         }

--- a/src/kernel/src/syscall/thread.rs
+++ b/src/kernel/src/syscall/thread.rs
@@ -1,9 +1,11 @@
 use twizzler_abi::{
+    arch::ArchRegisters,
     object::ObjID,
     syscall::{ThreadControl, ThreadSpawnArgs},
-    upcall::{UpcallFrame, UpcallTarget},
+    thread::ExecutionState,
+    upcall::{ResumeFlags, UpcallFrame, UpcallTarget},
 };
-use twizzler_rt_abi::Result;
+use twizzler_rt_abi::{error::TwzError, Result};
 
 use crate::{security::SwitchResult, thread::current_thread_ref};
 
@@ -11,7 +13,7 @@ pub fn sys_spawn(args: &ThreadSpawnArgs) -> Result<ObjID> {
     crate::thread::entry::start_new_user(*args)
 }
 
-pub fn thread_ctrl(cmd: ThreadControl, arg: u64, arg2: u64) -> [u64; 2] {
+pub fn thread_ctrl(cmd: ThreadControl, target: Option<ObjID>, arg: u64, arg2: u64) -> [u64; 2] {
     match cmd {
         ThreadControl::SetUpcall => {
             let Some(data) = (unsafe { (arg as usize as *const UpcallTarget).as_ref() }) else {
@@ -24,9 +26,18 @@ pub fn thread_ctrl(cmd: ThreadControl, arg: u64, arg2: u64) -> [u64; 2] {
             let Some(data) = (unsafe { (arg as usize as *const UpcallFrame).as_ref() }) else {
                 return [1, 1];
             };
+            let flags = ResumeFlags::from_bits_truncate(arg2);
             // TODO: verify args, check perms.
 
             current_thread_ref().unwrap().restore_upcall_frame(data);
+
+            if flags.contains(ResumeFlags::SUSPEND) {
+                log::info!(
+                    "resume-suspend: {:?}",
+                    current_thread_ref().unwrap().objid()
+                );
+                current_thread_ref().unwrap().suspend();
+            }
         }
         ThreadControl::SetTls => {
             current_thread_ref().unwrap().set_tls(arg);
@@ -49,7 +60,62 @@ pub fn thread_ctrl(cmd: ThreadControl, arg: u64, arg2: u64) -> [u64; 2] {
                 _ => [0, 0],
             };
         }
-        _ => todo!(),
+        ThreadControl::ReadRegisters => {
+            let thread = if let Some(target) = target {
+                crate::sched::lookup_thread_repr(target)
+            } else {
+                current_thread_ref()
+            };
+            let Some(thread) = thread else {
+                return [1, TwzError::INVALID_ARGUMENT.raw()];
+            };
+            let ptr = arg as usize as *mut ArchRegisters;
+            let regs = match thread.read_registers() {
+                Ok(regs) => regs,
+                Err(e) => return [1, e.raw()],
+            };
+            unsafe { ptr.write(regs) };
+        }
+        ThreadControl::ChangeState => {
+            let thread = if let Some(target) = target {
+                crate::sched::lookup_thread_repr(target)
+            } else {
+                current_thread_ref()
+            };
+            let Some(thread) = thread else {
+                log::info!("could not find {:?}", target);
+                return [1, TwzError::INVALID_ARGUMENT.raw()];
+            };
+            let target_state = ExecutionState::from_status(arg);
+            let cur_state = thread.get_state();
+            log::info!(
+                "change state {:?}: {:?} => {:?}",
+                target,
+                cur_state,
+                target_state
+            );
+            if cur_state == ExecutionState::Exited {
+                return [1, TwzError::INVALID_ARGUMENT.raw()];
+            }
+            if cur_state != target_state {
+                match target_state {
+                    ExecutionState::Running => {
+                        thread.unsuspend_thread();
+                    }
+                    ExecutionState::Suspended => {
+                        thread.suspend();
+                    }
+                    _ => {
+                        return [1, TwzError::INVALID_ARGUMENT.raw()];
+                    }
+                }
+            }
+
+            return [0, cur_state.to_status()];
+        }
+        _ => {
+            return [1, 1];
+        }
     }
     [0, 0]
 }

--- a/src/kernel/src/syscall/thread.rs
+++ b/src/kernel/src/syscall/thread.rs
@@ -32,9 +32,10 @@ pub fn thread_ctrl(cmd: ThreadControl, target: Option<ObjID>, arg: u64, arg2: u6
             current_thread_ref().unwrap().restore_upcall_frame(data);
 
             if flags.contains(ResumeFlags::SUSPEND) {
-                log::debug!(
-                    "resume-suspend: {:?}",
-                    current_thread_ref().unwrap().objid()
+                log::info!(
+                    "resume-suspend: {:?} => {}",
+                    current_thread_ref().unwrap().objid(),
+                    data.prior_ctx,
                 );
                 current_thread_ref().unwrap().suspend();
             }

--- a/src/kernel/src/syscall/thread.rs
+++ b/src/kernel/src/syscall/thread.rs
@@ -32,7 +32,7 @@ pub fn thread_ctrl(cmd: ThreadControl, target: Option<ObjID>, arg: u64, arg2: u6
             current_thread_ref().unwrap().restore_upcall_frame(data);
 
             if flags.contains(ResumeFlags::SUSPEND) {
-                log::info!(
+                log::debug!(
                     "resume-suspend: {:?} => {}",
                     current_thread_ref().unwrap().objid(),
                     data.prior_ctx,

--- a/src/kernel/src/syscall/thread.rs
+++ b/src/kernel/src/syscall/thread.rs
@@ -32,7 +32,7 @@ pub fn thread_ctrl(cmd: ThreadControl, target: Option<ObjID>, arg: u64, arg2: u6
             current_thread_ref().unwrap().restore_upcall_frame(data);
 
             if flags.contains(ResumeFlags::SUSPEND) {
-                log::info!(
+                log::debug!(
                     "resume-suspend: {:?}",
                     current_thread_ref().unwrap().objid()
                 );
@@ -83,12 +83,11 @@ pub fn thread_ctrl(cmd: ThreadControl, target: Option<ObjID>, arg: u64, arg2: u6
                 current_thread_ref()
             };
             let Some(thread) = thread else {
-                log::info!("could not find {:?}", target);
                 return [1, TwzError::INVALID_ARGUMENT.raw()];
             };
             let target_state = ExecutionState::from_status(arg);
             let cur_state = thread.get_state();
-            log::info!(
+            log::debug!(
                 "change state {:?}: {:?} => {:?}",
                 target,
                 cur_state,

--- a/src/kernel/src/thread/suspend.rs
+++ b/src/kernel/src/thread/suspend.rs
@@ -77,6 +77,7 @@ impl Thread {
 
         // goodnight!
         schedule(false);
+        self.set_state(ExecutionState::Running);
 
         // goodmorning! Clear the flags. This is one operation, so we'll never observe
         // THREAD_IS_SUSPENDED without THREAD_MUST_SUSPEND.

--- a/src/lib/dynlink/src/context.rs
+++ b/src/lib/dynlink/src/context.rs
@@ -291,5 +291,6 @@ bitflags::bitflags! {
     #[derive(Clone, Copy, Debug)]
     pub struct NewCompartmentFlags : u32 {
         const EXPORT_GATES = 0x1;
+        const DEBUG = 0x2;
     }
 }

--- a/src/lib/dynlink/src/context/load.rs
+++ b/src/lib/dynlink/src/context/load.rs
@@ -273,7 +273,7 @@ impl Context {
 
         let comp = self.get_compartment(comp_id)?;
         Ok(Library::new(
-            unlib.name,
+            backing.full_name().to_owned(),
             idx,
             comp.id,
             comp.name.clone(),

--- a/src/lib/dynlink/src/engines/mod.rs
+++ b/src/lib/dynlink/src/engines/mod.rs
@@ -59,30 +59,43 @@ pub struct Backing {
     start: *mut u8,
     len: usize,
     id: ObjID,
+    full_name: String,
 }
 
 unsafe impl Send for Backing {}
 unsafe impl Sync for Backing {}
 
 impl Backing {
-    pub fn new(inner: ObjectHandle) -> Self {
+    pub fn new(inner: ObjectHandle, full_name: String) -> Self {
         unsafe {
             Self::new_owned(
                 inner.start(),
                 MAX_SIZE - NULLPAGE_SIZE * 2,
                 inner.id(),
                 Arc::new(inner),
+                full_name,
             )
         }
     }
 
-    pub unsafe fn new_owned(start: *mut u8, len: usize, id: ObjID, owner: Arc<dyn Any>) -> Self {
+    pub unsafe fn new_owned(
+        start: *mut u8,
+        len: usize,
+        id: ObjID,
+        owner: Arc<dyn Any>,
+        full_name: String,
+    ) -> Self {
         Self {
             _owner: owner,
             start,
             len,
             id,
+            full_name,
         }
+    }
+
+    pub fn full_name(&self) -> &str {
+        &self.full_name
     }
 }
 

--- a/src/lib/dynlink/src/library.rs
+++ b/src/lib/dynlink/src/library.rs
@@ -3,7 +3,8 @@
 use std::fmt::{Debug, Display};
 
 use elf::{
-    abi::{DT_FLAGS_1, PT_PHDR, PT_TLS, STB_WEAK},
+    abi::{DT_FLAGS_1, PT_DYNAMIC, PT_PHDR, PT_TLS, STB_WEAK},
+    dynamic::Dyn,
     endian::NativeEndian,
     segment::{Elf64_Phdr, ProgramHeader},
     ParseError,
@@ -141,6 +142,16 @@ impl Library {
 
     pub fn allows_self_gates(&self) -> bool {
         self.allowed_gates == AllowedGates::PublicInclSelf
+    }
+
+    pub fn dynamic_ptr(&self) -> Option<*mut Dyn> {
+        let phdr = self
+            .get_elf()
+            .ok()?
+            .segments()?
+            .iter()
+            .find(|s| s.p_type == PT_DYNAMIC)?;
+        Some(self.laddr_mut(phdr.p_vaddr))
     }
 
     pub fn is_binary(&self) -> bool {

--- a/src/lib/twizzler-abi/src/arch/aarch64/mod.rs
+++ b/src/lib/twizzler-abi/src/arch/aarch64/mod.rs
@@ -5,3 +5,7 @@ pub(crate) mod upcall;
 
 // Max size of user addr space divided into slots of size MAX_SIZE
 pub const SLOTS: usize = (1 << 47) / MAX_SIZE;
+
+pub struct ArchRegisters {
+    pub frame: upcall::UpcallFrame,
+}

--- a/src/lib/twizzler-abi/src/arch/x86_64/mod.rs
+++ b/src/lib/twizzler-abi/src/arch/x86_64/mod.rs
@@ -6,4 +6,15 @@ pub(crate) mod upcall;
 // Max size of user addr space divided into slots of size MAX_SIZE
 pub const SLOTS: usize = (1 << 47) / MAX_SIZE;
 
+use upcall::UpcallFrame;
 pub use upcall::XSAVE_LEN;
+
+pub struct ArchRegisters {
+    pub frame: UpcallFrame,
+    pub fs: u32,
+    pub gs: u32,
+    pub es: u32,
+    pub ds: u32,
+    pub ss: u32,
+    pub cs: u32,
+}

--- a/src/lib/twizzler-abi/src/klog.rs
+++ b/src/lib/twizzler-abi/src/klog.rs
@@ -2,14 +2,18 @@
 
 use core::fmt;
 
-use crate::syscall::{sys_kernel_console_write, KernelConsoleWriteFlags};
+use crate::syscall::{sys_kernel_console_write, KernelConsoleSource, KernelConsoleWriteFlags};
 
 #[repr(C)]
 struct KernelLogger;
 
 impl fmt::Write for KernelLogger {
     fn write_str(&mut self, s: &str) -> fmt::Result {
-        sys_kernel_console_write(s.as_bytes(), KernelConsoleWriteFlags::empty());
+        sys_kernel_console_write(
+            KernelConsoleSource::Console,
+            s.as_bytes(),
+            KernelConsoleWriteFlags::empty(),
+        );
         Ok(())
     }
 }

--- a/src/lib/twizzler-abi/src/lib.rs
+++ b/src/lib/twizzler-abi/src/lib.rs
@@ -20,6 +20,8 @@
 #![feature(linkage)]
 #![feature(test)]
 #![feature(c_variadic)]
+
+use syscall::KernelConsoleSource;
 pub mod arch;
 
 #[allow(unused_extern_crates)]
@@ -46,7 +48,11 @@ unsafe fn internal_abort() -> ! {
 }
 
 pub fn print_err(err: &str) {
-    syscall::sys_kernel_console_write(err.as_bytes(), syscall::KernelConsoleWriteFlags::empty());
+    syscall::sys_kernel_console_write(
+        KernelConsoleSource::Console,
+        err.as_bytes(),
+        syscall::KernelConsoleWriteFlags::empty(),
+    );
 }
 
 #[allow(dead_code)]

--- a/src/lib/twizzler-abi/src/syscall/console.rs
+++ b/src/lib/twizzler-abi/src/syscall/console.rs
@@ -6,6 +6,7 @@ use crate::arch::syscall::raw_syscall;
 
 bitflags! {
     /// Flags to pass to [sys_kernel_console_read].
+    #[derive(Debug, Copy, Clone, PartialEq, Eq)]
     pub struct KernelConsoleReadFlags: u64 {
         /// If the read would block, return instead.
         const NONBLOCKING = 1;
@@ -66,6 +67,7 @@ pub fn sys_kernel_console_read(buffer: &mut [u8], flags: KernelConsoleReadFlags)
 
 bitflags! {
     /// Flags to pass to [sys_kernel_console_read_buffer].
+    #[derive(Debug, Copy, Clone, PartialEq, Eq)]
     pub struct KernelConsoleReadBufferFlags: u64 {
         /// If the operation would block, return instead.
         const NONBLOCKING = 1;
@@ -105,6 +107,7 @@ pub fn sys_kernel_console_read_buffer(
 
 bitflags! {
     /// Flags to pass to [sys_kernel_console_write].
+    #[derive(Debug, Copy, Clone, PartialEq, Eq)]
     pub struct KernelConsoleWriteFlags: u64 {
         /// If the buffer is full, discard this write instead of overwriting old data.
         const DISCARD_ON_FULL = 1;

--- a/src/lib/twizzler-abi/src/syscall/console.rs
+++ b/src/lib/twizzler-abi/src/syscall/console.rs
@@ -1,7 +1,9 @@
+use core::time::Duration;
+
 use bitflags::bitflags;
 use twizzler_rt_abi::Result;
 
-use super::{convert_codes_to_result, twzerr, Syscall};
+use super::{convert_codes_to_result, twzerr, Syscall, ThreadSyncSleep};
 use crate::arch::syscall::raw_syscall;
 
 bitflags! {
@@ -16,7 +18,7 @@ bitflags! {
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 #[repr(u64)]
 /// Possible sources for a kernel console read syscall.
-pub enum KernelConsoleReadSource {
+pub enum KernelConsoleSource {
     /// Read from the console itself.
     Console = 0,
     /// Read from the kernel write buffer.
@@ -25,13 +27,13 @@ pub enum KernelConsoleReadSource {
     DebugConsole = 2,
 }
 
-impl From<KernelConsoleReadSource> for u64 {
-    fn from(x: KernelConsoleReadSource) -> Self {
+impl From<KernelConsoleSource> for u64 {
+    fn from(x: KernelConsoleSource) -> Self {
         x as u64
     }
 }
 
-impl From<u64> for KernelConsoleReadSource {
+impl From<u64> for KernelConsoleSource {
     fn from(x: u64) -> Self {
         match x {
             1 => Self::Buffer,
@@ -47,80 +49,43 @@ impl From<KernelConsoleReadFlags> for u64 {
     }
 }
 
-/// Read from the kernel console input, placing data into `buffer`.
-///
-/// This is the INPUT mechanism, and not the BUFFER mechanism. For example, if the kernel console is
-/// a serial port, the input mechanism is the reading side of the serial console. To read from the
-/// kernel console output buffer, use [sys_kernel_console_read_buffer].
+/// Read from the specified kernel console input, placing data into `buffer`.
 ///
 /// Returns the number of bytes read on success.
-pub fn sys_kernel_console_read(buffer: &mut [u8], flags: KernelConsoleReadFlags) -> Result<usize> {
-    let (code, val) = unsafe {
-        raw_syscall(
-            Syscall::KernelConsoleRead,
-            &[
-                KernelConsoleReadSource::Console.into(),
-                buffer.as_mut_ptr() as u64,
-                buffer.len() as u64,
-                flags.into(),
-            ],
-        )
-    };
-    convert_codes_to_result(code, val, |c, _| c != 0, |_, v| v as usize, twzerr)
-}
-
-pub fn sys_kernel_console_read_debug(
+pub fn sys_kernel_console_read(
+    source: KernelConsoleSource,
     buffer: &mut [u8],
     flags: KernelConsoleReadFlags,
 ) -> Result<usize> {
-    let (code, val) = unsafe {
-        raw_syscall(
-            Syscall::KernelConsoleRead,
-            &[
-                KernelConsoleReadSource::DebugConsole.into(),
-                buffer.as_mut_ptr() as u64,
-                buffer.len() as u64,
-                flags.into(),
-            ],
-        )
-    };
-    convert_codes_to_result(code, val, |c, _| c != 0, |_, v| v as usize, twzerr)
+    sys_kernel_console_read_interruptable(source, buffer, flags, None, None)
 }
 
-bitflags! {
-    /// Flags to pass to [sys_kernel_console_read_buffer].
-    #[derive(Debug, Copy, Clone, PartialEq, Eq)]
-    pub struct KernelConsoleReadBufferFlags: u64 {
-        /// If the operation would block, return instead.
-        const NONBLOCKING = 1;
-    }
-}
-
-impl From<KernelConsoleReadBufferFlags> for u64 {
-    fn from(x: KernelConsoleReadBufferFlags) -> Self {
-        x.bits()
-    }
-}
-
-/// Read from the kernel console buffer, placing data into `buffer`.
-///
-/// This is the BUFFER mechanism, and not the INPUT mechanism. All writes to the kernel console get
-/// placed in the buffer and copied out to the underlying console device in the kernel. If you want
-/// to read from the INPUT device, see [sys_kernel_console_read].
+/// Read from the specified kernel console input, placing data into `buffer`.
 ///
 /// Returns the number of bytes read on success.
-pub fn sys_kernel_console_read_buffer(
+pub fn sys_kernel_console_read_interruptable(
+    source: KernelConsoleSource,
     buffer: &mut [u8],
-    flags: KernelConsoleReadBufferFlags,
+    flags: KernelConsoleReadFlags,
+    timeout: Option<Duration>,
+    waiter: Option<ThreadSyncSleep>,
 ) -> Result<usize> {
+    let timeout = timeout
+        .as_ref()
+        .map_or(core::ptr::null(), |t| t as *const Duration);
+    let waiter = waiter
+        .as_ref()
+        .map_or(core::ptr::null(), |w| w as *const ThreadSyncSleep);
     let (code, val) = unsafe {
         raw_syscall(
             Syscall::KernelConsoleRead,
             &[
-                KernelConsoleReadSource::Buffer.into(),
+                source.into(),
                 buffer.as_mut_ptr() as u64,
                 buffer.len() as u64,
                 flags.into(),
+                timeout as u64,
+                waiter as u64,
             ],
         )
     };
@@ -133,8 +98,6 @@ bitflags! {
     pub struct KernelConsoleWriteFlags: u64 {
         /// If the buffer is full, discard this write instead of overwriting old data.
         const DISCARD_ON_FULL = 1;
-        /// Write directly to the debug kernel device, if present.
-        const DEBUG_CONSOLE = 2;
     }
 }
 
@@ -146,11 +109,16 @@ bitflags! {
 /// (circular) buffer, but this behavior can be controlled by the `flags` argument.
 ///
 /// This function cannot fail.
-pub fn sys_kernel_console_write(buffer: &[u8], flags: KernelConsoleWriteFlags) {
+pub fn sys_kernel_console_write(
+    target: KernelConsoleSource,
+    buffer: &[u8],
+    flags: KernelConsoleWriteFlags,
+) {
     let arg0 = buffer.as_ptr() as usize as u64;
     let arg1 = buffer.len() as u64;
     let arg2 = flags.bits();
+    let arg3 = target.into();
     unsafe {
-        raw_syscall(Syscall::KernelConsoleWrite, &[arg0, arg1, arg2]);
+        raw_syscall(Syscall::KernelConsoleWrite, &[arg0, arg1, arg2, arg3]);
     }
 }

--- a/src/lib/twizzler-abi/src/syscall/mod.rs
+++ b/src/lib/twizzler-abi/src/syscall/mod.rs
@@ -102,9 +102,9 @@ use twizzler_rt_abi::error::{RawTwzError, TwzError};
 #[inline]
 fn convert_codes_to_result<T, E, D, F, G>(code: u64, val: u64, d: D, f: F, g: G) -> Result<T, E>
 where
-    F: Fn(u64, u64) -> T,
-    G: Fn(u64, u64) -> E,
-    D: Fn(u64, u64) -> bool,
+    F: FnOnce(u64, u64) -> T,
+    G: FnOnce(u64, u64) -> E,
+    D: FnOnce(u64, u64) -> bool,
 {
     if d(code, val) {
         Err(g(code, val))

--- a/src/lib/twizzler-abi/src/thread.rs
+++ b/src/lib/twizzler-abi/src/thread.rs
@@ -50,13 +50,22 @@ pub enum ExecutionState {
 }
 
 impl ExecutionState {
-    fn from_status(status: u64) -> Self {
+    pub fn from_status(status: u64) -> Self {
         // If we see a status we don't understand, just assume the thread is running.
         match status & 0xff {
             1 => ExecutionState::Sleeping,
             2 => ExecutionState::Suspended,
             255 => ExecutionState::Exited,
             _ => ExecutionState::Running,
+        }
+    }
+
+    pub fn to_status(&self) -> u64 {
+        match self {
+            ExecutionState::Running => 0,
+            ExecutionState::Sleeping => 1,
+            ExecutionState::Suspended => 2,
+            ExecutionState::Exited => 255,
         }
     }
 }

--- a/src/lib/twizzler-abi/src/upcall.rs
+++ b/src/lib/twizzler-abi/src/upcall.rs
@@ -1,5 +1,6 @@
 //! Functions for handling upcalls from the kernel.
 
+use bitflags::bitflags;
 use twizzler_rt_abi::error::RawTwzError;
 
 pub use crate::arch::upcall::UpcallFrame;
@@ -235,4 +236,12 @@ pub struct UpcallOptions {
     pub flags: UpcallFlags,
     /// The mode for the upcall.
     pub mode: UpcallMode,
+}
+
+bitflags! {
+    #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+    pub struct ResumeFlags: u64 {
+        /// Suspend the thread during resume.
+        const SUSPEND = 1;
+    }
 }

--- a/src/lib/twizzler-abi/src/upcall.rs
+++ b/src/lib/twizzler-abi/src/upcall.rs
@@ -1,5 +1,7 @@
 //! Functions for handling upcalls from the kernel.
 
+use core::fmt::Debug;
+
 use bitflags::bitflags;
 use twizzler_rt_abi::error::RawTwzError;
 
@@ -67,13 +69,23 @@ pub enum ObjectMemoryError {
 }
 
 /// Information about a non-object-related memory access violation.
-#[derive(Debug, Copy, Clone, PartialEq, PartialOrd, Ord, Eq)]
+#[derive(Copy, Clone, PartialEq, PartialOrd, Ord, Eq)]
 #[repr(C)]
 pub struct MemoryContextViolationInfo {
     /// The virtual address that caused the exception.
     pub address: u64,
     /// The kind of memory access.
     pub kind: MemoryAccessKind,
+}
+
+impl Debug for MemoryContextViolationInfo {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(
+            f,
+            "MemoryContextViolationInfo {{ {:?}: {:x} }}",
+            self.kind, self.address
+        )
+    }
 }
 
 impl MemoryContextViolationInfo {

--- a/src/lib/twizzler/src/marker.rs
+++ b/src/lib/twizzler/src/marker.rs
@@ -1,5 +1,7 @@
 //! Marker types for invariance, store side-effects, and base types.
 
+use twizzler_abi::thread::ThreadRepr;
+
 /// Indicates that a type is _invariant_ and thus can be stored in an object.
 ///
 /// # Safety
@@ -69,3 +71,5 @@ impl BaseType for u8 {}
 impl BaseType for u16 {}
 impl BaseType for u32 {}
 impl BaseType for u64 {}
+
+impl BaseType for ThreadRepr {}

--- a/src/ports/lwext4-rs/src/lwext4.rs
+++ b/src/ports/lwext4-rs/src/lwext4.rs
@@ -520,7 +520,7 @@ pub type uint_fast32_t = __mlibc_uint_fast32;
 pub type uint_fast64_t = __mlibc_uint_fast64;
 pub type intmax_t = __mlibc_intmax;
 pub type uintmax_t = __mlibc_uintmax;
-pub type wchar_t = ::std::os::raw::c_int;
+pub type wchar_t = ::std::os::raw::c_uint;
 #[repr(C)]
 #[repr(align(16))]
 #[derive(Debug, Copy, Clone)]

--- a/src/ports/lwext4-rs/src/lwext4.rs
+++ b/src/ports/lwext4-rs/src/lwext4.rs
@@ -520,7 +520,7 @@ pub type uint_fast32_t = __mlibc_uint_fast32;
 pub type uint_fast64_t = __mlibc_uint_fast64;
 pub type intmax_t = __mlibc_intmax;
 pub type uintmax_t = __mlibc_uintmax;
-pub type wchar_t = ::std::os::raw::c_uint;
+pub type wchar_t = ::std::os::raw::c_int;
 #[repr(C)]
 #[repr(align(16))]
 #[derive(Debug, Copy, Clone)]

--- a/src/rt/minimal/src/lib.rs
+++ b/src/rt/minimal/src/lib.rs
@@ -11,6 +11,8 @@
 #![feature(test)]
 #![feature(c_variadic)]
 
+use twizzler_abi::syscall::KernelConsoleSource;
+
 pub mod arch;
 
 #[allow(unused_extern_crates)]
@@ -25,6 +27,7 @@ unsafe fn internal_abort() -> ! {
 
 pub fn print_err(err: &str) {
     twizzler_abi::syscall::sys_kernel_console_write(
+        KernelConsoleSource::Buffer,
         err.as_bytes(),
         twizzler_abi::syscall::KernelConsoleWriteFlags::empty(),
     );

--- a/src/rt/minimal/src/runtime/fs.rs
+++ b/src/rt/minimal/src/runtime/fs.rs
@@ -10,17 +10,20 @@ use lru::LruCache;
 use rustc_alloc::sync::Arc;
 use stable_vec::{self, StableVec};
 use twizzler_abi::{
-    object::{ObjID, Protections, MAX_SIZE, NULLPAGE_SIZE},
+    object::{MAX_SIZE, NULLPAGE_SIZE, ObjID, Protections},
     simple_mutex::Mutex,
-    syscall::{sys_object_create, BackingType, LifetimeType, ObjectCreate, ObjectCreateFlags},
+    syscall::{
+        BackingType, KernelConsoleSource, LifetimeType, ObjectCreate, ObjectCreateFlags,
+        sys_object_create,
+    },
 };
 use twizzler_rt_abi::{
+    Result,
     bindings::{io_ctx, io_vec},
     error::{ArgumentError, GenericError, IoError},
     fd::RawFd,
     io::SeekFrom,
     object::{MapFlags, ObjectHandle},
-    Result,
 };
 
 use super::MinimalRuntime;
@@ -119,6 +122,7 @@ impl MinimalRuntime {
         let FdKind::File(file_desc) = &file_desc else {
             // Just do basic stdio via kernel console
             let len = twizzler_abi::syscall::sys_kernel_console_read(
+                KernelConsoleSource::Console,
                 buf,
                 twizzler_abi::syscall::KernelConsoleReadFlags::empty(),
             )
@@ -248,6 +252,7 @@ impl MinimalRuntime {
         let FdKind::File(file_desc) = &file_desc else {
             // Just do basic stdio via kernel console
             twizzler_abi::syscall::sys_kernel_console_write(
+                KernelConsoleSource::Console,
                 buf,
                 twizzler_abi::syscall::KernelConsoleWriteFlags::empty(),
             );

--- a/src/rt/monitor-api/src/lib.rs
+++ b/src/rt/monitor-api/src/lib.rs
@@ -391,6 +391,12 @@ impl Handle for CompartmentHandle {
     }
 }
 
+impl Drop for CompartmentHandle {
+    fn drop(&mut self) {
+        self.release();
+    }
+}
+
 impl Handle for LibraryHandle {
     type OpenError = TwzError;
 
@@ -406,12 +412,6 @@ impl Handle for LibraryHandle {
 
     fn release(&mut self) {
         let _ = gates::monitor_rt_drop_library_handle(self.desc);
-    }
-}
-
-impl Drop for CompartmentHandle {
-    fn drop(&mut self) {
-        self.release();
     }
 }
 
@@ -479,6 +479,11 @@ impl CompartmentHandle {
         LibraryIter::new(self)
     }
 
+    /// Get an iterator over the libraries for this compartment.
+    pub fn threads(&self) -> CompartmentThreadsIter<'_> {
+        CompartmentThreadsIter::new(self)
+    }
+
     pub fn wait(&self, flags: CompartmentFlags) -> CompartmentFlags {
         CompartmentFlags::from_bits_truncate(
             gates::monitor_rt_compartment_wait(self.desc(), flags.bits()).unwrap(),
@@ -510,7 +515,7 @@ impl<'a> Iterator for LibraryIter<'a> {
     }
 }
 
-/// An iterator over a compartmen's dependencies.
+/// An iterator over a compartment's dependencies.
 pub struct CompartmentDepsIter<'a> {
     n: usize,
     comp: &'a CompartmentHandle,
@@ -529,6 +534,33 @@ impl<'a> Iterator for CompartmentDepsIter<'a> {
         let desc = gates::monitor_rt_get_compartment_deps(self.comp.desc, self.n).ok()?;
         self.n += 1;
         Some(CompartmentHandle { desc: Some(desc) })
+    }
+
+    fn nth(&mut self, n: usize) -> Option<Self::Item> {
+        self.n += n;
+        self.next()
+    }
+}
+
+/// An iterator over a compartment's threads.
+pub struct CompartmentThreadsIter<'a> {
+    n: usize,
+    comp: &'a CompartmentHandle,
+}
+
+impl<'a> CompartmentThreadsIter<'a> {
+    fn new(comp: &'a CompartmentHandle) -> Self {
+        Self { n: 0, comp }
+    }
+}
+
+impl<'a> Iterator for CompartmentThreadsIter<'a> {
+    type Item = ThreadInfo;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let info = gates::monitor_rt_get_compartment_thread(self.comp.desc, self.n).ok()?;
+        self.n += 1;
+        Some(info)
     }
 
     fn nth(&mut self, n: usize) -> Option<Self::Item> {

--- a/src/rt/monitor-api/src/lib.rs
+++ b/src/rt/monitor-api/src/lib.rs
@@ -36,7 +36,7 @@ mod gates {
 
 pub use gates::*;
 use twizzler_rt_abi::{
-    debug::{DlPhdrInfo, LoadedImageId},
+    debug::{DlPhdrInfo, LinkMap, LoadedImageId},
     error::{ArgumentError, TwzError},
 };
 
@@ -200,6 +200,8 @@ pub struct LibraryInfo<'a> {
     pub len: usize,
     /// The DlPhdrInfo for this library
     pub dl_info: DlPhdrInfo,
+    /// The link_map structure for this library
+    pub link_map: LinkMap,
     /// The slot of the library text.
     pub slot: usize,
     _pd: PhantomData<&'a ()>,
@@ -219,6 +221,7 @@ impl<'a> LibraryInfo<'a> {
             slot: raw.slot,
             _pd: PhantomData,
             internal_name: name,
+            link_map: raw.link_map,
         };
         this.dl_info.name = this.internal_name.as_ptr().cast();
         this

--- a/src/rt/monitor/secapi/gates.rs
+++ b/src/rt/monitor/secapi/gates.rs
@@ -3,7 +3,7 @@ use std::fmt::Debug;
 use dynlink::context::NewCompartmentFlags;
 use secgate::{util::Descriptor, Crossing};
 use twizzler_rt_abi::{
-    debug::DlPhdrInfo,
+    debug::{DlPhdrInfo, LinkMap},
     error::{ArgumentError, ResourceError, TwzError},
     object::ObjID,
     thread::ThreadSpawnArgs,
@@ -89,6 +89,7 @@ pub struct LibraryInfo {
     pub start: *const u8,
     pub len: usize,
     pub dl_info: DlPhdrInfo,
+    pub link_map: LinkMap,
     pub desc: Descriptor,
 }
 

--- a/src/rt/monitor/secapi/gates.rs
+++ b/src/rt/monitor/secapi/gates.rs
@@ -165,6 +165,27 @@ pub fn monitor_rt_get_compartment_deps(
     monitor.get_compartment_deps(caller, desc, dep_n)
 }
 
+#[derive(Debug, Clone, PartialEq, PartialOrd, Ord, Eq, Hash, Copy)]
+#[repr(C)]
+pub struct ThreadInfo {
+    pub repr_id: ObjID,
+}
+
+#[cfg_attr(feature = "secgate-impl", secgate::secure_gate(options(info)))]
+#[cfg_attr(
+    not(feature = "secgate-impl"),
+    secgate::secure_gate(options(info, api))
+)]
+pub fn monitor_rt_get_compartment_thread(
+    info: &secgate::GateCallInfo,
+    desc: Option<Descriptor>,
+    dep_n: usize,
+) -> Result<ThreadInfo, TwzError> {
+    let monitor = crate::mon::get_monitor();
+    let caller = info.source_context().unwrap_or(MONITOR_INSTANCE_ID);
+    monitor.get_compartment_thread_info(caller, desc, dep_n)
+}
+
 #[cfg_attr(feature = "secgate-impl", secgate::secure_gate(options(info)))]
 #[cfg_attr(
     not(feature = "secgate-impl"),

--- a/src/rt/monitor/src/mon/compartment.rs
+++ b/src/rt/monitor/src/mon/compartment.rs
@@ -14,7 +14,7 @@ use twizzler_rt_abi::{
     object::ObjID,
 };
 
-use crate::gates::{CompartmentInfo, CompartmentMgrStats};
+use crate::gates::{CompartmentInfo, CompartmentMgrStats, ThreadInfo};
 
 mod compconfig;
 mod compthread;
@@ -374,6 +374,28 @@ impl super::Monitor {
         self.get_compartment_handle(caller, dep)
     }
 
+    /// Get the n'th thread's info from a compartment.
+    #[tracing::instrument(skip(self), level = tracing::Level::DEBUG)]
+    pub fn get_compartment_thread_info(
+        &self,
+        caller: ObjID,
+        desc: Option<Descriptor>,
+        t_n: usize,
+    ) -> Result<ThreadInfo, TwzError> {
+        let dep = {
+            let (_, ref mut comps, _, _, ref mut comphandles) =
+                *self.locks.lock(ThreadKey::get().unwrap());
+            let comp_id = desc
+                .map(|comp| comphandles.lookup(caller, comp).map(|ch| ch.instance))
+                .unwrap_or(Some(caller))
+                .ok_or(ArgumentError::InvalidArgument)?;
+            let comp = comps.get_mut(comp_id)?;
+            comp.get_nth_thread_info(t_n)
+        }
+        .ok_or(TwzError::INVALID_ARGUMENT);
+        dep
+    }
+
     /// Load a new compartment with a root library ID, and return a compartment handle.
     #[tracing::instrument(skip(self), level = tracing::Level::DEBUG)]
     pub fn load_compartment(
@@ -448,7 +470,13 @@ impl super::Monitor {
 
         let desc = self.get_compartment_handle(caller, root_comp)?;
 
-        self.start_compartment(root_comp, &args, &env, mondebug)?;
+        self.start_compartment(
+            root_comp,
+            &args,
+            &env,
+            mondebug,
+            new_comp_flags.contains(NewCompartmentFlags::DEBUG),
+        )?;
 
         Ok(desc)
     }

--- a/src/rt/monitor/src/mon/compartment.rs
+++ b/src/rt/monitor/src/mon/compartment.rs
@@ -463,7 +463,12 @@ impl super::Monitor {
                 &mut *self.locks.lock(ThreadKey::get().unwrap());
             // TODO: dynlink err map
             loader
-                .build_rcs(&mut *cmp, &mut *dynlink, mondebug)
+                .build_rcs(
+                    &mut *cmp,
+                    &mut *dynlink,
+                    mondebug,
+                    new_comp_flags.contains(NewCompartmentFlags::DEBUG),
+                )
                 .map_err(|_| GenericError::Internal)?
         };
         tracing::trace!("loaded {} as {}", compname, root_comp);

--- a/src/rt/monitor/src/mon/compartment/loader.rs
+++ b/src/rt/monitor/src/mon/compartment/loader.rs
@@ -86,6 +86,7 @@ impl LoadInfo {
         &self,
         handle: MapHandle,
         stack_object: StackObject,
+        is_debugging: bool,
     ) -> Result<RunComp, DynlinkError> {
         let comp_config =
             CompConfigObject::new(handle, SharedCompConfig::new(self.sctx_id, null_mut()));
@@ -102,6 +103,7 @@ impl LoadInfo {
             stack_object,
             self.entry as usize,
             &self.ctor_info,
+            is_debugging,
         ))
     }
 }
@@ -307,6 +309,7 @@ impl RunCompLoader {
         cmp: &mut CompartmentMgr,
         dynlink: &mut Context,
         _mondebug: bool,
+        is_debugging: bool,
     ) -> miette::Result<ObjID> {
         let make_new_handle = |id| {
             Space::safe_create_and_map_runtime_object(
@@ -319,6 +322,7 @@ impl RunCompLoader {
         let root_rc = self.root_comp.build_runcomp(
             make_new_handle(self.root_comp.sctx_id)?,
             StackObject::new(make_new_handle(self.root_comp.sctx_id)?, DEFAULT_STACK_SIZE)?,
+            is_debugging,
         )?;
 
         let mut ids = vec![root_rc.instance];
@@ -338,7 +342,7 @@ impl RunCompLoader {
             .loaded_extras
             .iter()
             .zip(handles)
-            .map(|extra| extra.0.build_runcomp(extra.1 .0, extra.1 .1))
+            .map(|extra| extra.0.build_runcomp(extra.1 .0, extra.1 .1, false))
             .try_collect::<Vec<_>>()?;
 
         for rc in extras.drain(..) {

--- a/src/rt/monitor/src/mon/compartment/runcomp.rs
+++ b/src/rt/monitor/src/mon/compartment/runcomp.rs
@@ -439,15 +439,20 @@ impl RunComp {
 
     pub fn upcall_handle(
         &self,
-        _frame: &mut UpcallFrame,
-        _info: &UpcallData,
-    ) -> Result<ResumeFlags, TwzError> {
-        self.set_flag(CompartmentFlags::EXITED.bits());
+        frame: &mut UpcallFrame,
+        info: &UpcallData,
+    ) -> Result<Option<ResumeFlags>, TwzError> {
         let flags = if self.is_debugging {
-            ResumeFlags::SUSPEND
+            tracing::info!("got monitor upcall {:?} {:?}", frame, info);
+            Some(ResumeFlags::SUSPEND)
         } else {
-            // TODO: maybe just exit if not debugging.
-            ResumeFlags::SUSPEND
+            tracing::warn!(
+                "supervisor exception in {}, thread {}: {:?}",
+                self.name,
+                info.thread_id,
+                info.info
+            );
+            None
         };
         Ok(flags)
     }

--- a/src/rt/monitor/src/mon/mod.rs
+++ b/src/rt/monitor/src/mon/mod.rs
@@ -277,7 +277,8 @@ impl Monitor {
         thread: ObjID,
         len: usize,
     ) -> Result<Vec<u8>, TwzError> {
-        let mut locks = self.locks.lock(ThreadKey::get().unwrap());
+        let t = ThreadKey::get().unwrap();
+        let mut locks = self.locks.lock(t);
         let (_, ref mut comps, _, _, _) = *locks;
         let rc = comps.get_mut(sctx)?;
         let pt = rc.get_per_thread(thread);
@@ -297,7 +298,7 @@ impl Monitor {
         &self,
         frame: &mut UpcallFrame,
         info: &UpcallData,
-    ) -> Result<ResumeFlags, TwzError> {
+    ) -> Result<Option<ResumeFlags>, TwzError> {
         self.comp_mgr
             .write(ThreadKey::get().unwrap())
             .get_mut(frame.prior_ctx)?

--- a/src/rt/monitor/src/mon/mod.rs
+++ b/src/rt/monitor/src/mon/mod.rs
@@ -15,7 +15,10 @@ use monitor_api::{
 use secgate::util::HandleMgr;
 use space::Space;
 use thread::DEFAULT_STACK_SIZE;
-use twizzler_abi::{syscall::sys_thread_exit, upcall::UpcallFrame};
+use twizzler_abi::{
+    syscall::sys_thread_exit,
+    upcall::{ResumeFlags, UpcallFrame},
+};
 use twizzler_rt_abi::{
     error::{GenericError, TwzError},
     object::{MapFlags, ObjID},
@@ -182,7 +185,9 @@ impl Monitor {
                 args.start,
                 args.arg,
             );
-            unsafe { twizzler_abi::syscall::sys_thread_resume_from_upcall(&frame) };
+            unsafe {
+                twizzler_abi::syscall::sys_thread_resume_from_upcall(&frame, ResumeFlags::empty())
+            };
         }))?;
         Ok(thread.id)
     }

--- a/src/rt/monitor/src/upcall.rs
+++ b/src/rt/monitor/src/upcall.rs
@@ -5,16 +5,26 @@ use std::{
 
 use tracing::info;
 use twizzler_abi::upcall::{UpcallData, UpcallFrame, UpcallHandlerFlags};
+
+use crate::mon::get_monitor;
 #[thread_local]
 static IN_UPCALL_HANDLER: AtomicBool = AtomicBool::new(false);
 
 pub fn upcall_monitor_handler(frame: &mut UpcallFrame, info: &UpcallData) {
     let nested = IN_UPCALL_HANDLER.swap(true, Ordering::SeqCst);
+    if nested {}
+
     if info.flags.contains(UpcallHandlerFlags::SWITCHED_CONTEXT) {
         info!("got monitor upcall {:?} {:?}", frame, info);
-        // TODO
-        if nested {
-            twizzler_abi::syscall::sys_thread_exit(101);
+        let mon = get_monitor();
+        match mon.upcall_handle(frame, info) {
+            Ok(flags) => {
+                IN_UPCALL_HANDLER.store(false, Ordering::SeqCst);
+                unsafe { twizzler_abi::syscall::sys_thread_resume_from_upcall(frame, flags) };
+            }
+            Err(_) => {
+                twizzler_abi::syscall::sys_thread_exit(101);
+            }
         }
     } else {
         twizzler_abi::klog_println!(
@@ -24,10 +34,6 @@ pub fn upcall_monitor_handler(frame: &mut UpcallFrame, info: &UpcallData) {
         );
         twizzler_abi::syscall::sys_thread_exit(101);
     }
-    IN_UPCALL_HANDLER.store(nested, Ordering::SeqCst);
-
-    // TODO: we don't always need to exit.
-    twizzler_abi::syscall::sys_thread_exit(101);
 }
 
 pub extern "C-unwind" fn upcall_monitor_handler_entry(frame: *mut c_void, info: *const c_void) {

--- a/src/rt/monitor/src/upcall.rs
+++ b/src/rt/monitor/src/upcall.rs
@@ -3,7 +3,6 @@ use std::{
     sync::atomic::{AtomicBool, Ordering},
 };
 
-use tracing::info;
 use twizzler_abi::upcall::{UpcallData, UpcallFrame, UpcallHandlerFlags};
 
 use crate::mon::get_monitor;
@@ -11,18 +10,16 @@ use crate::mon::get_monitor;
 static IN_UPCALL_HANDLER: AtomicBool = AtomicBool::new(false);
 
 pub fn upcall_monitor_handler(frame: &mut UpcallFrame, info: &UpcallData) {
-    let nested = IN_UPCALL_HANDLER.swap(true, Ordering::SeqCst);
-    if nested {}
+    let _nested = IN_UPCALL_HANDLER.swap(true, Ordering::SeqCst);
 
     if info.flags.contains(UpcallHandlerFlags::SWITCHED_CONTEXT) {
-        info!("got monitor upcall {:?} {:?}", frame, info);
         let mon = get_monitor();
         match mon.upcall_handle(frame, info) {
-            Ok(flags) => {
+            Ok(Some(flags)) => {
                 IN_UPCALL_HANDLER.store(false, Ordering::SeqCst);
                 unsafe { twizzler_abi::syscall::sys_thread_resume_from_upcall(frame, flags) };
             }
-            Err(_) => {
+            _ => {
                 twizzler_abi::syscall::sys_thread_exit(101);
             }
         }

--- a/src/rt/monitor/tests/montest/Cargo.toml
+++ b/src/rt/monitor/tests/montest/Cargo.toml
@@ -14,3 +14,6 @@ ctor = "*"
 tracing = "0.1"
 tracing-subscriber = "0.3"
 twizzler-abi = { path = "../../../../lib/twizzler-abi" }
+
+[profile.release]
+debug = true

--- a/src/rt/monitor/tests/montest/src/main.rs
+++ b/src/rt/monitor/tests/montest/src/main.rs
@@ -18,6 +18,15 @@ extern crate twizzler_runtime;
 fn main() {
     setup_logging();
     montest_lib::test_global_call_count().unwrap();
+    if std::env::args().find(|p| p == "-e").is_some() {
+        unsafe {
+            let nul = core::ptr::null_mut::<u32>();
+            let v = nul.read_volatile();
+            std::hint::black_box(v);
+        }
+    } else if std::env::args().find(|p| p == "-p").is_some() {
+        panic!("montest test panic");
+    }
 }
 use tracing::Level;
 fn setup_logging() {

--- a/src/rt/reference/Cargo.toml
+++ b/src/rt/reference/Cargo.toml
@@ -27,3 +27,6 @@ paste = "1"
 printf-compat = { version = "0.1", default-features = false }
 naming-core = { path = "../../lib/naming/naming-core" }
 pager-dynamic = { path = "../../lib/pager/pager-dynamic" }
+
+[profile.release]
+debug = true

--- a/src/rt/reference/src/arch/aarch64.rs
+++ b/src/rt/reference/src/arch/aarch64.rs
@@ -1,4 +1,4 @@
-use twizzler_abi::upcall::{UpcallData, UpcallFrame};
+use twizzler_abi::upcall::{ResumeFlags, UpcallData, UpcallFrame};
 use twizzler_rt_abi::thread::TlsDesc;
 
 #[no_mangle]
@@ -13,7 +13,7 @@ pub(crate) unsafe extern "C-unwind" fn twz_rt_upcall_entry_c(
     if std::panic::catch_unwind(handler).is_err() {
         sys_thread_exit(UPCALL_EXIT_CODE);
     }
-    twizzler_abi::syscall::sys_thread_resume_from_upcall(&*frame);
+    twizzler_abi::syscall::sys_thread_resume_from_upcall(&*frame, ResumeFlags::empty());
 }
 
 #[no_mangle]

--- a/src/rt/reference/src/arch/x86_64.rs
+++ b/src/rt/reference/src/arch/x86_64.rs
@@ -1,4 +1,4 @@
-use twizzler_abi::upcall::{UpcallData, UpcallFrame};
+use twizzler_abi::upcall::{ResumeFlags, UpcallData, UpcallFrame};
 
 #[no_mangle]
 pub(crate) unsafe extern "C-unwind" fn twz_rt_upcall_entry_c(
@@ -13,5 +13,5 @@ pub(crate) unsafe extern "C-unwind" fn twz_rt_upcall_entry_c(
         sys_thread_exit(UPCALL_EXIT_CODE);
     }
     // TODO: with uiret instruction, we may be able to avoid the kernel, here.
-    twizzler_abi::syscall::sys_thread_resume_from_upcall(&*rdi);
+    twizzler_abi::syscall::sys_thread_resume_from_upcall(&*rdi, ResumeFlags::empty());
 }

--- a/src/rt/reference/src/preinit.rs
+++ b/src/rt/reference/src/preinit.rs
@@ -2,14 +2,20 @@
 
 use std::fmt;
 
-use twizzler_abi::syscall::{sys_kernel_console_write, KernelConsoleWriteFlags};
+use twizzler_abi::syscall::{
+    sys_kernel_console_write, KernelConsoleSource, KernelConsoleWriteFlags,
+};
 
 #[repr(C)]
 struct PreinitLogger;
 
 impl fmt::Write for PreinitLogger {
     fn write_str(&mut self, s: &str) -> fmt::Result {
-        sys_kernel_console_write(s.as_bytes(), KernelConsoleWriteFlags::empty());
+        sys_kernel_console_write(
+            KernelConsoleSource::Console,
+            s.as_bytes(),
+            KernelConsoleWriteFlags::empty(),
+        );
         Ok(())
     }
 }

--- a/src/rt/reference/src/runtime/file.rs
+++ b/src/rt/reference/src/runtime/file.rs
@@ -16,7 +16,10 @@ use raw_file::RawFile;
 use stable_vec::{self, StableVec};
 use twizzler_abi::{
     object::{ObjID, Protections},
-    syscall::{sys_object_create, BackingType, LifetimeType, ObjectCreate, ObjectCreateFlags},
+    syscall::{
+        sys_object_create, BackingType, KernelConsoleSource, LifetimeType, ObjectCreate,
+        ObjectCreateFlags,
+    },
 };
 use twizzler_rt_abi::{
     bindings::{create_options, io_ctx, io_vec},
@@ -101,6 +104,7 @@ impl Read for FdKind {
             FdKind::RawFile(arc) => arc.lock().unwrap().read(buf),
             FdKind::Stdio => {
                 let len = twizzler_abi::syscall::sys_kernel_console_read(
+                    KernelConsoleSource::Console,
                     buf,
                     twizzler_abi::syscall::KernelConsoleReadFlags::empty(),
                 )
@@ -121,6 +125,7 @@ impl Write for FdKind {
             FdKind::RawFile(arc) => arc.lock().unwrap().write(buf),
             FdKind::Stdio => {
                 twizzler_abi::syscall::sys_kernel_console_write(
+                    KernelConsoleSource::Console,
                     buf,
                     twizzler_abi::syscall::KernelConsoleWriteFlags::empty(),
                 );

--- a/src/rt/reference/src/syms.rs
+++ b/src/rt/reference/src/syms.rs
@@ -868,3 +868,7 @@ pub unsafe extern "C-unwind" fn __is_monitor_ready() -> bool {
 pub unsafe extern "C-unwind" fn __is_monitor() -> *mut c_void {
     OUR_RUNTIME.is_monitor().unwrap_or(core::ptr::null_mut())
 }
+
+#[linkage = "weak"]
+#[no_mangle]
+pub unsafe extern "C-unwind" fn _ZdlPvm() {}

--- a/src/srv/logboi-srv/src/lib.rs
+++ b/src/srv/logboi-srv/src/lib.rs
@@ -9,8 +9,8 @@ use secgate::{
 use twizzler_abi::{
     object::{ObjID, Protections},
     syscall::{
-        sys_kernel_console_write, sys_object_create, BackingType, KernelConsoleWriteFlags,
-        LifetimeType, ObjectCreate, ObjectCreateFlags,
+        sys_kernel_console_write, sys_object_create, BackingType, KernelConsoleSource,
+        KernelConsoleWriteFlags, LifetimeType, ObjectCreate, ObjectCreateFlags,
     },
 };
 use twizzler_rt_abi::{
@@ -118,6 +118,10 @@ pub fn logboi_post(
         String::from_utf8_lossy(&buf[0..len])
     );
     logger.count += 1;
-    let _ = sys_kernel_console_write(msg.as_bytes(), KernelConsoleWriteFlags::DISCARD_ON_FULL);
+    let _ = sys_kernel_console_write(
+        KernelConsoleSource::Console,
+        msg.as_bytes(),
+        KernelConsoleWriteFlags::DISCARD_ON_FULL,
+    );
     Ok(())
 }

--- a/tools/xtask/src/main.rs
+++ b/tools/xtask/src/main.rs
@@ -181,6 +181,13 @@ struct QemuOptions {
     repeat: bool,
     #[clap(long, help = "Auto-start a program in init.")]
     autostart: Option<String>,
+    #[clap(
+        long,
+        short,
+        help = "Enable GDB connection via serial, exposed via host TCP <port>. Defaults to :2159.",
+        default_value_t = 2159
+    )]
+    gdb: u16,
 }
 
 impl From<&QemuOptions> for ImageOptions {

--- a/tools/xtask/src/qemu.rs
+++ b/tools/xtask/src/qemu.rs
@@ -134,15 +134,23 @@ impl QemuCommand {
 
         self.cmd
             .arg("--no-reboot") // exit instead of rebooting
-            //.arg("-s") // shorthand for -gdb tcp::1234
             .arg("-serial")
             .arg("mon:stdio");
         //-serial mon:stdio creates a multiplexed stdio backend connected
         // to the serial port and the QEMU monitor, and
         // -nographic also multiplexes the console and the monitor to stdio.
 
+        println!("GDB debugging port: {}", options.gdb);
+        if options.gdb != 0 {
+            self.cmd
+                .arg("-serial")
+                .arg(&format!("tcp::{},server,nowait", options.gdb));
+        }
+
         // add additional options for qemu
         self.cmd.args(&options.qemu_options);
+
+        println!("qemu: {:?}", self.cmd);
 
         //self.cmd.arg("-smp").arg("4,sockets=1,cores=2,threads=2");
     }


### PR DESCRIPTION
This PR adds functionality for:

- running userspace programs under a debugging monitor program ("debug"), which can communicate via GDB remote protocol to a debugger.
- running GDB and getting access to the libraries and executables via the sysroot.
- initial functionality for debugging support in the monitor.
- initial implementation of gdbstub-rs for Twizzler, in the debug stub program.
