### PR TITLE
Implement file/namespace rename through full naming stack

### DIFF
--- a/src/lib/naming/naming-core/src/api.rs
+++ b/src/lib/naming/naming-core/src/api.rs
@@ -14,5 +14,6 @@ pub trait NamerAPI {
     fn enumerate_names(&self, desc: Descriptor, name_len: usize) -> Result<usize>;
     fn enumerate_names_nsid(&self, desc: Descriptor, id: ObjID) -> Result<usize>;
     fn remove(&self, desc: Descriptor, name_len: usize) -> Result<()>;
+    fn rename(&self, desc: Descriptor, old_len: usize, new_len: usize) -> Result<()>;
     fn change_namespace(&self, desc: Descriptor, name_len: usize) -> Result<()>;
 }

--- a/src/lib/naming/naming-core/src/dynamic.rs
+++ b/src/lib/naming/naming-core/src/dynamic.rs
@@ -17,6 +17,7 @@ pub struct DynamicNamerAPI {
     enumerate_names: DynamicSecGate<'static, (Descriptor, usize), usize>,
     enumerate_names_nsid: DynamicSecGate<'static, (Descriptor, ObjID), usize>,
     remove: DynamicSecGate<'static, (Descriptor, usize), ()>,
+    rename: DynamicSecGate<'static, (Descriptor, usize, usize), ()>,
     change_namespace: DynamicSecGate<'static, (Descriptor, usize), ()>,
 }
 
@@ -48,6 +49,10 @@ impl NamerAPI for DynamicNamerAPI {
 
     fn remove(&self, desc: Descriptor, name_len: usize) -> Result<()> {
         (self.remove)(desc, name_len)
+    }
+
+    fn rename(&self, desc: Descriptor, old_len: usize, new_len: usize) -> Result<()> {
+        (self.rename)(desc, old_len, new_len)
     }
 
     fn change_namespace(&self, desc: Descriptor, name_len: usize) -> Result<()> {
@@ -116,6 +121,11 @@ pub fn dynamic_namer_api() -> &'static DynamicNamerAPI {
                 handle
                     .dynamic_gate("remove")
                     .expect("failed to find remove gate call")
+            },
+            rename: unsafe {
+                handle
+                    .dynamic_gate("rename")
+                    .expect("failed to find rename gate call")
             },
             change_namespace: unsafe {
                 handle

--- a/src/lib/naming/naming-core/src/handle.rs
+++ b/src/lib/naming/naming-core/src/handle.rs
@@ -116,6 +116,12 @@ impl<'a, API: NamerAPI> NamingHandle<'a, API> {
         self.api.mkns(self.desc, name_len, persist)
     }
 
+    pub fn rename<P: AsRef<Path>, Q: AsRef<Path>>(&mut self, old: P, new: Q) -> Result<()> {
+        let old_len = self.write_buffer(old)?;
+        let new_len = self.write_buffer_at(new, old_len)?;
+        self.api.rename(self.desc, old_len, new_len)
+    }
+
     pub fn symlink<P: AsRef<Path>, L: AsRef<Path>>(&mut self, path: P, link: L) -> Result<()> {
         let name_len = self.write_buffer(path)?;
         let link_len = self.write_buffer_at(link, name_len)?;

--- a/src/lib/naming/naming-core/src/store.rs
+++ b/src/lib/naming/naming-core/src/store.rs
@@ -438,6 +438,37 @@ impl NameSession<'_> {
             .ok_or(NamingError::NotFound.into())
     }
 
+    pub fn rename<P: AsRef<Path>, Q: AsRef<Path>>(&self, old: P, new: Q) -> Result<()> {
+        // Look up the old entry (don't follow symlinks — we're moving the entry itself)
+        let (old_node, old_container) =
+            self.namei_exist(None, &old, Self::MAX_SYMLINK_DEREF, false)?;
+
+        // Check that the new path doesn't already exist
+        let (new_node, new_container) = self.namei(None, &new, Self::MAX_SYMLINK_DEREF, false)?;
+        let Err(new_name) = new_node else {
+            return Err(NamingError::AlreadyExists.into());
+        };
+
+        // Create new entry preserving the old node's type and data
+        let new_entry = if old_node.kind == NsNodeKind::SymLink {
+            NsNode::new(
+                NsNodeKind::SymLink,
+                old_node.id,
+                &new_name,
+                Some(old_node.readlink()?),
+            )?
+        } else {
+            NsNode::new::<_, &str>(old_node.kind, old_node.id, &new_name, None)?
+        };
+
+        // Insert at new location, then remove from old location
+        new_container.insert(new_entry);
+        old_container
+            .remove(old_node.name()?)
+            .map(|_| ())
+            .ok_or(NamingError::NotFound.into())
+    }
+
     pub fn link<P: AsRef<Path>, L: AsRef<Path>>(&self, name: P, link: L) -> Result<()> {
         let (node, container) = self.namei(None, &name, Self::MAX_SYMLINK_DEREF, false)?;
         let Err(name) = node else {

--- a/src/lib/naming/src/lib.rs
+++ b/src/lib/naming/src/lib.rs
@@ -37,6 +37,10 @@ impl NamerAPI for StaticNamingAPI {
         naming_srv::remove(desc, name_len)
     }
 
+    fn rename(&self, desc: Descriptor, old_len: usize, new_len: usize) -> Result<()> {
+        naming_srv::rename(desc, old_len, new_len)
+    }
+
     fn change_namespace(&self, desc: Descriptor, name_len: usize) -> Result<()> {
         naming_srv::change_namespace(desc, name_len)
     }

--- a/src/rt/reference/src/runtime/file.rs
+++ b/src/rt/reference/src/runtime/file.rs
@@ -359,6 +359,11 @@ impl ReferenceRuntime {
         Ok(fd.try_into().unwrap())
     }
 
+    pub fn rename(&self, old: &str, new: &str) -> Result<()> {
+        let mut session = get_naming_handle().lock().unwrap();
+        Ok(session.rename(old, new)?)
+    }
+
     pub fn remove(&self, path: &str) -> Result<()> {
         let mut session = get_naming_handle().lock().unwrap();
         Ok(session.remove(path)?)

--- a/src/rt/reference/src/syms.rs
+++ b/src/rt/reference/src/syms.rs
@@ -430,6 +430,29 @@ pub unsafe extern "C-unwind" fn twz_rt_fd_symlink(
 check_ffi_type!(twz_rt_fd_symlink, _, _, _, _);
 
 #[no_mangle]
+pub unsafe extern "C-unwind" fn twz_rt_fd_rename(
+    old_name: *const c_char,
+    old_len: usize,
+    new_name: *const c_char,
+    new_len: usize,
+) -> twz_error {
+    let old = unsafe { core::slice::from_raw_parts(old_name.cast(), old_len) };
+    let old = core::str::from_utf8(old).map_err(|_| TwzError::INVALID_ARGUMENT.raw());
+    let new = unsafe { core::slice::from_raw_parts(new_name.cast(), new_len) };
+    let Ok(new) = core::str::from_utf8(new).map_err(|_| TwzError::INVALID_ARGUMENT.raw()) else {
+        return TwzError::INVALID_ARGUMENT.into();
+    };
+    match old {
+        Ok(old) => match OUR_RUNTIME.rename(old, new) {
+            Ok(_) => RawTwzError::success().raw(),
+            Err(e) => e.raw(),
+        },
+        Err(e) => e,
+    }
+}
+check_ffi_type!(twz_rt_fd_rename, _, _, _, _);
+
+#[no_mangle]
 pub unsafe extern "C-unwind" fn twz_rt_fd_readlink(
     name: *const c_char,
     len: usize,

--- a/src/srv/naming-srv/src/lib.rs
+++ b/src/srv/naming-srv/src/lib.rs
@@ -273,6 +273,25 @@ pub fn get(
 }
 
 #[secure_gate(options(info))]
+pub fn rename(
+    info: &secgate::GateCallInfo,
+    desc: Descriptor,
+    old_len: usize,
+    new_len: usize,
+) -> Result<()> {
+    let service = NAMINGSERVICE.get().unwrap();
+    let mut binding = service.handles.lock().unwrap();
+    let client = binding
+        .lookup_mut(info.source_context().unwrap_or(0.into()), desc)
+        .ok_or(ErrorKind::Other)?;
+
+    let old_path = client.read_buffer(old_len)?;
+    let new_path = client.read_buffer_at(new_len, old_len)?;
+
+    client.session.rename(old_path, new_path)
+}
+
+#[secure_gate(options(info))]
 pub fn remove(info: &secgate::GateCallInfo, desc: Descriptor, name_len: usize) -> Result<()> {
     let service = NAMINGSERVICE.get().unwrap();
     let mut binding = service.handles.lock().unwrap();


### PR DESCRIPTION
Adds rename support across all layers:
- NameSession::rename() in naming-core store (preserves symlink targets)
- NamerAPI trait, NamingHandle, DynamicNamerAPI, StaticNamingAPI
- naming-srv secure gate
- Runtime file.rs, FFI exports in syms.rs
- ABI submodule updated with twz_rt_fd_rename