### PR TITLE
Enable --data flag for including host files in initrd

### DIFF
--- a/tools/initrd_gen/src/main.rs
+++ b/tools/initrd_gen/src/main.rs
@@ -1,20 +1,11 @@
-use std::{fs::File, io::Seek, path::Path};
+use std::{
+    fs::{self, File},
+    io::Seek,
+    path::{Path, PathBuf},
+};
 
 use clap::{Arg, Command};
 use tar::Builder;
-
-#[repr(C)]
-#[derive(Clone, Copy)]
-#[allow(dead_code)]
-struct FileMetadata {
-    magic: u64,
-    size: u64,
-    direct: [u128; 255],
-}
-
-unsafe fn _any_as_u8_slice<T: Sized>(p: &T) -> &[u8] {
-    ::core::slice::from_raw_parts((p as *const T) as *const u8, ::core::mem::size_of::<T>())
-}
 
 fn main() {
     let app = Command::new("initrd_gen")
@@ -49,7 +40,7 @@ fn main() {
         .map(|s| s.as_str())
         .unwrap();
 
-    let _data_dir = matches
+    let data_dir = matches
         .get_one::<String>("data")
         .map(|s| s.as_str())
         .unwrap();
@@ -87,76 +78,29 @@ fn main() {
                 .unwrap();
         }
     }
-    let _ = archive.into_inner().unwrap();
-    // TODO: set this up with profiles
-    /*
+    // Add data files (raw bytes — kernel sets MEXT_SIZED, runtime uses RawFile fallback)
+    if let Ok(md) = fs::metadata(data_dir) {
         let mut data_files: Vec<PathBuf> = vec![];
-        if let Ok(md) = metadata(&data_dir) {
-            if md.is_dir() {
-                let f: Vec<PathBuf> = walkdir::WalkDir::new(data_dir)
-                    .min_depth(1)
-                    .max_depth(3)
-                    .into_iter()
-                    .filter_map(|e| e.ok())
-                    .filter_map(|e| {
-                        if e.file_type().is_file() {
-                            Some(e)
-                        } else {
-                            None
-                        }
-                    })
-                    .map(|x| x.path().to_owned())
-                    .map(|x| x.to_path_buf())
-                    .collect();
-
-                data_files.extend(f)
-            } else if md.is_file() {
-                data_files.push(PathBuf::from(data_dir));
-            }
+        if md.is_dir() {
+            data_files = walkdir::WalkDir::new(data_dir)
+                .min_depth(1)
+                .max_depth(3)
+                .into_iter()
+                .filter_map(|e| e.ok())
+                .filter(|e| e.file_type().is_file())
+                .map(|x| x.path().to_path_buf())
+                .collect();
+        } else if md.is_file() {
+            data_files.push(PathBuf::from(data_dir));
         }
 
         for file in data_files {
-            let mut f = File::open(file.clone()).unwrap();
-            let md = f.metadata().unwrap();
-
-            let file_metadata = FileMetadata {
-                magic: 0xBEEFDEAD,
-                size: md.size(),
-                direct: [0; 255],
-            };
-
-            let mut data: Vec<u8> = vec![];
-
-            let fmd_bytes: &[u8] = unsafe { any_as_u8_slice(&file_metadata) };
-            data.extend(fmd_bytes);
-
-            f.read_to_end(&mut data).unwrap();
-            let mut header = Header::new_old();
-
-            header.set_size(data.len().try_into().unwrap());
-            header
-                .set_path(
-                    Path::new(&file)
-                        .file_name()
-                        .map(|s| s.to_str().unwrap())
-                        .unwrap(),
-                )
-                .unwrap();
-            header.set_uid(md.uid().into());
-            header.set_gid(md.gid().into());
-            header.set_mode(md.mode());
-            header.set_cksum();
-
+            let mut f = File::open(&file).unwrap();
             archive
-                .append_data(
-                    &mut header,
-                    Path::new(&file)
-                        .file_name()
-                        .map(|s| s.to_str().unwrap())
-                        .unwrap(),
-                    Cursor::new(data),
-                )
+                .append_file(file.file_name().unwrap().to_str().unwrap(), &mut f)
                 .unwrap();
         }
-    */
+    }
+
+    let _ = archive.into_inner().unwrap();
 }

--- a/tools/xtask/src/image.rs
+++ b/tools/xtask/src/image.rs
@@ -105,17 +105,21 @@ fn get_genfile_path(comp: &TwizzlerCompilation, name: &str) -> PathBuf {
     path
 }
 
-fn generate_data_folder(comp: &TwizzlerCompilation) -> PathBuf {
+fn generate_data_folder(comp: &TwizzlerCompilation, data_override: Option<&Path>) -> PathBuf {
     let mut destination = comp.get_kernel_image(false).parent().unwrap().to_path_buf();
     destination.push("data/");
 
-    let source = PathBuf::from("./src/data/");
-    let _ = Command::new("rsync")
-        .arg("-a")
-        .arg("--delete")
-        .arg(&source)
-        .arg(&destination)
-        .status();
+    let source = data_override
+        .map(|p| p.to_path_buf())
+        .unwrap_or_else(|| PathBuf::from("./src/data/"));
+    if source.exists() {
+        let _ = Command::new("rsync")
+            .arg("-a")
+            .arg("--delete")
+            .arg(format!("{}/", source.display()))
+            .arg(&destination)
+            .status();
+    }
 
     destination
 }
@@ -276,7 +280,7 @@ pub(crate) fn do_make_image(cli: ImageOptions) -> anyhow::Result<ImageInfo> {
     let comp = crate::build::do_build(cli.clone().into())?;
 
     let initrd_files = build_initrd(&cli, &comp)?;
-    let data_files = generate_data_folder(&comp);
+    let data_files = generate_data_folder(&comp, cli.data.as_deref());
     let initrd_path = generate_initrd(initrd_files, data_files, &comp)?;
 
     let debug_sysroot = PathBuf::from("target/dynamic/")


### PR DESCRIPTION
This creates an easy path for importing a host directory to the twizzler guest. Currently just shows up at `/host`

Wire the existing but disconnected --data CLI flag through to initrd generation. generate_data_folder() now accepts an optional override path, and initrd_gen processes data files as raw bytes (the kernel sets MEXT_SIZED metadata, so the runtime RawFile fallback handles them correctly without FileMetadata headers).

Usage: cargo start-qemu --data /path/to/host/dir