### PR TITLE
Initial libc++ port

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -37,3 +37,6 @@
 	path = src/ports/libc
 	url = ../../twizzler-operating-system/libc.git
 	branch = twizzler-2025-04
+[submodule "src/ports/rust-rocksdb"]
+	path = src/ports/rust-rocksdb
+	url = ../../twizzler-operating-system/rust-rocksdb.git

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -462,6 +462,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "bindgen"
+version = "0.69.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
+dependencies = [
+ "bitflags 2.9.0",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.12.1",
+ "lazy_static",
+ "lazycell",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 1.1.0",
+ "shlex",
+ "syn 2.0.100",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -632,6 +652,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
+name = "bzip2-sys"
+version = "0.1.13+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
+
+[[package]]
 name = "camino"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -693,7 +723,7 @@ dependencies = [
  "rand 0.9.0",
  "regex",
  "rusqlite",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "rustc-stable-hash",
  "rustfix",
  "same-file",
@@ -861,6 +891,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom 7.1.3",
+]
+
+[[package]]
 name = "cfg-if"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -934,6 +973,17 @@ dependencies = [
  "crypto-common",
  "inout",
  "zeroize",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
 ]
 
 [[package]]
@@ -3972,6 +4022,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "librocksdb-sys"
+version = "0.17.2+9.10.0"
+dependencies = [
+ "bindgen",
+ "bzip2-sys",
+ "cc",
+ "libc",
+ "libz-sys",
+ "lz4-sys",
+ "zstd-sys",
+]
+
+[[package]]
 name = "libsqlite3-sys"
 version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4136,10 +4199,21 @@ name = "lwext4-rs"
 version = "0.1.0"
 
 [[package]]
+<<<<<<< HEAD
 name = "managed"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ca88d725a0a943b096803bd34e73a4437208b6077654cc4ecb2947a5f91618d"
+=======
+name = "lz4-sys"
+version = "1.11.1+lz4-1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bd8c0d6c6ed0cd30b3652886bb8711dc4bb01d637a68105a3d5158039b418e6"
+dependencies = [
+ "cc",
+ "libc",
+]
+>>>>>>> a4e37b2a (Working on rocksdb.)
 
 [[package]]
 name = "matchers"
@@ -5267,6 +5341,7 @@ dependencies = [
  "libc",
  "miette",
  "naming",
+ "rocksdb",
  "tracing",
  "tracing-subscriber",
  "twizzler",
@@ -5549,6 +5624,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "rocksdb"
+version = "0.23.0"
+dependencies = [
+ "libc",
+ "librocksdb-sys",
+]
+
+[[package]]
 name = "roff"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5601,6 +5684,12 @@ name = "rustc-demangle"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
@@ -8325,3 +8414,13 @@ version = "0.17.2+9.10.0"
 [[patch.unused]]
 name = "rocksdb"
 version = "0.23.0"
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.15+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb81183ddd97d0c74cedf1d50d85c8d08c1b8b68ee863bdee9e706eedba1a237"
+dependencies = [
+ "cc",
+ "pkg-config",
+]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -462,26 +462,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bindgen"
-version = "0.69.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
-dependencies = [
- "bitflags 2.9.0",
- "cexpr",
- "clang-sys",
- "itertools 0.12.1",
- "lazy_static",
- "lazycell",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash 1.1.0",
- "shlex",
- "syn 2.0.100",
-]
-
-[[package]]
 name = "bit-set"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -652,16 +632,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
-name = "bzip2-sys"
-version = "0.1.13+1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
-dependencies = [
- "cc",
- "pkg-config",
-]
-
-[[package]]
 name = "camino"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -723,7 +693,7 @@ dependencies = [
  "rand 0.9.0",
  "regex",
  "rusqlite",
- "rustc-hash 2.1.1",
+ "rustc-hash",
  "rustc-stable-hash",
  "rustfix",
  "same-file",
@@ -891,15 +861,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cexpr"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
-dependencies = [
- "nom 7.1.3",
-]
-
-[[package]]
 name = "cfg-if"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -973,17 +934,6 @@ dependencies = [
  "crypto-common",
  "inout",
  "zeroize",
-]
-
-[[package]]
-name = "clang-sys"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
-dependencies = [
- "glob",
- "libc",
- "libloading",
 ]
 
 [[package]]
@@ -3355,13 +3305,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hw-cxx"
-version = "0.1.0"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "hwlocality"
 version = "1.0.0-alpha.8"
 dependencies = [
@@ -4029,19 +3972,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "librocksdb-sys"
-version = "0.17.2+9.10.0"
-dependencies = [
- "bindgen",
- "bzip2-sys",
- "cc",
- "libc",
- "libz-sys",
- "lz4-sys",
- "zstd-sys",
-]
-
-[[package]]
 name = "libsqlite3-sys"
 version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4204,6 +4134,12 @@ dependencies = [
 [[package]]
 name = "lwext4-rs"
 version = "0.1.0"
+
+[[package]]
+name = "managed"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ca88d725a0a943b096803bd34e73a4437208b6077654cc4ecb2947a5f91618d"
 
 [[package]]
 name = "matchers"
@@ -5331,7 +5267,6 @@ dependencies = [
  "libc",
  "miette",
  "naming",
- "rocksdb",
  "tracing",
  "tracing-subscriber",
  "twizzler",
@@ -5614,14 +5549,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rocksdb"
-version = "0.23.0"
-dependencies = [
- "libc",
- "librocksdb-sys",
-]
-
-[[package]]
 name = "roff"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5674,12 +5601,6 @@ name = "rustc-demangle"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
-
-[[package]]
-name = "rustc-hash"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
@@ -8377,7 +8298,6 @@ dependencies = [
  "syn 2.0.100",
 ]
 
-<<<<<<< HEAD
 [[patch.unused]]
 name = "candle-core"
 version = "0.9.1"
@@ -8397,14 +8317,11 @@ source = "git+https://github.com/dbittman/candle.git?branch=dbittman#7cb2af49767
 name = "gemm-common"
 version = "0.18.2"
 source = "git+https://github.com/dbittman/gemm.git?branch=dbittman-fixes#2aed8d805f6a82c31e80a191a660bfc396bdcd5f"
-=======
-[[package]]
-name = "zstd-sys"
-version = "2.0.15+zstd.1.5.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb81183ddd97d0c74cedf1d50d85c8d08c1b8b68ee863bdee9e706eedba1a237"
-dependencies = [
- "cc",
- "pkg-config",
-]
->>>>>>> 9a7cefcb (Porting libc++.)
+
+[[patch.unused]]
+name = "librocksdb-sys"
+version = "0.17.2+9.10.0"
+
+[[patch.unused]]
+name = "rocksdb"
+version = "0.23.0"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4199,12 +4199,6 @@ name = "lwext4-rs"
 version = "0.1.0"
 
 [[package]]
-<<<<<<< HEAD
-name = "managed"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ca88d725a0a943b096803bd34e73a4437208b6077654cc4ecb2947a5f91618d"
-=======
 name = "lz4-sys"
 version = "1.11.1+lz4-1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4213,7 +4207,12 @@ dependencies = [
  "cc",
  "libc",
 ]
->>>>>>> a4e37b2a (Working on rocksdb.)
+
+[[package]]
+name = "managed"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ca88d725a0a943b096803bd34e73a4437208b6077654cc4ecb2947a5f91618d"
 
 [[package]]
 name = "matchers"
@@ -8387,6 +8386,16 @@ dependencies = [
  "syn 2.0.100",
 ]
 
+[[package]]
+name = "zstd-sys"
+version = "2.0.15+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb81183ddd97d0c74cedf1d50d85c8d08c1b8b68ee863bdee9e706eedba1a237"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
+
 [[patch.unused]]
 name = "candle-core"
 version = "0.9.1"
@@ -8406,21 +8415,3 @@ source = "git+https://github.com/dbittman/candle.git?branch=dbittman#7cb2af49767
 name = "gemm-common"
 version = "0.18.2"
 source = "git+https://github.com/dbittman/gemm.git?branch=dbittman-fixes#2aed8d805f6a82c31e80a191a660bfc396bdcd5f"
-
-[[patch.unused]]
-name = "librocksdb-sys"
-version = "0.17.2+9.10.0"
-
-[[patch.unused]]
-name = "rocksdb"
-version = "0.23.0"
-
-[[package]]
-name = "zstd-sys"
-version = "2.0.15+zstd.1.5.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb81183ddd97d0c74cedf1d50d85c8d08c1b8b68ee863bdee9e706eedba1a237"
-dependencies = [
- "cc",
- "pkg-config",
-]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -462,6 +462,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "bindgen"
+version = "0.69.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
+dependencies = [
+ "bitflags 2.9.0",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.12.1",
+ "lazy_static",
+ "lazycell",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 1.1.0",
+ "shlex",
+ "syn 2.0.100",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -632,6 +652,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
+name = "bzip2-sys"
+version = "0.1.13+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
+
+[[package]]
 name = "camino"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -693,7 +723,7 @@ dependencies = [
  "rand 0.9.0",
  "regex",
  "rusqlite",
- "rustc-hash",
+ "rustc-hash 2.1.1",
  "rustc-stable-hash",
  "rustfix",
  "same-file",
@@ -861,6 +891,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom 7.1.3",
+]
+
+[[package]]
 name = "cfg-if"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -934,6 +973,17 @@ dependencies = [
  "crypto-common",
  "inout",
  "zeroize",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
 ]
 
 [[package]]
@@ -3305,6 +3355,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "hw-cxx"
+version = "0.1.0"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "hwlocality"
 version = "1.0.0-alpha.8"
 dependencies = [
@@ -3972,6 +4029,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "librocksdb-sys"
+version = "0.17.2+9.10.0"
+dependencies = [
+ "bindgen",
+ "bzip2-sys",
+ "cc",
+ "libc",
+ "libz-sys",
+ "lz4-sys",
+ "zstd-sys",
+]
+
+[[package]]
 name = "libsqlite3-sys"
 version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4134,12 +4204,6 @@ dependencies = [
 [[package]]
 name = "lwext4-rs"
 version = "0.1.0"
-
-[[package]]
-name = "managed"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ca88d725a0a943b096803bd34e73a4437208b6077654cc4ecb2947a5f91618d"
 
 [[package]]
 name = "matchers"
@@ -5267,6 +5331,7 @@ dependencies = [
  "libc",
  "miette",
  "naming",
+ "rocksdb",
  "tracing",
  "tracing-subscriber",
  "twizzler",
@@ -5549,6 +5614,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "rocksdb"
+version = "0.23.0"
+dependencies = [
+ "libc",
+ "librocksdb-sys",
+]
+
+[[package]]
 name = "roff"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5601,6 +5674,12 @@ name = "rustc-demangle"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
@@ -8298,6 +8377,7 @@ dependencies = [
  "syn 2.0.100",
 ]
 
+<<<<<<< HEAD
 [[patch.unused]]
 name = "candle-core"
 version = "0.9.1"
@@ -8317,3 +8397,14 @@ source = "git+https://github.com/dbittman/candle.git?branch=dbittman#7cb2af49767
 name = "gemm-common"
 version = "0.18.2"
 source = "git+https://github.com/dbittman/gemm.git?branch=dbittman-fixes#2aed8d805f6a82c31e80a191a660bfc396bdcd5f"
+=======
+[[package]]
+name = "zstd-sys"
+version = "2.0.15+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb81183ddd97d0c74cedf1d50d85c8d08c1b8b68ee863bdee9e706eedba1a237"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
+>>>>>>> 9a7cefcb (Porting libc++.)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -462,26 +462,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bindgen"
-version = "0.69.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
-dependencies = [
- "bitflags 2.9.0",
- "cexpr",
- "clang-sys",
- "itertools 0.12.1",
- "lazy_static",
- "lazycell",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash 1.1.0",
- "shlex",
- "syn 2.0.100",
-]
-
-[[package]]
 name = "bit-set"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -652,16 +632,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
-name = "bzip2-sys"
-version = "0.1.13+1.0.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "225bff33b2141874fe80d71e07d6eec4f85c5c216453dd96388240f96e1acc14"
-dependencies = [
- "cc",
- "pkg-config",
-]
-
-[[package]]
 name = "camino"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -723,7 +693,7 @@ dependencies = [
  "rand 0.9.0",
  "regex",
  "rusqlite",
- "rustc-hash 2.1.1",
+ "rustc-hash",
  "rustc-stable-hash",
  "rustfix",
  "same-file",
@@ -891,15 +861,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cexpr"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
-dependencies = [
- "nom 7.1.3",
-]
-
-[[package]]
 name = "cfg-if"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -973,17 +934,6 @@ dependencies = [
  "crypto-common",
  "inout",
  "zeroize",
-]
-
-[[package]]
-name = "clang-sys"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
-dependencies = [
- "glob",
- "libc",
- "libloading",
 ]
 
 [[package]]
@@ -4022,19 +3972,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "librocksdb-sys"
-version = "0.17.2+9.10.0"
-dependencies = [
- "bindgen",
- "bzip2-sys",
- "cc",
- "libc",
- "libz-sys",
- "lz4-sys",
- "zstd-sys",
-]
-
-[[package]]
 name = "libsqlite3-sys"
 version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4197,16 +4134,6 @@ dependencies = [
 [[package]]
 name = "lwext4-rs"
 version = "0.1.0"
-
-[[package]]
-name = "lz4-sys"
-version = "1.11.1+lz4-1.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bd8c0d6c6ed0cd30b3652886bb8711dc4bb01d637a68105a3d5158039b418e6"
-dependencies = [
- "cc",
- "libc",
-]
 
 [[package]]
 name = "managed"
@@ -5340,7 +5267,6 @@ dependencies = [
  "libc",
  "miette",
  "naming",
- "rocksdb",
  "tracing",
  "tracing-subscriber",
  "twizzler",
@@ -5623,14 +5549,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rocksdb"
-version = "0.23.0"
-dependencies = [
- "libc",
- "librocksdb-sys",
-]
-
-[[package]]
 name = "roff"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5683,12 +5601,6 @@ name = "rustc-demangle"
 version = "0.1.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
-
-[[package]]
-name = "rustc-hash"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
@@ -8384,16 +8296,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.100",
-]
-
-[[package]]
-name = "zstd-sys"
-version = "2.0.15+zstd.1.5.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb81183ddd97d0c74cedf1d50d85c8d08c1b8b68ee863bdee9e706eedba1a237"
-dependencies = [
- "cc",
- "pkg-config",
 ]
 
 [[patch.unused]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,10 +51,15 @@ members = [
     #"src/bin/ls",
     #"src/lib/devmgr",
     #"src/bin/serialecho", "tools/serialtest",
-    "src/bin/ptest", "src/bin/debug",
+    "src/bin/ptest",
+    "src/bin/debug",
 ]
 
-exclude = ["toolchain/src/rust", "src/ports/candle-test/candle", "src/ports/candle-test/gemm"]
+exclude = [
+    "toolchain/src/rust",
+    "src/ports/candle-test/candle",
+    "src/ports/candle-test/gemm",
+]
 resolver = "2"
 
 [workspace.metadata]
@@ -116,6 +121,8 @@ lock_api = { git = "https://github.com/twizzler-operating-system/parking_lot.git
 #lock_api = { path = "src/ports/parking_lot/lock_api" }
 #blocking = { path = "src/ports/blocking" }
 
+
+candle-core = { git = "https://github.com/dbittman/candle.git", branch = "dbittman" }
 twizzler-futures = { path = "src/lib/twizzler-futures" }
 twizzler-abi = { path = "src/lib/twizzler-abi" }
 twizzler-rt-abi = { path = "src/abi/rt-abi" }
@@ -129,9 +136,8 @@ hwlocality = { path = "src/ports/hwlocality" }
 hwlocality-sys = { path = "src/ports/hwlocality/hwlocality-sys" }
 errno = { path = "src/ports/rust-errno" }
 libc = { path = "src/ports/libc" }
-
-
-candle-core = { git = "https://github.com/dbittman/candle.git", branch = "dbittman" }
 candle-transformers = { git = "https://github.com/dbittman/candle.git", branch = "dbittman" }
 candle-nn = { git = "https://github.com/dbittman/candle.git", branch = "dbittman" }
 gemm-common = { git = "https://github.com/dbittman/gemm.git", branch = "dbittman-fixes" }
+rocksdb = { path = "src/ports/rust-rocksdb" }
+librocksdb-sys = { path = "src/ports/rust-rocksdb/librocksdb-sys" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -139,5 +139,5 @@ libc = { path = "src/ports/libc" }
 candle-transformers = { git = "https://github.com/dbittman/candle.git", branch = "dbittman" }
 candle-nn = { git = "https://github.com/dbittman/candle.git", branch = "dbittman" }
 gemm-common = { git = "https://github.com/dbittman/gemm.git", branch = "dbittman-fixes" }
-rocksdb = { path = "src/ports/rust-rocksdb" }
-librocksdb-sys = { path = "src/ports/rust-rocksdb/librocksdb-sys" }
+#rocksdb = { path = "src/ports/rust-rocksdb" }
+#librocksdb-sys = { path = "src/ports/rust-rocksdb/librocksdb-sys" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,8 +81,6 @@ initrd = [
     "crate:sec-test",
     "crate:ptest",
 
-    "crate:hw-cxx",
-
     #"third-party:hello-world-rs"
     #"crate:test-tiny-http",
     #"crate:etl_twizzler",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,6 +81,8 @@ initrd = [
     "crate:sec-test",
     "crate:ptest",
 
+    "crate:hw-cxx",
+
     #"third-party:hello-world-rs"
     #"crate:test-tiny-http",
     #"crate:etl_twizzler",

--- a/src/bin/ptest/Cargo.toml
+++ b/src/bin/ptest/Cargo.toml
@@ -14,4 +14,4 @@ tracing = "*"
 tracing-subscriber = "*"
 hwlocality = { version = "1.0.0-alpha.8", features = ["vendored"] }
 libc = "*"
-#rocksdb = "*"
+rocksdb = "*"

--- a/src/bin/ptest/Cargo.toml
+++ b/src/bin/ptest/Cargo.toml
@@ -14,3 +14,4 @@ tracing = "*"
 tracing-subscriber = "*"
 hwlocality = { version = "1.0.0-alpha.8", features = ["vendored"] }
 libc = "*"
+rocksdb = "*"

--- a/src/bin/ptest/Cargo.toml
+++ b/src/bin/ptest/Cargo.toml
@@ -14,4 +14,4 @@ tracing = "*"
 tracing-subscriber = "*"
 hwlocality = { version = "1.0.0-alpha.8", features = ["vendored"] }
 libc = "*"
-rocksdb = "*"
+#rocksdb = "*"

--- a/src/bin/ptest/src/main.rs
+++ b/src/bin/ptest/src/main.rs
@@ -86,6 +86,7 @@ enum SubCommand {
     Append,
     Read,
     Hw,
+    Rdb,
 }
 
 fn open_or_create_arena() -> Result<ArenaObject> {
@@ -259,6 +260,18 @@ fn main() {
                 println!("done!: {:?}", end - start);
             }
         },
+        SubCommand::Rdb => {
+            println!("rocksdb test");
+            let start = std::time::Instant::now();
+            let db = rocksdb::DB::open_default("db").unwrap();
+            println!("rocksdb test: put");
+            db.put("test", "value").unwrap();
+            let val = db.get("test").unwrap().unwrap();
+            let val = String::from_utf8(val).unwrap();
+            println!("rocksdb test: get: {}", val);
+            let end = std::time::Instant::now();
+            println!("done!: {:?}", end - start);
+        }
     }
 
     /*

--- a/src/bin/ptest/src/main.rs
+++ b/src/bin/ptest/src/main.rs
@@ -261,6 +261,10 @@ fn main() {
             }
         },
         SubCommand::Rdb => {
+            println!("in progress");
+        }
+        /*
+        SubCommand::Rdb => {
             println!("rocksdb test");
             let start = std::time::Instant::now();
             let db = rocksdb::DB::open_default("db").unwrap();
@@ -272,6 +276,7 @@ fn main() {
             let end = std::time::Instant::now();
             println!("done!: {:?}", end - start);
         }
+        */
     }
 
     /*

--- a/src/kernel/src/processor.rs
+++ b/src/kernel/src/processor.rs
@@ -238,7 +238,7 @@ impl Processor {
             .store(true, core::sync::atomic::Ordering::SeqCst);
     }
 
-    fn is_running(&self) -> bool {
+    pub fn is_running(&self) -> bool {
         self.running.load(Ordering::SeqCst)
     }
 

--- a/src/kernel/src/syscall/mod.rs
+++ b/src/kernel/src/syscall/mod.rs
@@ -272,6 +272,13 @@ fn zero_ok<T: Into<u64>>(t: T) -> (u64, u64) {
 }
 
 pub fn syscall_entry<T: SyscallContext>(context: &mut T) {
+    if context.num() as u64 != Syscall::KernelConsoleWrite.num() {
+        log::trace!(
+            "sys {}: {}",
+            crate::thread::current_thread_ref().unwrap().id(),
+            context.num()
+        );
+    }
     /*
     log!(
         ">{}:{}<",

--- a/src/kernel/src/syscall/mod.rs
+++ b/src/kernel/src/syscall/mod.rs
@@ -91,8 +91,18 @@ fn type_sys_thread_sync(ptr: u64, len: u64, timeoutptr: u64) -> Result<usize> {
 }
 
 fn write_sysinfo(info: &mut SysInfo) {
-    // TODO
-    info.cpu_count = 4;
+    info.cpu_count = crate::processor::all_processors().iter().fold(0, |acc, p| {
+        acc + match &p {
+            Some(p) => {
+                if p.is_running() {
+                    1
+                } else {
+                    0
+                }
+            }
+            None => 0,
+        }
+    });
     info.flags = 0;
     info.version = 1;
     info.page_size = 0x1000;

--- a/src/lib/dynlink/src/arch/x86_64.rs
+++ b/src/lib/dynlink/src/arch/x86_64.rs
@@ -64,7 +64,7 @@ impl Context {
         // Lookup a symbol if the relocation's symbol index is non-zero.
         let symbol = if rel.sym() != 0 {
             let sym = syms.get(rel.sym() as usize)?;
-            let flags = LookupFlags::empty();
+            let flags = LookupFlags::ALLOW_WEAK;
             strings
                 .get(sym.st_name as usize)
                 .map(|name| (name, self.lookup_symbol(lib.id(), name, flags)))

--- a/src/lib/dynlink/src/context/load.rs
+++ b/src/lib/dynlink/src/context/load.rs
@@ -431,6 +431,7 @@ impl Context {
                     let mut recs = self
                         .load_library(load_comp, dep_unlib.clone(), idx, allowed_gates, load_ctx)
                         .map_err(|e| {
+                            tracing::error!("failed to load dependency for {}: {}", lib, e);
                             DynlinkError::new_collect(
                                 DynlinkErrorKind::LibraryLoadFail {
                                     library: dep_unlib.clone(),
@@ -453,7 +454,6 @@ impl Context {
             deps,
         )?;
 
-        tracing::debug!("HERE");
         assert_eq!(idx, lib.idx);
         self.library_deps[idx] = LoadedOrUnloaded::Loaded(lib);
         Ok(ids)

--- a/src/ports/hw-cxx/Cargo.toml
+++ b/src/ports/hw-cxx/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "hw-cxx"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+
+[build-dependencies]
+cc = "*"

--- a/src/ports/hw-cxx/build.rs
+++ b/src/ports/hw-cxx/build.rs
@@ -1,3 +1,12 @@
 fn main() {
-    cc::Build::new().file("src/test.cpp").compile("cxxtest");
+    cc::Build::new()
+        .cpp(true)
+        .compiler("clang++")
+        .file("src/test.cpp")
+        .cpp_set_stdlib("c++")
+        .compile("cxxtest");
+
+    println!("cargo::rustc-link-lib=c");
+    println!("cargo::rustc-link-lib=static=c++abi");
+    println!("cargo::rustc-link-lib=unwind");
 }

--- a/src/ports/hw-cxx/build.rs
+++ b/src/ports/hw-cxx/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    cc::Build::new().file("src/test.cpp").compile("cxxtest");
+}

--- a/src/ports/hw-cxx/src/main.rs
+++ b/src/ports/hw-cxx/src/main.rs
@@ -1,8 +1,11 @@
 fn main() {
     println!("Hello, world!");
+    unsafe {
+        testcxx();
+    }
 }
 
-#[link("testcxx")]
-extern "C" {
+#[link(name = "cxxtest")]
+unsafe extern "C" {
     fn testcxx() -> i32;
 }

--- a/src/ports/hw-cxx/src/main.rs
+++ b/src/ports/hw-cxx/src/main.rs
@@ -1,0 +1,8 @@
+fn main() {
+    println!("Hello, world!");
+}
+
+#[link("testcxx")]
+extern "C" {
+    fn testcxx() -> i32;
+}

--- a/src/ports/hw-cxx/src/test.cpp
+++ b/src/ports/hw-cxx/src/test.cpp
@@ -1,5 +1,6 @@
 
 #include<iostream>
+#include <cstdlib>
 
 extern "C" {
 int testcxx() {

--- a/src/ports/hw-cxx/src/test.cpp
+++ b/src/ports/hw-cxx/src/test.cpp
@@ -3,7 +3,8 @@
 
 extern "C" {
 int testcxx() {
-    std::cout << "Hello, World!" << std::endl;
+    auto x = new int(3);
+    std::cout << "Hello, World! " << x << ", " << *x << std::endl;
     return 0;
 }
 }

--- a/src/ports/hw-cxx/src/test.cpp
+++ b/src/ports/hw-cxx/src/test.cpp
@@ -1,0 +1,9 @@
+
+#include<iostream>
+
+extern "C" {
+int testcxx() {
+    std::cout << "Hello, World!" << std::endl;
+    return 0;
+}
+}

--- a/src/ports/lwext4-rs/src/lwext4.rs
+++ b/src/ports/lwext4-rs/src/lwext4.rs
@@ -520,7 +520,7 @@ pub type uint_fast32_t = __mlibc_uint_fast32;
 pub type uint_fast64_t = __mlibc_uint_fast64;
 pub type intmax_t = __mlibc_intmax;
 pub type uintmax_t = __mlibc_uintmax;
-pub type wchar_t = ::std::os::raw::c_int;
+pub type wchar_t = ::std::os::raw::c_uint;
 #[repr(C)]
 #[repr(align(16))]
 #[derive(Debug, Copy, Clone)]

--- a/src/ports/lwext4-rs/src/lwext4.rs
+++ b/src/ports/lwext4-rs/src/lwext4.rs
@@ -520,7 +520,7 @@ pub type uint_fast32_t = __mlibc_uint_fast32;
 pub type uint_fast64_t = __mlibc_uint_fast64;
 pub type intmax_t = __mlibc_intmax;
 pub type uintmax_t = __mlibc_uintmax;
-pub type wchar_t = ::std::os::raw::c_uint;
+pub type wchar_t = ::std::os::raw::c_int;
 #[repr(C)]
 #[repr(align(16))]
 #[derive(Debug, Copy, Clone)]

--- a/src/rt/monitor-api/src/lib.rs
+++ b/src/rt/monitor-api/src/lib.rs
@@ -681,10 +681,13 @@ mod lazy_sb {
 
 pub const THREAD_STARTED: u32 = 1;
 pub struct RuntimeThreadControl {
+    pub id: UnsafeCell<u32>,
+    pub did_exit: UnsafeCell<u32>,
     // Need to keep a lock for the ID, though we don't expect to use it much.
     pub internal_lock: AtomicU32,
     pub flags: AtomicU32,
-    pub id: UnsafeCell<u32>,
+    pub stack_canary: u64,
+    pub libc_data: [u64; 1000],
 }
 
 impl Default for RuntimeThreadControl {
@@ -699,6 +702,9 @@ impl RuntimeThreadControl {
             internal_lock: AtomicU32::new(0),
             flags: AtomicU32::new(0),
             id: UnsafeCell::new(id),
+            did_exit: UnsafeCell::new(0),
+            stack_canary: 0,
+            libc_data: [0; 1000],
         }
     }
 

--- a/src/rt/monitor/src/mon/compartment/loader.rs
+++ b/src/rt/monitor/src/mon/compartment/loader.rs
@@ -255,7 +255,7 @@ impl RunCompLoader {
             extra_lids.as_slice(),
         )?;
 
-        if true || mondebug {
+        if mondebug {
             let print_comp = |cmp: &LoadInfo| -> miette::Result<()> {
                 let dcmp = dynlink.get_compartment(cmp.comp_id)?;
                 tracing::info!("Loaded libraries for {}:", &dcmp.name);

--- a/src/rt/monitor/src/mon/compartment/loader.rs
+++ b/src/rt/monitor/src/mon/compartment/loader.rs
@@ -255,7 +255,7 @@ impl RunCompLoader {
             extra_lids.as_slice(),
         )?;
 
-        if mondebug {
+        if true || mondebug {
             let print_comp = |cmp: &LoadInfo| -> miette::Result<()> {
                 let dcmp = dynlink.get_compartment(cmp.comp_id)?;
                 tracing::info!("Loaded libraries for {}:", &dcmp.name);

--- a/src/rt/monitor/src/mon/compartment/runcomp.rs
+++ b/src/rt/monitor/src/mon/compartment/runcomp.rs
@@ -314,9 +314,6 @@ impl RunComp {
         debug_assert!(self.main.is_none());
         // Unwrap-Ok: we only take this once, when starting the main thread.
         let (stack, entry, ctors) = self.init_info.take().unwrap();
-        for c in &ctors {
-            tracing::info!("==> {:?}", c);
-        }
         let mut build_init_info = || -> Option<_> {
             let comp_config_info =
                 self.comp_config_object.get_comp_config() as *mut SharedCompConfig;

--- a/src/rt/monitor/src/mon/compartment/runcomp.rs
+++ b/src/rt/monitor/src/mon/compartment/runcomp.rs
@@ -314,6 +314,9 @@ impl RunComp {
         debug_assert!(self.main.is_none());
         // Unwrap-Ok: we only take this once, when starting the main thread.
         let (stack, entry, ctors) = self.init_info.take().unwrap();
+        for c in &ctors {
+            tracing::info!("==> {:?}", c);
+        }
         let mut build_init_info = || -> Option<_> {
             let comp_config_info =
                 self.comp_config_object.get_comp_config() as *mut SharedCompConfig;

--- a/src/rt/reference/src/runtime.rs
+++ b/src/rt/reference/src/runtime.rs
@@ -74,8 +74,10 @@ pub static OUR_RUNTIME: ReferenceRuntime = ReferenceRuntime {
 // Or, at least, that's what it seems like. In any case, they're no-ops in libunwind and musl, so
 // this is fine for now.
 #[no_mangle]
+#[linkage = "weak"]
 pub extern "C" fn __register_frame_info() {}
 #[no_mangle]
+#[linkage = "weak"]
 pub extern "C" fn __deregister_frame_info() {}
 #[no_mangle]
 #[linkage = "weak"]

--- a/src/rt/reference/src/runtime/core.rs
+++ b/src/rt/reference/src/runtime/core.rs
@@ -113,7 +113,22 @@ impl ReferenceRuntime {
                         .unwrap()
                 };
                 let _ = MON_RTINFO.set(None);
-                self.init_for_compartment(init_info);
+                let mut entry_stack = Vec::new();
+                entry_stack.push(rtinfo.argc);
+                if !rtinfo.args.is_null() {
+                    for arg in unsafe { core::slice::from_raw_parts(rtinfo.args, rtinfo.argc) } {
+                        entry_stack.push(*arg as usize);
+                    }
+                }
+                entry_stack.push(0);
+                if !rtinfo.envp.is_null() {
+                    for env in unsafe { core::slice::from_raw_parts(rtinfo.envp, rtinfo.argc) } {
+                        entry_stack.push(*env as usize);
+                    }
+                }
+                entry_stack.push(0);
+                self.init_for_compartment(init_info, entry_stack.as_mut_ptr());
+                std::mem::forget(entry_stack);
             }
             x => {
                 preinit_println!("unsupported runtime kind: {}", x);
@@ -211,7 +226,7 @@ impl ReferenceRuntime {
         self.init_ctors(&init_info.ctors);
     }
 
-    fn init_for_compartment(&self, init_info: &CompartmentInitInfo) {
+    fn init_for_compartment(&self, init_info: &CompartmentInitInfo, entry_stack: *mut usize) {
         unsafe {
             preinit_unwrap(
                 monitor_api::set_comp_config(
@@ -225,6 +240,13 @@ impl ReferenceRuntime {
         let mut tg = TLS_GEN_MGR.lock();
         let tls = tg.get_next_tls_info(None, || RuntimeThreadControl::new(0));
         twizzler_abi::syscall::sys_thread_settls(preinit_unwrap(tls) as u64);
+
+        if !unsafe { __mlibc_entry.is_null() } {
+            let mlibc_entry = unsafe {
+                std::mem::transmute::<_, extern "C" fn(*mut usize, *mut u8)>(__mlibc_entry)
+            };
+            mlibc_entry(entry_stack, core::ptr::null_mut());
+        }
 
         if !init_info.ctor_set_array.is_null() && init_info.ctor_set_len != 0 {
             let ctor_slice = unsafe {
@@ -264,4 +286,9 @@ impl ReferenceRuntime {
         let tls = info.tls_region.get_thread_pointer_value();
         twizzler_abi::syscall::sys_thread_settls(tls as u64);
     }
+}
+
+extern "C" {
+    #[linkage = "extern_weak"]
+    static __mlibc_entry: *mut u8;
 }

--- a/src/rt/reference/src/runtime/core.rs
+++ b/src/rt/reference/src/runtime/core.rs
@@ -235,6 +235,7 @@ impl ReferenceRuntime {
 
     fn init_ctors(&self, ctor_array: &[CtorSet]) {
         for ctor in ctor_array {
+            twizzler_abi::klog_println!("run ctors: {:?}", ctor);
             unsafe {
                 if let Some(legacy_init) = ctor.legacy_init {
                     (core::mem::transmute::<_, extern "C" fn()>(legacy_init))();
@@ -245,6 +246,7 @@ impl ReferenceRuntime {
                         ctor.init_array_len,
                     );
                     for call in init_slice.iter().cloned() {
+                        twizzler_abi::klog_println!("call: {}", call);
                         (core::mem::transmute::<_, extern "C" fn()>(call))();
                     }
                 }

--- a/src/rt/reference/src/syms.rs
+++ b/src/rt/reference/src/syms.rs
@@ -871,4 +871,12 @@ pub unsafe extern "C-unwind" fn __is_monitor() -> *mut c_void {
 
 #[linkage = "weak"]
 #[no_mangle]
+pub unsafe extern "C-unwind" fn _ZdlPv() {}
+
+#[linkage = "weak"]
+#[no_mangle]
+pub unsafe extern "C-unwind" fn _ZdlPvj() {}
+
+#[linkage = "weak"]
+#[no_mangle]
 pub unsafe extern "C-unwind" fn _ZdlPvm() {}

--- a/src/srv/naming-srv/Cargo.toml
+++ b/src/srv/naming-srv/Cargo.toml
@@ -19,7 +19,7 @@ arrayvec = "0.7.6"
 naming-core = { path = "../../lib/naming/naming-core" }
 lazy-init = "0.5.1"
 tracing = "*"
-pager = { path = "../../lib/pager/"}
+pager = { path = "../../lib/pager/" }
 tracing-subscriber = "*"
 
 [features]

--- a/tools/xtask/src/qemu.rs
+++ b/tools/xtask/src/qemu.rs
@@ -47,7 +47,7 @@ impl QemuCommand {
 
     pub fn config(&mut self, options: &QemuOptions, image_info: ImageInfo) {
         // Set up the basic stuff, memory and bios, etc.
-        self.cmd.arg("-m").arg("8000,slots=4,maxmem=8T");
+        self.cmd.arg("-m").arg("8000,slots=4,maxmem=512G");
 
         // configure architechture specific parameters
         self.arch_config(options);

--- a/tools/xtask/src/toolchain.rs
+++ b/tools/xtask/src/toolchain.rs
@@ -489,17 +489,48 @@ pub(crate) fn do_bootstrap(cli: BootstrapOptions) -> anyhow::Result<()> {
             "toolchain/src/rust/build/{}/native/libcxx",
             target_triple.to_string()
         ));
-        let sysroot_include = sysroot_dir.join("include");
 
-        println!("copying c++ headers");
+        let cxxabi_install_dir = current_dir.join(&format!(
+            "toolchain/src/rust/build/{}/native/libcxxabi",
+            target_triple.to_string()
+        ));
+        let sysroot_include = sysroot_dir.join("include");
+        let sysroot_lib = sysroot_dir.join("lib");
+
+        println!("copying c++ headers and stdlib");
         let status = Command::new("cp")
             .arg("-R")
             .arg(cxx_install_dir.join("include/c++"))
-            .arg(sysroot_include)
+            .arg(&sysroot_include)
             .status()?;
         if !status.success() {
-            anyhow::bail!("failed to copy twizzler ABI headers");
+            anyhow::bail!("failed to copy C++ headers");
         }
+        let status = Command::new("cp")
+            .arg("-R")
+            .arg(cxxabi_install_dir.join("include/c++"))
+            .arg(&sysroot_include)
+            .status()?;
+        if !status.success() {
+            anyhow::bail!("failed to copy C++ ABI headers");
+        }
+
+        std::fs::copy(
+            cxx_install_dir.join("lib/libc++.a"),
+            sysroot_lib.join("libc++.a"),
+        )?;
+        std::fs::copy(
+            cxx_install_dir.join("lib/libc++experimental.a"),
+            sysroot_lib.join("jibc++experimental.a"),
+        )?;
+        std::fs::copy(
+            cxxabi_install_dir.join("lib/libc++abi.a"),
+            sysroot_lib.join("libc++abi.a"),
+        )?;
+        std::fs::copy(
+            cxxabi_install_dir.join("lib/libc++abi.so"),
+            sysroot_lib.join("libc++abi.so"),
+        )?;
 
         let usr_link = sysroot_dir.join("usr");
         let _ = std::fs::remove_file(&usr_link);
@@ -570,9 +601,18 @@ pub fn set_cc(target: &Triple) {
         target.to_string(),
         sysroot_path.display(),
     );
+    let cxxflags = format!(
+        "-fno-stack-protector -cxx-isystem {} -stdlib++-isystem {} -isysroot {} -target {} --sysroot {} ",
+        sysroot_path.join("include/c++/v1").display(),
+        sysroot_path.join("include/c++/v1").display(),
+        sysroot_path.display(),
+        target.to_string(),
+        sysroot_path.display(),
+    );
     std::env::set_var("CFLAGS", &cflags);
     std::env::set_var("LDFLAGS", &cflags);
     std::env::set_var("CXXFLAGS", &cflags);
+    std::env::set_var("CXXFLAGS", &cxxflags);
 }
 
 pub fn clear_cc() {

--- a/tools/xtask/src/toolchain.rs
+++ b/tools/xtask/src/toolchain.rs
@@ -596,13 +596,13 @@ pub fn set_cc(target: &Triple) {
     // We don't yet support stack protector. Also, don't pull in standard lib includes, as those may
     // go to the system includes.
     let cflags = format!(
-        "-fno-stack-protector -isysroot {} -target {} --sysroot {}",
+        "-fno-stack-protector -isysroot {} -target {} --sysroot {} -D__Twizzler__",
         sysroot_path.display(),
         target.to_string(),
         sysroot_path.display(),
     );
     let cxxflags = format!(
-        "-fno-stack-protector -cxx-isystem {} -stdlib++-isystem {} -isysroot {} -target {} --sysroot {} ",
+        "-fno-stack-protector -cxx-isystem {} -stdlib++-isystem {} -isysroot {} -target {} --sysroot {} -D__Twizzler__",
         sysroot_path.join("include/c++/v1").display(),
         sysroot_path.join("include/c++/v1").display(),
         sysroot_path.display(),
@@ -613,6 +613,7 @@ pub fn set_cc(target: &Triple) {
     std::env::set_var("LDFLAGS", &cflags);
     std::env::set_var("CXXFLAGS", &cflags);
     std::env::set_var("CXXFLAGS", &cxxflags);
+    std::env::set_var("CXXSTDLIB", "c++");
 }
 
 pub fn clear_cc() {

--- a/tools/xtask/src/toolchain.rs
+++ b/tools/xtask/src/toolchain.rs
@@ -485,6 +485,22 @@ pub(crate) fn do_bootstrap(cli: BootstrapOptions) -> anyhow::Result<()> {
             anyhow::bail!("failed to install mlibc");
         }
 
+        let cxx_install_dir = current_dir.join(&format!(
+            "toolchain/src/rust/build/{}/native/libcxx",
+            target_triple.to_string()
+        ));
+        let sysroot_include = sysroot_dir.join("include");
+
+        println!("copying c++ headers");
+        let status = Command::new("cp")
+            .arg("-R")
+            .arg(cxx_install_dir.join("include/c++"))
+            .arg(sysroot_include)
+            .status()?;
+        if !status.success() {
+            anyhow::bail!("failed to copy twizzler ABI headers");
+        }
+
         let usr_link = sysroot_dir.join("usr");
         let _ = std::fs::remove_file(&usr_link);
         std::os::unix::fs::symlink(".", usr_link)?;


### PR DESCRIPTION
This PR adds support for libc++, the C++ standard library, the C++ abi, and compiling C++ programs.

- Modify mlibc to support libc++.
- Add support to Rust for building libc++ as part of other native llvm libraries (e.g. unwind).
- Add support to the build system for defining CXXFLAGS, etc.
- Initial port of rocksdb as a driving application of the libc++ port.



