### PR TITLE
Implement object info system call

### DIFF
--- a/src/kernel/src/obj/mod.rs
+++ b/src/kernel/src/obj/mod.rs
@@ -4,8 +4,7 @@ use alloc::{
     vec::Vec,
 };
 use core::{
-    fmt::Display,
-    sync::atomic::{AtomicU32, Ordering},
+    fmt::Display, sync::atomic::{AtomicU32, Ordering}
 };
 
 use pages::PageRef;
@@ -13,7 +12,7 @@ use range::{GetPageFlags, PageStatus};
 use twizzler_abi::{
     meta::{MetaFlags, MetaInfo},
     object::{ObjID, Protections, MAX_SIZE},
-    syscall::{CreateTieSpec, LifetimeType},
+    syscall::{BackingType, CreateTieSpec, LifetimeType, ObjectInfo},
 };
 use twizzler_rt_abi::object::Nonce;
 
@@ -301,6 +300,30 @@ impl Object {
 
     pub fn dirty_set(&self) -> &DirtySet {
         &self.dirty_set
+    }
+
+    pub fn info(&self) -> ObjectInfo {
+        let num_pages = {
+            let page_tree = self.lock_page_tree();
+            let r = page_tree.range(0.into()..usize::MAX.into());
+            let mut page_count = 0;
+            for range in r {
+                page_count += range.1.length;
+            }
+            page_count
+        };
+        ObjectInfo {
+            id: self.id,
+            // TODO: see self.contexts?
+            maps: 0,
+            // TODO: see TIE_MGR
+            ties_to: 0,
+            ties_from: 0,
+            life: self.lifetime_type,
+            backing: BackingType::default(),
+            pages: num_pages,
+
+        }
     }
 }
 

--- a/src/kernel/src/syscall/object.rs
+++ b/src/kernel/src/syscall/object.rs
@@ -8,8 +8,7 @@ use twizzler_abi::{
     object::{ObjID, Protections, MAX_SIZE},
     pager::PagerFlags,
     syscall::{
-        CreateTieSpec, DeleteFlags, HandleType, MapControlCmd, MapFlags, MapInfo, ObjectControlCmd,
-        ObjectCreate, ObjectCreateFlags, ObjectSource,
+        CreateTieSpec, DeleteFlags, HandleType, MapControlCmd, MapFlags, MapInfo, ObjectControlCmd, ObjectCreate, ObjectCreateFlags, ObjectInfo, ObjectSource
     },
 };
 use twizzler_rt_abi::{
@@ -149,6 +148,12 @@ pub fn sys_object_readmap(handle: ObjID, slot: usize) -> Result<MapInfo> {
         slot,
         flags: MapFlags::empty(),
     })
+}
+
+pub fn sys_object_info(handle: ObjID) -> Result<ObjectInfo> {
+    let obj = crate::obj::lookup_object(handle, LookupFlags::empty())
+        .ok_or(ObjectError::NoSuchObject)?;
+    Ok(obj.info())
 }
 
 pub trait ObjectHandle {

--- a/src/lib/twizzler-abi/src/syscall/object_stat.rs
+++ b/src/lib/twizzler-abi/src/syscall/object_stat.rs
@@ -21,6 +21,8 @@ pub struct ObjectInfo {
     pub life: LifetimeType,
     /// The backing type of this object.
     pub backing: BackingType,
+    /// The number of pages allocated to this object.
+    pub pages: usize,
 }
 
 /// Read information about a given object.


### PR DESCRIPTION
This PR implements a simple PoC for the object info system call. It adds a field to the `ObjectInfo` struct to record the number of pages currently allocated to an object. Currently the implementation only fills out the `id`, `lifetime`, `backing`, and `pages` fields.