### PR TITLE
Add virtio-input driver crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,6 +58,7 @@ members = [
     #"src/bin/randtest",
     #"src/bin/stdfs_demo",
     "src/lib/virtio-gpu",
+    "src/lib/virtio-input",
     #"src/bin/ls",
     #"src/lib/devmgr",
     #"src/bin/serialecho", "tools/serialtest",

--- a/src/lib/virtio-input/Cargo.toml
+++ b/src/lib/virtio-input/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "virtio-input"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+twizzler-driver = { path = "../../lib/twizzler-driver" }
+twizzler-abi = { path = "../../lib/twizzler-abi" }
+devmgr = { path = "../../lib/devmgr" }
+virtio-drivers = "0.12"
+volatile = { version = "0.5", features = ["unstable"] }
+tracing = "*"
+zerocopy = "*"

--- a/src/lib/virtio-input/src/hal.rs
+++ b/src/lib/virtio-input/src/hal.rs
@@ -1,0 +1,153 @@
+use core::ptr::NonNull;
+use std::{
+    collections::HashMap,
+    ptr::copy_nonoverlapping,
+    sync::{Mutex, OnceLock},
+};
+
+use twizzler_driver::dma::{Access, DmaOptions, DmaPool, DmaSliceRegion, SyncMode, DMA_PAGE_SIZE};
+use virtio_drivers::{BufferDirection, Hal, PhysAddr, PAGE_SIZE};
+
+struct TwzHalStatic {
+    host_to_device: DmaPool,
+    device_to_host: DmaPool,
+    bidirectional: DmaPool,
+
+    available: Vec<DmaSliceRegion<u8>>,
+    shared: HashMap<PhysAddr, DmaSliceRegion<u8>>,
+}
+
+pub struct TwzHal;
+
+static TWZHAL: OnceLock<Mutex<TwzHalStatic>> = OnceLock::new();
+
+fn get_twz_hal() -> &'static Mutex<TwzHalStatic> {
+    TWZHAL.get_or_init(|| Mutex::new(TwzHalStatic::new()))
+}
+
+impl TwzHalStatic {
+    fn new() -> Self {
+        Self {
+            host_to_device: DmaPool::new(
+                DmaPool::default_spec(),
+                Access::HostToDevice,
+                DmaOptions::empty(),
+            ),
+            device_to_host: DmaPool::new(
+                DmaPool::default_spec(),
+                Access::DeviceToHost,
+                DmaOptions::empty(),
+            ),
+            bidirectional: DmaPool::new(
+                DmaPool::default_spec(),
+                Access::BiDirectional,
+                DmaOptions::empty(),
+            ),
+            available: Vec::new(),
+            shared: HashMap::new(),
+        }
+    }
+
+    fn get_dma_pool(&self, dir: BufferDirection) -> &DmaPool {
+        match dir {
+            BufferDirection::DriverToDevice => &self.host_to_device,
+            BufferDirection::DeviceToDriver => &self.device_to_host,
+            BufferDirection::Both => &self.bidirectional,
+        }
+    }
+}
+
+unsafe impl Hal for TwzHal {
+    fn dma_alloc(pages: usize, direction: BufferDirection) -> (PhysAddr, NonNull<u8>) {
+        if pages > 1 {
+            let twzhal = get_twz_hal().lock().unwrap();
+            let pool = twzhal.get_dma_pool(direction);
+            let mut dma_slice = pool.allocate_array(pages * PAGE_SIZE, 0u8).unwrap();
+
+            let pin = dma_slice.pin().unwrap();
+            let phys_addr: virtio_drivers::PhysAddr =
+                u64::from(pin.into_iter().next().unwrap().addr()) as virtio_drivers::PhysAddr;
+            let virt = unsafe { NonNull::<u8>::new(dma_slice.get_mut().as_mut_ptr()) }.unwrap();
+            std::mem::forget(dma_slice);
+            return (phys_addr as PhysAddr, virt);
+        }
+
+        let mut twzhal = get_twz_hal().lock().unwrap();
+        let mut dma_slice = if let Some(buffer) = twzhal.available.pop() {
+            buffer
+        } else {
+            let pool = twzhal.get_dma_pool(direction);
+            pool.allocate_array(pages * PAGE_SIZE, 0u8).unwrap()
+        };
+
+        let pin = dma_slice.pin().unwrap();
+        let phys_addr: virtio_drivers::PhysAddr =
+            u64::from(pin.into_iter().next().unwrap().addr()) as virtio_drivers::PhysAddr;
+        let virt = unsafe { NonNull::<u8>::new(dma_slice.get_mut().as_mut_ptr()) }.unwrap();
+        twzhal.shared.insert(phys_addr, dma_slice);
+        (phys_addr as PhysAddr, virt)
+    }
+
+    unsafe fn dma_dealloc(paddr: PhysAddr, _vaddr: NonNull<u8>, pages: usize) -> i32 {
+        let mut twzhal = get_twz_hal().lock().unwrap();
+
+        if pages > 1 {
+            // TODO: this leaks
+            return 0;
+        }
+
+        if let Some(dma_slice) = twzhal.shared.remove(&paddr) {
+            twzhal.available.push(dma_slice);
+        }
+        0
+    }
+
+    unsafe fn mmio_phys_to_virt(_paddr: PhysAddr, _size: usize) -> NonNull<u8> {
+        panic!("Should never be called as we have our own transport implementation");
+    }
+
+    unsafe fn share(buffer: NonNull<[u8]>, direction: BufferDirection) -> PhysAddr {
+        let buf_len = buffer.len();
+        assert!(buf_len <= DMA_PAGE_SIZE, "Hal::Share(): Buffer too large");
+        let (phys, virt) = TwzHal::dma_alloc(1, direction);
+
+        let buf_casted = buffer.cast::<u8>();
+        let buf = buf_casted.as_ptr();
+        let dma_buf = virt.as_ptr();
+        copy_nonoverlapping(buf, dma_buf, buf_len);
+
+        let twzhal = get_twz_hal().lock().unwrap();
+        if let Some(dma_slice) = twzhal.shared.get(&phys) {
+            match direction {
+                BufferDirection::DriverToDevice => {
+                    dma_slice.sync(0..buf_len, SyncMode::PostCpuToDevice);
+                }
+                BufferDirection::DeviceToDriver => {
+                    dma_slice.sync(0..buf_len, SyncMode::PreDeviceToCpu);
+                }
+                _ => {}
+            }
+        }
+        phys as PhysAddr
+    }
+
+    unsafe fn unshare(paddr: PhysAddr, buffer: NonNull<[u8]>, direction: BufferDirection) {
+        let mut twzhal = get_twz_hal().lock().unwrap();
+        if let Some(mut dma_slice) = twzhal.shared.remove(&paddr) {
+            match direction {
+                BufferDirection::DeviceToDriver => {
+                    dma_slice.sync(0..buffer.len(), SyncMode::PostDeviceToCpu);
+                }
+                _ => {}
+            }
+
+            let buf_len = buffer.len();
+            let buf_casted = buffer.cast::<u8>();
+            let buf = buf_casted.as_ptr();
+            let dma_buf = unsafe { dma_slice.get_mut().as_ptr() };
+
+            copy_nonoverlapping(dma_buf, buf, buf_len);
+            twzhal.available.push(dma_slice);
+        }
+    }
+}

--- a/src/lib/virtio-input/src/lib.rs
+++ b/src/lib/virtio-input/src/lib.rs
@@ -1,0 +1,51 @@
+//! VirtIO input device driver for Twizzler.
+//!
+//! Wraps the virtio-drivers VirtIOInput device with Twizzler transport and DMA,
+//! providing a simple event polling API.
+
+mod hal;
+mod transport;
+
+use std::sync::{Arc, Mutex};
+
+use virtio_drivers::{
+    device::input::{InputEvent, VirtIOInput},
+    transport::{pci::VirtioPciError, Transport},
+};
+
+use crate::{hal::TwzHal, transport::TwizzlerTransport};
+
+pub use transport::TwizzlerTransport as InputTransport;
+pub use virtio_drivers::device::input::InputEvent as VirtioInputEvent;
+
+type DeviceImpl<T> = VirtIOInput<TwzHal, T>;
+
+#[derive(Clone)]
+pub struct InputDevice<T: Transport> {
+    inner: Arc<Mutex<DeviceImpl<T>>>,
+}
+
+impl<T: Transport> InputDevice<T> {
+    fn new(dev: DeviceImpl<T>) -> Self {
+        InputDevice {
+            inner: Arc::new(Mutex::new(dev)),
+        }
+    }
+
+    pub fn pop_event(&self) -> Option<InputEvent> {
+        self.inner.lock().unwrap().pop_pending_event()
+    }
+
+    pub fn with_device<R>(&self, f: impl FnOnce(&mut DeviceImpl<T>) -> R) -> R {
+        f(&mut *self.inner.lock().unwrap())
+    }
+}
+
+pub fn get_device(
+    notifier: std::sync::mpsc::Sender<Option<()>>,
+) -> Result<InputDevice<TwizzlerTransport>, VirtioPciError> {
+    let input =
+        VirtIOInput::<TwzHal, TwizzlerTransport>::new(TwizzlerTransport::new(notifier)?)
+            .expect("failed to create input driver");
+    Ok(InputDevice::<TwizzlerTransport>::new(input))
+}

--- a/src/lib/virtio-input/src/transport.rs
+++ b/src/lib/virtio-input/src/transport.rs
@@ -1,0 +1,427 @@
+use core::{mem::size_of, ptr::NonNull};
+use std::sync::Arc;
+
+use twizzler_abi::{
+    device::{bus::pcie::PcieDeviceInfo, DeviceInterruptFlags},
+    syscall::{sys_thread_sync, ThreadSync},
+};
+use twizzler_driver::{bus::pcie::PcieCapability, device::Device};
+use virtio_drivers::{
+    transport::{pci::VirtioPciError, DeviceStatus, DeviceType, InterruptStatus, Transport},
+    Error,
+};
+use virtio_pcie::{VirtioIsrStatus, VirtioPciNotifyCap};
+use volatile::{map_field, VolatilePtr};
+use zerocopy::{FromBytes, Immutable, IntoBytes};
+
+pub mod virtio_pcie;
+use self::virtio_pcie::{CfgLocation, VirtioCfgType, VirtioCommonCfg, VirtioPciCap};
+
+pub struct TwizzlerTransport {
+    device: Arc<Device>,
+
+    common_cfg: CfgLocation,
+
+    notify_region: CfgLocation,
+    notify_offset_multiplier: u32,
+
+    isr_status: CfgLocation,
+
+    config_space: Option<NonNull<[u32]>>,
+}
+
+unsafe impl Send for TwizzlerTransport {}
+
+fn get_device() -> Option<Device> {
+    // VirtIO input devices use PCI class 9 (input device controller)
+    let devices = devmgr::get_devices(devmgr::DriverSpec {
+        supported: devmgr::Supported::PcieClass(9, 0, 0),
+    })
+    .ok()?;
+
+    for device in &devices {
+        let device = Device::new(device.id).ok();
+        if let Some(device) = device {
+            let info = unsafe { device.get_info::<PcieDeviceInfo>(0).unwrap() };
+            // VirtIO input device ID: 0x1040 + 18 = 0x1052
+            if info.get_data().vendor_id == 0x1AF4 && info.get_data().device_id == 0x1052 {
+                tracing::info!(
+                    "found virtio-input device at {:02x}:{:02x}.{:02x}",
+                    info.get_data().bus_nr,
+                    info.get_data().dev_nr,
+                    info.get_data().func_nr
+                );
+                return Some(device);
+            }
+        }
+    }
+    None
+}
+
+impl TwizzlerTransport {
+    pub fn new(notifier: std::sync::mpsc::Sender<Option<()>>) -> Result<Self, VirtioPciError> {
+        let device = Arc::new(
+            get_device().ok_or(VirtioPciError::InvalidVendorId(0))?,
+        );
+        let int = device.allocate_interrupt(0).unwrap();
+        device
+            .repr_mut()
+            .register_interrupt(int.1 as usize, int.0, DeviceInterruptFlags::empty());
+        let int_device = device.clone();
+
+        let info = unsafe { device.get_info::<PcieDeviceInfo>(0).unwrap() };
+        if info.get_data().vendor_id != 0x1AF4 {
+            return Err(VirtioPciError::InvalidVendorId(info.get_data().vendor_id));
+        }
+
+        let mut common_cfg = None;
+        let mut notify_region = None;
+        let mut notify_offset_multiplier = 0;
+        let mut isr_status = None;
+        let mut config_space = None;
+
+        let mm = device.find_mmio_bar(0xff).unwrap();
+        for cap in device.pcie_capabilities(&mm).unwrap() {
+            let off: usize = match cap {
+                PcieCapability::VendorSpecific(x) => x,
+                _ => {
+                    continue;
+                }
+            };
+
+            let mut virtio_cfg_ref = unsafe { mm.get_mmio_offset_mut::<VirtioPciCap>(off) };
+            let virtio_cfg = virtio_cfg_ref.as_mut_ptr();
+            match map_field!(virtio_cfg.cfg_type).read() {
+                VirtioCfgType::CommonCfg if common_cfg.is_none() => {
+                    tracing::trace!(
+                        "Common CFG found! Bar: {:?}, Offset: {:?}, Length: {:?}",
+                        map_field!(virtio_cfg.bar).read(),
+                        map_field!(virtio_cfg.offset).read(),
+                        map_field!(virtio_cfg.length).read()
+                    );
+                    common_cfg = Some(CfgLocation {
+                        bar: map_field!(virtio_cfg.bar).read() as usize,
+                        offset: map_field!(virtio_cfg.offset).read() as usize,
+                        length: map_field!(virtio_cfg.length).read() as usize,
+                    });
+                }
+                VirtioCfgType::NotifyCfg if notify_region.is_none() => {
+                    let mut notify_ref =
+                        unsafe { mm.get_mmio_offset_mut::<VirtioPciNotifyCap>(off) };
+                    let notify_cap = notify_ref.as_mut_ptr();
+                    notify_offset_multiplier = map_field!(notify_cap.notify_off_multiplier).read();
+                    tracing::trace!("Notify CFG found! Bar: {:?}, Offset: {:?}, Length: {:?}, Offset multiplier: {:?}", map_field!(virtio_cfg.bar).read(), map_field!(virtio_cfg.offset).read(), map_field!(virtio_cfg.length).read(), notify_offset_multiplier);
+                    notify_region = Some(CfgLocation {
+                        bar: map_field!(virtio_cfg.bar).read() as usize,
+                        offset: map_field!(virtio_cfg.offset).read() as usize,
+                        length: map_field!(virtio_cfg.length).read() as usize,
+                    })
+                }
+
+                VirtioCfgType::IsrCfg if isr_status.is_none() => {
+                    tracing::trace!(
+                        "ISR CFG found! Bar: {:?}, Offset: {:?}, Length: {:?}",
+                        map_field!(virtio_cfg.bar).read(),
+                        map_field!(virtio_cfg.offset).read(),
+                        map_field!(virtio_cfg.length).read()
+                    );
+                    isr_status = Some(CfgLocation {
+                        bar: map_field!(virtio_cfg.bar).read() as usize,
+                        offset: map_field!(virtio_cfg.offset).read() as usize,
+                        length: map_field!(virtio_cfg.length).read() as usize,
+                    });
+                }
+
+                VirtioCfgType::DeviceCfg if config_space.is_none() => {
+                    tracing::trace!(
+                        "Device CFG found! Bar: {:?}, Offset: {:?}, Length: {:?}",
+                        map_field!(virtio_cfg.bar).read(),
+                        map_field!(virtio_cfg.offset).read(),
+                        map_field!(virtio_cfg.length).read()
+                    );
+                    let bar_num = map_field!(virtio_cfg.bar).read() as usize;
+                    let bar = device.find_mmio_bar(bar_num).unwrap();
+                    let mut start = unsafe {
+                        bar.get_mmio_offset_mut::<u32>(map_field!(virtio_cfg.offset).read() as usize)
+                    };
+                    let len = map_field!(virtio_cfg.length).read() as usize;
+
+                    let ptr = unsafe {
+                        NonNull::from(core::slice::from_raw_parts_mut(
+                            start.as_mut_ptr().as_raw_ptr().as_ptr(),
+                            len,
+                        ))
+                    };
+                    config_space = Some(ptr);
+                }
+                _ => {}
+            }
+        }
+        let common_cfg = common_cfg.ok_or(VirtioPciError::MissingCommonConfig)?;
+        let notify_region = notify_region.ok_or(VirtioPciError::MissingNotifyConfig)?;
+        let isr_status = isr_status.ok_or(VirtioPciError::MissingIsrConfig)?;
+
+        let _thread = std::thread::spawn(move || loop {
+            if int_device.repr().check_for_interrupt(0).is_some() {
+                let _ = notifier.send(None);
+            }
+
+            if int_device.repr().check_for_interrupt(0).is_none() {
+                let int_sleep = int_device.repr().setup_interrupt_sleep(0);
+                let _ = sys_thread_sync(&mut [ThreadSync::new_sleep(int_sleep)], None);
+            }
+        });
+
+        Ok(Self {
+            device,
+            common_cfg,
+            notify_region,
+            notify_offset_multiplier,
+            isr_status,
+            config_space,
+        })
+    }
+}
+
+impl Transport for TwizzlerTransport {
+    fn device_type(&self) -> DeviceType {
+        device_type(
+            unsafe { self.device.get_info::<PcieDeviceInfo>(0) }
+                .unwrap()
+                .get_data()
+                .device_id,
+        )
+    }
+
+    fn read_device_features(&mut self) -> u64 {
+        let bar = self.device.find_mmio_bar(self.common_cfg.bar).unwrap();
+        let mut reference =
+            unsafe { bar.get_mmio_offset_mut::<VirtioCommonCfg>(self.common_cfg.offset) };
+        let ptr = reference.as_mut_ptr();
+
+        map_field!(ptr.device_feature_select).write(0);
+        let mut device_feature_bits = map_field!(ptr.device_feature).read() as u64;
+        map_field!(ptr.device_feature_select).write(1);
+        device_feature_bits |= (map_field!(ptr.device_feature).read() as u64) << 32;
+        device_feature_bits
+    }
+
+    fn write_driver_features(&mut self, driver_features: u64) {
+        let bar = self.device.find_mmio_bar(self.common_cfg.bar).unwrap();
+        let mut reference =
+            unsafe { bar.get_mmio_offset_mut::<VirtioCommonCfg>(self.common_cfg.offset) };
+        let ptr = reference.as_mut_ptr();
+
+        map_field!(ptr.driver_feature_select).write(0);
+        map_field!(ptr.driver_feature).write(driver_features as u32);
+        map_field!(ptr.driver_feature_select).write(1);
+        map_field!(ptr.driver_feature).write((driver_features >> 32) as u32);
+    }
+
+    fn max_queue_size(&mut self, queue: u16) -> u32 {
+        let bar = self.device.find_mmio_bar(self.common_cfg.bar).unwrap();
+        let mut reference =
+            unsafe { bar.get_mmio_offset_mut::<VirtioCommonCfg>(self.common_cfg.offset) };
+        let ptr = reference.as_mut_ptr();
+
+        map_field!(ptr.queue_select).write(queue);
+        map_field!(ptr.queue_size).read().into()
+    }
+
+    fn notify(&mut self, queue: u16) {
+        let bar = self.device.find_mmio_bar(self.common_cfg.bar).unwrap();
+        let mut reference =
+            unsafe { bar.get_mmio_offset_mut::<VirtioCommonCfg>(self.common_cfg.offset) };
+        let ptr = reference.as_mut_ptr();
+
+        map_field!(ptr.queue_select).write(queue);
+
+        let queue_notify_off = map_field!(ptr.queue_notify_off).read();
+
+        let offset_bytes = queue_notify_off as usize * self.notify_offset_multiplier as usize;
+        let index = offset_bytes / size_of::<u16>();
+
+        let notify_bar = self.device.find_mmio_bar(self.notify_region.bar).unwrap();
+        let start = unsafe {
+            notify_bar
+                .get_mmio_offset_mut::<u16>(self.notify_region.offset as usize)
+                .as_mut_ptr()
+                .as_raw_ptr()
+                .as_ptr()
+        };
+
+        let notify_ptr = unsafe {
+            VolatilePtr::new(NonNull::from(core::slice::from_raw_parts_mut(
+                start,
+                self.notify_region.length as usize,
+            )))
+        };
+
+        let to_write = notify_ptr.index(index);
+        to_write.write(queue);
+    }
+
+    fn get_status(&self) -> virtio_drivers::transport::DeviceStatus {
+        let bar = self.device.find_mmio_bar(self.common_cfg.bar).unwrap();
+        let mut reference =
+            unsafe { bar.get_mmio_offset_mut::<VirtioCommonCfg>(self.common_cfg.offset) };
+        let ptr = reference.as_mut_ptr();
+
+        let status = map_field!(ptr.device_status).read();
+        DeviceStatus::from_bits_truncate(status.into())
+    }
+
+    fn set_status(&mut self, status: virtio_drivers::transport::DeviceStatus) {
+        let bar = self.device.find_mmio_bar(self.common_cfg.bar).unwrap();
+        let mut reference =
+            unsafe { bar.get_mmio_offset_mut::<VirtioCommonCfg>(self.common_cfg.offset) };
+        let ptr = reference.as_mut_ptr();
+
+        map_field!(ptr.device_status).write(status.bits() as u8);
+    }
+
+    fn set_guest_page_size(&mut self, _guest_page_size: u32) {
+        // No-op, the PCI transport doesn't care.
+    }
+
+    fn requires_legacy_layout(&self) -> bool {
+        false
+    }
+
+    fn queue_set(
+        &mut self,
+        queue: u16,
+        size: u32,
+        descriptors: virtio_drivers::PhysAddr,
+        driver_area: virtio_drivers::PhysAddr,
+        device_area: virtio_drivers::PhysAddr,
+    ) {
+        let bar = self.device.find_mmio_bar(self.common_cfg.bar).unwrap();
+        let mut reference =
+            unsafe { bar.get_mmio_offset_mut::<VirtioCommonCfg>(self.common_cfg.offset) };
+        let ptr = reference.as_mut_ptr();
+
+        map_field!(ptr.config_msix_vector).write(0);
+        map_field!(ptr.queue_select).write(queue);
+        map_field!(ptr.queue_size).write(size as u16);
+        map_field!(ptr.queue_desc).write(descriptors.try_into().unwrap());
+        map_field!(ptr.queue_driver).write(driver_area.try_into().unwrap());
+        map_field!(ptr.queue_device).write(device_area.try_into().unwrap());
+        map_field!(ptr.queue_msix_vector).write(0);
+        map_field!(ptr.queue_enable).write(1);
+    }
+
+    fn queue_unset(&mut self, _queue: u16) {
+        // The VirtIO spec doesn't allow queues to be unset once they have been set up for the PCI
+        // transport, so this is a no-op.
+    }
+
+    fn queue_used(&mut self, queue: u16) -> bool {
+        let bar = self.device.find_mmio_bar(self.common_cfg.bar).unwrap();
+        let mut reference =
+            unsafe { bar.get_mmio_offset_mut::<VirtioCommonCfg>(self.common_cfg.offset) };
+        let ptr = reference.as_mut_ptr();
+
+        map_field!(ptr.queue_select).write(queue);
+        map_field!(ptr.queue_enable).read() == 1
+    }
+
+    fn ack_interrupt(&mut self) -> InterruptStatus {
+        let bar = self.device.find_mmio_bar(self.isr_status.bar).unwrap();
+        let mut reference =
+            unsafe { bar.get_mmio_offset_mut::<VirtioIsrStatus>(self.isr_status.offset) };
+        let ptr = reference.as_mut_ptr();
+
+        let status = ptr.read();
+        if status & 0x3 != 0 {
+            InterruptStatus::all()
+        } else {
+            InterruptStatus::empty()
+        }
+    }
+
+    fn read_config_generation(&self) -> u32 {
+        0
+    }
+
+    fn read_config_space<T: FromBytes + IntoBytes>(
+        &self,
+        offset: usize,
+    ) -> virtio_drivers::Result<T> {
+        if let Some(config_space) = self.config_space {
+            if offset > config_space.len() * size_of::<u32>() {
+                Err(Error::ConfigSpaceTooSmall)
+            } else {
+                let result = unsafe {
+                    config_space
+                        .as_ptr()
+                        .cast::<T>()
+                        .byte_add(offset)
+                        .read_volatile()
+                };
+                Ok(result)
+            }
+        } else {
+            Err(Error::ConfigSpaceMissing)
+        }
+    }
+
+    fn write_config_space<T: IntoBytes + Immutable>(
+        &mut self,
+        offset: usize,
+        value: T,
+    ) -> virtio_drivers::Result<()> {
+        if let Some(config_space) = self.config_space {
+            if offset > config_space.len() * size_of::<u32>() {
+                Err(Error::ConfigSpaceTooSmall)
+            } else {
+                unsafe {
+                    config_space
+                        .as_ptr()
+                        .cast::<T>()
+                        .byte_add(offset)
+                        .write_volatile(value)
+                };
+                Ok(())
+            }
+        } else {
+            Err(Error::ConfigSpaceMissing)
+        }
+    }
+}
+
+impl Drop for TwizzlerTransport {
+    fn drop(&mut self) {
+        self.set_status(DeviceStatus::empty());
+        while self.get_status() != DeviceStatus::empty() {
+            core::hint::spin_loop();
+        }
+    }
+}
+
+/// The offset to add to a VirtIO device ID to get the corresponding PCI device ID.
+const PCI_DEVICE_ID_OFFSET: u16 = 0x1040;
+
+const TRANSITIONAL_NETWORK: u16 = 0x1000;
+const TRANSITIONAL_BLOCK: u16 = 0x1001;
+const TRANSITIONAL_MEMORY_BALLOONING: u16 = 0x1002;
+const TRANSITIONAL_CONSOLE: u16 = 0x1003;
+const TRANSITIONAL_SCSI_HOST: u16 = 0x1004;
+const TRANSITIONAL_ENTROPY_SOURCE: u16 = 0x1005;
+const TRANSITIONAL_9P_TRANSPORT: u16 = 0x1009;
+
+fn device_type(pci_device_id: u16) -> DeviceType {
+    match pci_device_id {
+        TRANSITIONAL_NETWORK => DeviceType::Network,
+        TRANSITIONAL_BLOCK => DeviceType::Block,
+        TRANSITIONAL_MEMORY_BALLOONING => DeviceType::MemoryBalloon,
+        TRANSITIONAL_CONSOLE => DeviceType::Console,
+        TRANSITIONAL_SCSI_HOST => DeviceType::ScsiHost,
+        TRANSITIONAL_ENTROPY_SOURCE => DeviceType::EntropySource,
+        TRANSITIONAL_9P_TRANSPORT => DeviceType::_9P,
+        id if id >= PCI_DEVICE_ID_OFFSET => {
+            DeviceType::try_from(id - PCI_DEVICE_ID_OFFSET).unwrap()
+        }
+        _ => todo!(),
+    }
+}

--- a/src/lib/virtio-input/src/transport/virtio_pcie.rs
+++ b/src/lib/virtio-input/src/transport/virtio_pcie.rs
@@ -1,0 +1,61 @@
+// Virtio vendor specific PCI Capability
+#[repr(C)]
+pub struct VirtioPciCap {
+    pub cap_vndr: u8,            /* Generic PCI field: PCI_CAP_ID_VNDR */
+    pub cap_next: u8,            /* Generic PCI field: next ptr. */
+    pub cap_len: u8,             /* Generic PCI field: capability length */
+    pub cfg_type: VirtioCfgType, /* Identifies the structure. */
+    pub bar: u8,                 /* Where to find it. */
+    pub id: u8,                  /* Multiple capabilities of the same type */
+    pub padding: [u8; 2],        /* Pad to full dword. */
+    pub offset: u32,             /* Offset within bar. */
+    pub length: u32,             /* Length of the structure, in bytes. */
+}
+
+#[derive(Copy, Clone)]
+#[allow(dead_code)]
+pub enum VirtioCfgType {
+    CommonCfg = 1,
+    NotifyCfg = 2,
+    IsrCfg = 3,
+    DeviceCfg = 4,
+    PciCfg = 5,
+    SharedMemoryCfg = 8,
+    VendorCfg = 9,
+}
+#[repr(C)]
+pub struct VirtioPciNotifyCap {
+    pub virtio_pci_cap: VirtioPciCap,
+    pub notify_off_multiplier: u32, /* Multiplier for queue_notify_off. */
+}
+
+#[repr(C)]
+pub struct VirtioCommonCfg {
+    pub device_feature_select: u32,
+    pub device_feature: u32,
+    pub driver_feature_select: u32,
+    pub driver_feature: u32,
+    pub config_msix_vector: u16,
+    pub num_queues: u16,
+    pub device_status: u8,
+    pub config_generation: u8,
+
+    pub queue_select: u16,
+    pub queue_size: u16,
+    pub queue_msix_vector: u16,
+    pub queue_enable: u16,
+    pub queue_notify_off: u16,
+    pub queue_desc: u64,
+    pub queue_driver: u64,
+    pub queue_device: u64,
+    pub queue_notify_data: u16,
+    pub queue_reset: u16,
+}
+
+pub type VirtioIsrStatus = u8;
+
+pub struct CfgLocation {
+    pub bar: usize,
+    pub offset: usize,
+    pub length: usize,
+}

--- a/tools/xtask/src/qemu.rs
+++ b/tools/xtask/src/qemu.rs
@@ -116,6 +116,7 @@ impl QemuCommand {
         );
 
         self.cmd.arg("-device").arg("virtio-net-pci,netdev=net0");
+        self.cmd.arg("-device").arg("virtio-keyboard-pci");
 
         let port = {
             let listener = match TcpListener::bind(format!("0.0.0.0:{}", DEFAULT_QEMU_PORT)) {


### PR DESCRIPTION
## Summary
- New `src/lib/virtio-input/` crate wrapping `VirtIOInput` from virtio-drivers 0.12, using the same transport/HAL pattern as virtio-gpu and virtio-net
- Discovers VirtIO input devices via PCI class 9/0 (vendor 0x1AF4, device 0x1052) and provides `InputDevice` with `pop_event()` for raw evdev-format events
- Adds `-device virtio-keyboard-pci` to QEMU so the keyboard device is present on boot
- devmgr confirms discovery as `KeyboardController (9 0)` at PCIe enumeration

## Test plan
- [x] `cargo build-all --profile release` compiles cleanly
- [x] QEMU boot confirms devmgr discovers `KeyboardController (9 0)`
- [x] Driver initializes successfully (`[input] virtio-input device initialized`)
- [x] Existing WASI test suite passes (32/32, no regression)
- [ ] Verify keyboard events are received via `pop_event()` when typing in QEMU window